### PR TITLE
ci: add GitHub Actions CI pipeline for backend and frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           cache: pip
           cache-dependency-path: backend/requirements.txt
 
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
           cache-dependency-path: web/package-lock.json
 


### PR DESCRIPTION
## Summary
- Add a CI workflow (`.github/workflows/ci.yml`) that runs on every push and PR to `main` and `dev`
- **Backend job:** Spins up a PostgreSQL 15 service container, installs Python 3.12 dependencies, runs migrations, and executes `manage.py test`
- **Frontend job:** Sets up Node.js 18, runs `npm ci`, `npm run build`, and `npm run test`
- Both jobs run in parallel; pipeline fails if any step fails

## Test plan
- [x] Verify the workflow appears in the Actions tab
- [x] Confirm backend tests pass with the PostgreSQL service container
- [x] Confirm frontend build and tests pass
- [ ] Verify pipeline fails when a test is intentionally broken