### PR TITLE
chore: created a workflow that generates API Endpoints documentation

### DIFF
--- a/.github/workflows/wiki-api-endpoints.yml
+++ b/.github/workflows/wiki-api-endpoints.yml
@@ -1,0 +1,91 @@
+name: Wiki API PDF Sync
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - backend/**
+      - .github/workflows/wiki-api-endpoints.yml
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync-api-pdf:
+    runs-on: ubuntu-latest
+
+    env:
+      SECRET_KEY: github-actions-api-docs-key
+      DEBUG: "True"
+      DATABASE_URL: sqlite:////tmp/wiki_api_docs.sqlite3
+
+    steps:
+      - name: Checkout Main Repo
+        uses: actions/checkout@v4
+
+      - name: Checkout Wiki Repo
+        run: git clone https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git wiki
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+        working-directory: backend
+
+      - name: Generate OpenAPI schema JSON
+        run: python backend/manage.py spectacular --format openapi-json --file /tmp/openapi.json
+
+      - name: Set up Java for OpenAPI Generator
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Download OpenAPI Generator CLI
+        run: |
+          curl -L https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.6.0/openapi-generator-cli-7.6.0.jar -o /tmp/openapi-generator-cli.jar
+
+      - name: Convert OpenAPI to AsciiDoc
+        run: |
+          java -jar /tmp/openapi-generator-cli.jar generate \
+            -i /tmp/openapi.json \
+            -g asciidoc \
+            -o /tmp/openapi-asciidoc
+
+      - name: Install Asciidoctor PDF
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ruby-full
+          gem install asciidoctor-pdf
+
+      - name: Generate PDF documentation
+        run: |
+          asciidoctor-pdf -o wiki/API-Documentation.pdf /tmp/openapi-asciidoc/index.adoc
+
+      - name: Detect wiki changes
+        id: wiki_diff
+        run: |
+          cd wiki
+          if git diff --quiet -- API-Documentation.pdf; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "No API PDF documentation changes detected."
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "API PDF documentation changed."
+          fi
+
+      - name: Push Changes to Wiki
+        if: steps.wiki_diff.outputs.changed == 'true'
+        run: |
+          cd wiki
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add API-Documentation.pdf
+          git commit -m "Auto-update API documentation PDF"
+          git push

--- a/README.md
+++ b/README.md
@@ -214,6 +214,22 @@ Auth and identity remain in the `accounts` app (`User`, registration/login/logou
 
 Local development seed data is included via migration `accounts.0004_seed_profile_page_data` and creates demo mentor, mentee, and both-role profiles.
 
+### 🧾 API Documentation PDF for Wiki
+
+We generate a PDF from our OpenAPI schema (`drf-spectacular`) and publish it to the GitHub Wiki.
+
+**Automatic sync in GitHub Actions:**
+
+- Workflow: `.github/workflows/wiki-api-endpoints.yml`
+- Trigger: pushes to `main` or `dev` affecting `backend/**` (or manual dispatch)
+- Behavior: runs a three-step OpenAPI-to-PDF pipeline and commits `wiki/API-Documentation.pdf`.
+
+Pipeline steps:
+
+1. Generate OpenAPI JSON from Django (`manage.py spectacular`).
+2. Convert OpenAPI JSON to AsciiDoc (`openapi-generator-cli`).
+3. Convert AsciiDoc to PDF (`asciidoctor-pdf`).
+
 ### 🗄️ Connecting to the Database
 
 To view, manage, and query the local PostgreSQL database, we recommend using DBeaver (or DataGrip/pgAdmin). Create a new PostgreSQL connection using the following credentials:


### PR DESCRIPTION
## Related Issue

Closes #126

## Description

This PR adds automated API documentation publishing to the project wiki as a PDF.

What is included:
- A new GitHub Actions workflow that generates OpenAPI JSON from the Django backend and converts it to PDF using OpenAPI Generator (AsciiDoc) + Asciidoctor PDF.
- Automatic commit and push of API-Documentation.pdf to the wiki repository only when the generated PDF changes.
- README updates describing the new API documentation pipeline and trigger conditions.

Why:
- Swagger UI under api/docs is useful for live browsing, but this adds a versioned, shareable documentation artifact in the wiki for easier access and distribution.

## Type of Change

- [x] Documentation
- [x] CI/CD or configuration

## Checklist

- [x] I have tested my changes locally
- [x] I have performed a self-review of my code