### PR TITLE
feat: implemented mentorship availability slots api endpoints

### DIFF
--- a/backend/profiles/serializers.py
+++ b/backend/profiles/serializers.py
@@ -1,8 +1,11 @@
 """Serializers for profile self-service API endpoints."""
 
+from datetime import datetime
+
+from django.utils import timezone
 from rest_framework import serializers
 
-from .models import MentorshipMode, Profile
+from .models import AvailabilitySlot, MentorshipMode, Profile
 
 
 class ProfileResponseSerializer(serializers.ModelSerializer):
@@ -44,3 +47,93 @@ class ProfileUpdateSerializer(serializers.ModelSerializer):
             "show_initials_only",
             "mentorship_mode",
         )
+
+
+class AvailabilitySlotSerializer(serializers.ModelSerializer):
+    """Read serializer for mentor availability slots."""
+
+    date = serializers.SerializerMethodField()
+    startTime = serializers.SerializerMethodField()
+    endTime = serializers.SerializerMethodField()
+
+    class Meta:
+        model = AvailabilitySlot
+        fields = (
+            "id",
+            "date",
+            "startTime",
+            "endTime",
+            "is_booked",
+            "created_at",
+            "updated_at",
+        )
+        read_only_fields = fields
+
+    def get_date(self, obj: AvailabilitySlot):
+        """Return slot date in current timezone."""
+        return timezone.localtime(obj.start_at).date()
+
+    def get_startTime(self, obj: AvailabilitySlot):
+        """Return slot start time in current timezone."""
+        return timezone.localtime(obj.start_at).time().replace(microsecond=0)
+
+    def get_endTime(self, obj: AvailabilitySlot):
+        """Return slot end time in current timezone."""
+        return timezone.localtime(obj.end_at).time().replace(microsecond=0)
+
+
+class AvailabilitySlotWriteSerializer(serializers.Serializer):
+    """Create/update serializer for mentor availability slots."""
+
+    date = serializers.DateField()
+    startTime = serializers.TimeField()
+    endTime = serializers.TimeField()
+
+    def validate(self, attrs: dict) -> dict:
+        """Validate date and time constraints for an availability slot."""
+        slot_date = attrs.get("date")
+        start_time = attrs.get("startTime")
+        end_time = attrs.get("endTime")
+
+        if self.instance is not None:
+            if slot_date is None:
+                slot_date = timezone.localtime(self.instance.start_at).date()
+            if start_time is None:
+                start_time = timezone.localtime(self.instance.start_at).time()
+            if end_time is None:
+                end_time = timezone.localtime(self.instance.end_at).time()
+
+        if slot_date < timezone.localdate():
+            raise serializers.ValidationError({"date": "Date cannot be in the past."})
+
+        if end_time <= start_time:
+            raise serializers.ValidationError(
+                {"endTime": "endTime must be greater than startTime."}
+            )
+
+        timezone_info = timezone.get_current_timezone()
+        attrs["start_at"] = timezone.make_aware(
+            datetime.combine(slot_date, start_time),
+            timezone_info,
+        )
+        attrs["end_at"] = timezone.make_aware(
+            datetime.combine(slot_date, end_time),
+            timezone_info,
+        )
+        return attrs
+
+    def create(self, validated_data: dict) -> AvailabilitySlot:
+        """Create a slot for the profile passed in serializer context."""
+        profile = self.context["profile"]
+        return AvailabilitySlot.objects.create(
+            profile=profile,
+            start_at=validated_data["start_at"],
+            end_at=validated_data["end_at"],
+        )
+
+    def update(self, instance: AvailabilitySlot, validated_data: dict) -> AvailabilitySlot:
+        """Update an existing availability slot."""
+        instance.start_at = validated_data["start_at"]
+        instance.end_at = validated_data["end_at"]
+        instance.save(update_fields=["start_at", "end_at", "updated_at"])
+        return instance

--- a/backend/profiles/tests.py
+++ b/backend/profiles/tests.py
@@ -1,6 +1,6 @@
 """Tests for profiles domain models."""
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any
 
 from django.contrib.auth import get_user_model
@@ -366,3 +366,262 @@ class ProfileByUsernameAPIViewTests(TestCase):
         self.assertEqual(response.status_code, 400)
         payload = response.json()
         self.assertIn("mentorship_mode", payload)
+
+
+class AvailabilitySlotAPIViewTests(TestCase):
+    """Integration tests for mentor availability slot CRUD endpoints."""
+
+    def setUp(self) -> None:
+        """Create mentor/mentee users and authenticate API clients."""
+        self.api_client: Any = APIClient()
+
+        self.mentor_user = User.objects.create_user(
+            email="mentor-slots@example.com",
+            password="SecurePass123",
+        )
+        self.mentor_profile = Profile.objects.create(
+            user=self.mentor_user,
+            display_name="Mentor Slots",
+            mentorship_mode=MentorshipMode.MENTOR,
+        )
+
+        self.other_mentor_user = User.objects.create_user(
+            email="other-mentor@example.com",
+            password="SecurePass123",
+        )
+        self.other_mentor_profile = Profile.objects.create(
+            user=self.other_mentor_user,
+            display_name="Other Mentor",
+            mentorship_mode=MentorshipMode.MENTOR,
+        )
+
+        self.mentee_user = User.objects.create_user(
+            email="mentee-slots@example.com",
+            password="SecurePass123",
+        )
+        self.mentee_profile = Profile.objects.create(
+            user=self.mentee_user,
+            display_name="Mentee Slots",
+            mentorship_mode=MentorshipMode.MENTEE,
+        )
+
+        mentor_refresh = RefreshToken.for_user(self.mentor_user)
+        self.mentor_access_token = str(mentor_refresh.access_token)
+
+        other_mentor_refresh = RefreshToken.for_user(self.other_mentor_user)
+        self.other_mentor_access_token = str(other_mentor_refresh.access_token)
+
+        mentee_refresh = RefreshToken.for_user(self.mentee_user)
+        self.mentee_access_token = str(mentee_refresh.access_token)
+
+        self.collection_url = f"/api/profiles/{self.mentor_profile.username}/availability-slots/"
+        self.other_collection_url = (
+            f"/api/profiles/{self.other_mentor_profile.username}/availability-slots/"
+        )
+
+    def test_create_availability_slot_success(self) -> None:
+        """Mentor can create a slot with date/startTime/endTime payload."""
+        self.api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.mentor_access_token}")
+        payload = {
+            "date": (timezone.localdate() + timedelta(days=1)).isoformat(),
+            "startTime": "10:00:00",
+            "endTime": "11:00:00",
+        }
+
+        response = self.api_client.post(self.collection_url, payload)
+
+        self.assertEqual(response.status_code, 201)
+        body = response.json()
+        self.assertEqual(body["date"], payload["date"])
+        self.assertEqual(body["startTime"], payload["startTime"])
+        self.assertEqual(body["endTime"], payload["endTime"])
+        self.assertTrue(
+            AvailabilitySlot.objects.filter(id=body["id"], profile=self.mentor_profile).exists()
+        )
+
+    def test_create_availability_slot_rejects_past_date(self) -> None:
+        """Serializer rejects past dates for slot creation."""
+        self.api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.mentor_access_token}")
+        payload = {
+            "date": (timezone.localdate() - timedelta(days=1)).isoformat(),
+            "startTime": "10:00:00",
+            "endTime": "11:00:00",
+        }
+
+        response = self.api_client.post(self.collection_url, payload)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("date", response.json())
+
+    def test_create_availability_slot_rejects_end_before_start(self) -> None:
+        """Serializer rejects invalid time ranges where endTime <= startTime."""
+        self.api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.mentor_access_token}")
+        payload = {
+            "date": (timezone.localdate() + timedelta(days=1)).isoformat(),
+            "startTime": "14:00:00",
+            "endTime": "13:59:59",
+        }
+
+        response = self.api_client.post(self.collection_url, payload)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("endTime", response.json())
+
+    def test_list_upcoming_slots_returns_only_future_slots(self) -> None:
+        """GET endpoint returns only slots whose start_at is in the future."""
+        self.api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.mentor_access_token}")
+        tz = timezone.get_current_timezone()
+
+        past_start = timezone.now() - timedelta(days=1)
+        past_end = past_start + timedelta(hours=1)
+        AvailabilitySlot.objects.create(
+            profile=self.mentor_profile,
+            start_at=past_start,
+            end_at=past_end,
+        )
+
+        future_date = timezone.localdate() + timedelta(days=2)
+        future_start = timezone.make_aware(datetime.combine(future_date, datetime.min.time()), tz)
+        future_start = future_start.replace(hour=9)
+        future_end = future_start + timedelta(hours=1)
+        future_slot = AvailabilitySlot.objects.create(
+            profile=self.mentor_profile,
+            start_at=future_start,
+            end_at=future_end,
+        )
+
+        response = self.api_client.get(self.collection_url)
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        returned_ids = {slot["id"] for slot in payload}
+        self.assertIn(str(future_slot.id), returned_ids)
+        self.assertEqual(len(payload), 1)
+
+    def test_patch_availability_slot_success(self) -> None:
+        """Mentor can update own slot via PATCH."""
+        self.api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.mentor_access_token}")
+        slot_start = timezone.now() + timedelta(days=3)
+        slot = AvailabilitySlot.objects.create(
+            profile=self.mentor_profile,
+            start_at=slot_start,
+            end_at=slot_start + timedelta(hours=1),
+        )
+        detail_url = f"/api/profiles/{self.mentor_profile.username}/availability-slots/{slot.id}/"
+
+        response = self.api_client.patch(
+            detail_url,
+            {
+                "date": (timezone.localdate() + timedelta(days=4)).isoformat(),
+                "startTime": "15:00:00",
+                "endTime": "16:00:00",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        slot.refresh_from_db()
+        self.assertEqual(timezone.localtime(slot.start_at).hour, 15)
+        self.assertEqual(timezone.localtime(slot.end_at).hour, 16)
+
+    def test_delete_availability_slot_success(self) -> None:
+        """Mentor can delete own availability slot."""
+        self.api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.mentor_access_token}")
+        slot_start = timezone.now() + timedelta(days=1)
+        slot = AvailabilitySlot.objects.create(
+            profile=self.mentor_profile,
+            start_at=slot_start,
+            end_at=slot_start + timedelta(hours=1),
+        )
+        detail_url = f"/api/profiles/{self.mentor_profile.username}/availability-slots/{slot.id}/"
+
+        response = self.api_client.delete(detail_url)
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(AvailabilitySlot.objects.filter(id=slot.id).exists())
+
+    def test_delete_other_mentor_slot_returns_404(self) -> None:
+        """Mentors cannot delete slots that belong to another mentor."""
+        self.api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.mentor_access_token}")
+        slot_start = timezone.now() + timedelta(days=1)
+        slot = AvailabilitySlot.objects.create(
+            profile=self.other_mentor_profile,
+            start_at=slot_start,
+            end_at=slot_start + timedelta(hours=1),
+        )
+        detail_url = (
+            f"/api/profiles/{self.other_mentor_profile.username}/availability-slots/{slot.id}/"
+        )
+
+        response = self.api_client.delete(detail_url)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertTrue(AvailabilitySlot.objects.filter(id=slot.id).exists())
+
+    def test_mentee_cannot_create_or_delete_slots(self) -> None:
+        """Mentees cannot manage availability slots."""
+        self.api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.mentee_access_token}")
+        payload = {
+            "date": (timezone.localdate() + timedelta(days=1)).isoformat(),
+            "startTime": "10:00:00",
+            "endTime": "11:00:00",
+        }
+
+        create_response = self.api_client.post(self.collection_url, payload)
+        self.assertEqual(create_response.status_code, 403)
+
+        slot_start = timezone.now() + timedelta(days=1)
+        slot = AvailabilitySlot.objects.create(
+            profile=self.mentor_profile,
+            start_at=slot_start,
+            end_at=slot_start + timedelta(hours=1),
+        )
+        detail_url = f"/api/profiles/{self.mentor_profile.username}/availability-slots/{slot.id}/"
+        delete_response = self.api_client.delete(detail_url)
+
+        self.assertEqual(delete_response.status_code, 403)
+
+    def test_other_authenticated_user_can_get_mentor_slots(self) -> None:
+        """Other authenticated users can read a mentor's availability slots."""
+        self.api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.mentee_access_token}")
+        slot_start = timezone.now() + timedelta(days=1)
+        slot = AvailabilitySlot.objects.create(
+            profile=self.mentor_profile,
+            start_at=slot_start,
+            end_at=slot_start + timedelta(hours=1),
+        )
+
+        list_response = self.api_client.get(self.collection_url)
+        detail_response = self.api_client.get(
+            f"/api/profiles/{self.mentor_profile.username}/availability-slots/{slot.id}/"
+        )
+
+        self.assertEqual(list_response.status_code, 200)
+        self.assertEqual(detail_response.status_code, 200)
+
+    def test_non_owner_cannot_create_for_other_mentor_username(self) -> None:
+        """Authenticated non-owners cannot create slots for another mentor."""
+        self.api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.mentee_access_token}")
+
+        response = self.api_client.post(
+            self.collection_url,
+            {
+                "date": (timezone.localdate() + timedelta(days=1)).isoformat(),
+                "startTime": "10:00:00",
+                "endTime": "11:00:00",
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_create_availability_slot_requires_authentication(self) -> None:
+        """Unauthenticated requests cannot create availability slots."""
+        response = self.api_client.post(
+            self.collection_url,
+            {
+                "date": (timezone.localdate() + timedelta(days=1)).isoformat(),
+                "startTime": "10:00:00",
+                "endTime": "11:00:00",
+            },
+        )
+
+        self.assertEqual(response.status_code, 401)

--- a/backend/profiles/urls.py
+++ b/backend/profiles/urls.py
@@ -2,8 +2,22 @@
 
 from django.urls import path
 
-from .views import ProfileByUsernameAPIView
+from .views import (
+    AvailabilitySlotDetailAPIView,
+    AvailabilitySlotListCreateAPIView,
+    ProfileByUsernameAPIView,
+)
 
 urlpatterns = [
+    path(
+        "<str:username>/availability-slots/",
+        AvailabilitySlotListCreateAPIView.as_view(),
+        name="availability-slot-list-create",
+    ),
+    path(
+        "<str:username>/availability-slots/<uuid:slot_id>/",
+        AvailabilitySlotDetailAPIView.as_view(),
+        name="availability-slot-detail",
+    ),
     path("<str:username>/", ProfileByUsernameAPIView.as_view(), name="profile-by-username"),
 ]

--- a/backend/profiles/views.py
+++ b/backend/profiles/views.py
@@ -1,5 +1,7 @@
 """Views for profile self-service API endpoints."""
 
+from django.db import IntegrityError
+from django.utils import timezone
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
 from rest_framework.permissions import AllowAny, BasePermission
@@ -9,10 +11,17 @@ from rest_framework.views import APIView
 
 from accounts.permissions import IsNotBanned, IsUser
 
-from .models import Profile
-from .serializers import ProfileResponseSerializer, ProfileUpdateSerializer
+from .models import AvailabilitySlot, MentorshipMode, Profile
+from .serializers import (
+    AvailabilitySlotSerializer,
+    AvailabilitySlotWriteSerializer,
+    ProfileResponseSerializer,
+    ProfileUpdateSerializer,
+)
 
 NOT_FOUND_DETAIL = {"detail": "Not found."}
+OVERLAP_DETAIL = {"detail": "Availability slot overlaps with an existing slot."}
+PERMISSION_DENIED_DETAIL = {"detail": "You do not have permission to perform this action."}
 
 
 class ProfileByUsernameAPIView(APIView):
@@ -85,3 +94,215 @@ class ProfileByUsernameAPIView(APIView):
         serializer.save()
 
         return Response(ProfileResponseSerializer(profile).data, status=status.HTTP_200_OK)
+
+
+class AvailabilitySlotListCreateAPIView(APIView):
+    """Create and list mentor availability slots scoped by username."""
+
+    permission_classes = [IsUser, IsNotBanned]
+
+    def _get_profile_or_404(self, username: str) -> Profile | None:
+        """Return profile by username when it exists."""
+        try:
+            return Profile.objects.get(username=username)
+        except Profile.DoesNotExist:
+            return None
+
+    def _is_mentor_profile(self, profile: Profile) -> bool:
+        """Return True when profile supports mentoring."""
+        return profile.mentorship_mode in {MentorshipMode.MENTOR, MentorshipMode.BOTH}
+
+    @extend_schema(
+        request=AvailabilitySlotWriteSerializer,
+        responses={
+            201: AvailabilitySlotSerializer,
+            400: OpenApiResponse(description="Validation error."),
+            401: OpenApiResponse(description="Authentication required."),
+            403: OpenApiResponse(description="Permission denied."),
+        },
+        description=(
+            "Create a mentor availability slot using date/startTime/endTime. "
+            "endTime must be later than startTime."
+        ),
+        tags=["Profiles"],
+    )
+    def post(self, request: Request, username: str) -> Response:
+        """Create an availability slot for mentor matching requested username."""
+        profile = self._get_profile_or_404(username)
+        if profile is None:
+            return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
+
+        if request.user != profile.user or not self._is_mentor_profile(profile):
+            return Response(PERMISSION_DENIED_DETAIL, status=status.HTTP_403_FORBIDDEN)
+
+        serializer = AvailabilitySlotWriteSerializer(
+            data=request.data,
+            context={"profile": profile},
+        )
+        serializer.is_valid(raise_exception=True)
+
+        try:
+            slot = serializer.save()
+        except IntegrityError:
+            return Response(OVERLAP_DETAIL, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(AvailabilitySlotSerializer(slot).data, status=status.HTTP_201_CREATED)
+
+    @extend_schema(
+        responses={
+            200: AvailabilitySlotSerializer(many=True),
+            401: OpenApiResponse(description="Authentication required."),
+            403: OpenApiResponse(description="Permission denied."),
+        },
+        description="List upcoming availability slots for authenticated mentor.",
+        tags=["Profiles"],
+    )
+    def get(self, request: Request, username: str) -> Response:
+        """List upcoming availability slots for the mentor matching username."""
+        profile = self._get_profile_or_404(username)
+        if profile is None or not self._is_mentor_profile(profile):
+            return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
+
+        upcoming_slots = AvailabilitySlot.objects.filter(
+            profile=profile,
+            start_at__gte=timezone.now(),
+        ).order_by("start_at")
+
+        return Response(
+            AvailabilitySlotSerializer(upcoming_slots, many=True).data,
+            status=status.HTTP_200_OK,
+        )
+
+
+class AvailabilitySlotDetailAPIView(APIView):
+    """Retrieve, update, and delete mentor-owned availability slots."""
+
+    permission_classes = [IsUser, IsNotBanned]
+
+    def _get_profile_or_404(self, username: str) -> Profile | None:
+        """Return profile by username when it exists."""
+        try:
+            return Profile.objects.get(username=username)
+        except Profile.DoesNotExist:
+            return None
+
+    def _is_mentor_profile(self, profile: Profile) -> bool:
+        """Return True when profile supports mentoring."""
+        return profile.mentorship_mode in {MentorshipMode.MENTOR, MentorshipMode.BOTH}
+
+    def _get_slot_or_404(self, profile: Profile, slot_id: str) -> AvailabilitySlot | None:
+        """Return slot when it belongs to provided profile; otherwise None."""
+        try:
+            return AvailabilitySlot.objects.get(id=slot_id, profile=profile)
+        except AvailabilitySlot.DoesNotExist:
+            return None
+
+    @extend_schema(
+        responses={
+            200: AvailabilitySlotSerializer,
+            404: OpenApiResponse(description="Availability slot not found."),
+        },
+        description="Retrieve a mentor-owned availability slot by ID.",
+        tags=["Profiles"],
+    )
+    def get(self, request: Request, username: str, slot_id: str) -> Response:
+        """Retrieve one availability slot for mentor matching username."""
+        profile = self._get_profile_or_404(username)
+        if profile is None or not self._is_mentor_profile(profile):
+            return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
+
+        slot = self._get_slot_or_404(profile, slot_id)
+        if slot is None:
+            return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
+
+        return Response(AvailabilitySlotSerializer(slot).data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        request=AvailabilitySlotWriteSerializer,
+        responses={
+            200: AvailabilitySlotSerializer,
+            400: OpenApiResponse(description="Validation error."),
+            404: OpenApiResponse(description="Availability slot not found."),
+        },
+        description="Update a mentor-owned availability slot.",
+        tags=["Profiles"],
+    )
+    def patch(self, request: Request, username: str, slot_id: str) -> Response:
+        """Partially update one availability slot for owner mentor only."""
+        profile = self._get_profile_or_404(username)
+        if profile is None:
+            return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
+
+        if request.user != profile.user or not self._is_mentor_profile(profile):
+            return Response(PERMISSION_DENIED_DETAIL, status=status.HTTP_403_FORBIDDEN)
+
+        slot = self._get_slot_or_404(profile, slot_id)
+        if slot is None:
+            return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
+
+        serializer = AvailabilitySlotWriteSerializer(slot, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+
+        try:
+            updated_slot = serializer.save()
+        except IntegrityError:
+            return Response(OVERLAP_DETAIL, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(AvailabilitySlotSerializer(updated_slot).data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        request=AvailabilitySlotWriteSerializer,
+        responses={
+            200: AvailabilitySlotSerializer,
+            400: OpenApiResponse(description="Validation error."),
+            404: OpenApiResponse(description="Availability slot not found."),
+        },
+        description="Replace a mentor-owned availability slot.",
+        tags=["Profiles"],
+    )
+    def put(self, request: Request, username: str, slot_id: str) -> Response:
+        """Fully update one availability slot for owner mentor only."""
+        profile = self._get_profile_or_404(username)
+        if profile is None:
+            return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
+
+        if request.user != profile.user or not self._is_mentor_profile(profile):
+            return Response(PERMISSION_DENIED_DETAIL, status=status.HTTP_403_FORBIDDEN)
+
+        slot = self._get_slot_or_404(profile, slot_id)
+        if slot is None:
+            return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
+
+        serializer = AvailabilitySlotWriteSerializer(slot, data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        try:
+            updated_slot = serializer.save()
+        except IntegrityError:
+            return Response(OVERLAP_DETAIL, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(AvailabilitySlotSerializer(updated_slot).data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        responses={
+            204: OpenApiResponse(description="Availability slot deleted."),
+            404: OpenApiResponse(description="Availability slot not found."),
+        },
+        description="Delete a mentor-owned availability slot.",
+        tags=["Profiles"],
+    )
+    def delete(self, request: Request, username: str, slot_id: str) -> Response:
+        """Delete one availability slot for owner mentor only."""
+        profile = self._get_profile_or_404(username)
+        if profile is None:
+            return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
+
+        if request.user != profile.user or not self._is_mentor_profile(profile):
+            return Response(PERMISSION_DENIED_DETAIL, status=status.HTTP_403_FORBIDDEN)
+
+        slot = self._get_slot_or_404(profile, slot_id)
+        if slot is None:
+            return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
+
+        slot.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## Related Issue

Closes #119

## Description

Implemented username-scoped DRF endpoints for mentor availability slot management and aligned permissions with profile ownership.

### What this PR includes
- Added availability slot API endpoints under username-scoped routes:
  - `GET /api/profiles/{username}/availability-slots/`
  - `POST /api/profiles/{username}/availability-slots/`
  - `GET /api/profiles/{username}/availability-slots/{slot_id}/`
  - `PUT /api/profiles/{username}/availability-slots/{slot_id}/`
  - `PATCH /api/profiles/{username}/availability-slots/{slot_id}/`
  - `DELETE /api/profiles/{username}/availability-slots/{slot_id}/`
- Added serializers for read/write payloads with strict validation:
  - `date` cannot be in the past
  - `endTime` must be greater than `startTime`
- Enforced authorization rules:
  - Only the owner mentor profile can create/update/delete their slots
  - Authenticated users can read mentor availability
- Added/updated integration tests for:
  - create/read/update/delete flows
  - validation errors
  - ownership and permission checks
  - username-scoped routing behavior

## Type of Change

- [x] New feature

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code