### PR TITLE
feat: added username field to users table.

### DIFF
--- a/backend/accounts/admin.py
+++ b/backend/accounts/admin.py
@@ -6,6 +6,7 @@ from .models import User
 @admin.register(User)
 class UserAdmin(admin.ModelAdmin):
     list_display = (
+        "username",
         "email",
         "role",
         "auth_provider",
@@ -22,5 +23,5 @@ class UserAdmin(admin.ModelAdmin):
         "is_banned",
         "is_staff",
     )
-    search_fields = ("email",)
+    search_fields = ("email", "username")
     ordering = ("email",)

--- a/backend/accounts/migrations/0008_user_username.py
+++ b/backend/accounts/migrations/0008_user_username.py
@@ -1,0 +1,59 @@
+import re
+
+from django.db import migrations, models
+
+
+def _build_unique_username(user_model, user_id, source_value):
+    sanitized_base = re.sub(r"[^a-z0-9_]+", "_", source_value.lower()).strip("_")
+    base_username = (sanitized_base or "user")[:50]
+    candidate = base_username
+    suffix = 1
+
+    while user_model.objects.filter(username=candidate).exclude(pk=user_id).exists():
+        numeric_suffix = f"_{suffix}"
+        candidate = f"{base_username[: 50 - len(numeric_suffix)]}{numeric_suffix}"
+        suffix += 1
+
+    return candidate
+
+
+def populate_usernames(apps, schema_editor):
+    user_model = apps.get_model("accounts", "User")
+    profile_model = apps.get_model("profiles", "Profile")
+
+    for user in user_model.objects.all():
+        if user.username:
+            continue
+
+        profile = profile_model.objects.filter(user_id=user.pk).first()
+        source_value = ""
+
+        if profile is not None and profile.username:
+            source_value = profile.username
+        elif user.email:
+            source_value = user.email.split("@", 1)[0]
+
+        user.username = _build_unique_username(user_model, user.pk, source_value)
+        user.save(update_fields=["username"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("profiles", "0002_profile_username"),
+        ("accounts", "0007_alter_user_role"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="user",
+            name="username",
+            field=models.CharField(blank=True, default="", max_length=50),
+        ),
+        migrations.RunPython(populate_usernames, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name="user",
+            name="username",
+            field=models.CharField(max_length=50, unique=True),
+        ),
+    ]

--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -1,3 +1,4 @@
+import re
 import uuid
 from typing import Any
 
@@ -59,6 +60,7 @@ class User(AbstractBaseUser, PermissionsMixin):
         default=UserRole.USER,
     )
     email = models.EmailField(unique=True)
+    username = models.CharField(max_length=50, unique=True)
     auth_provider = models.CharField(
         max_length=16,
         choices=AuthProvider.choices,
@@ -80,9 +82,27 @@ class User(AbstractBaseUser, PermissionsMixin):
         ordering = ["-created_at"]
 
     def save(self, *args: Any, **kwargs: Any) -> None:
-        """Ensure email is always stored in lowercase."""
+        """Ensure email is lowercase and generate a unique username when needed."""
         self.email = self.email.lower()
+        if not self.username:
+            email_prefix = (self.email or "").split("@", 1)[0]
+            self.username = self._generate_unique_username(email_prefix)
         super().save(*args, **kwargs)
+
+    @classmethod
+    def _generate_unique_username(cls, source_value: str) -> str:
+        """Build a unique username from a source value."""
+        sanitized_base = re.sub(r"[^a-z0-9_]+", "_", source_value.lower()).strip("_")
+        base_username = (sanitized_base or "user")[:50]
+        candidate = base_username
+        suffix = 1
+
+        while cls.objects.filter(username=candidate).exists():
+            numeric_suffix = f"_{suffix}"
+            candidate = f"{base_username[: 50 - len(numeric_suffix)]}{numeric_suffix}"
+            suffix += 1
+
+        return candidate
 
     def __str__(self):
         return self.email

--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -14,15 +14,6 @@ from .models import AuthProvider, User, UserRole
 
 
 class UserResponseSerializer(serializers.ModelSerializer):
-    username = serializers.SerializerMethodField()
-
-    def get_username(self, obj: User) -> str | None:
-        """Return linked profile username for route navigation compatibility."""
-        profile = getattr(obj, "profile", None)
-        if profile is None:
-            return None
-        return cast(str, profile.username)
-
     class Meta:
         model = User
         fields = (
@@ -98,6 +89,7 @@ class RegisterSerializer(serializers.Serializer):
         display_name = email.split("@", 1)[0].replace(".", " ").replace("_", " ").title()
         Profile.objects.create(
             user=user,
+            username=user.username,
             display_name=display_name,
         )
 

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -28,6 +28,21 @@ class UserModelTests(TestCase):
         self.assertFalse(user.is_staff)
         self.assertFalse(user.is_superuser)
         self.assertTrue(user.check_password("SecurePass123"))
+        self.assertEqual(user.username, "test")
+
+    def test_create_user_generates_unique_username(self) -> None:
+        """Test that username generation appends numeric suffix on collision."""
+        first_user = User.objects.create_user(
+            email="same.user@example.com",
+            password="SecurePass123",
+        )
+        second_user = User.objects.create_user(
+            email="same_user@example.com",
+            password="SecurePass123",
+        )
+
+        self.assertEqual(first_user.username, "same_user")
+        self.assertEqual(second_user.username, "same_user_1")
 
     def test_create_user_email_normalized(self) -> None:
         """Test that email is normalized (lowercase)."""
@@ -95,12 +110,14 @@ class RegisterAPIViewTests(TestCase):
         self.assertIn(settings.AUTH_ACCESS_COOKIE_NAME, response.cookies)
         self.assertIn(settings.AUTH_REFRESH_COOKIE_NAME, response.cookies)
         self.assertEqual(data["user"]["email"], "newuser@example.com")
+        self.assertEqual(data["user"]["username"], "newuser")
         self.assertEqual(data["user"]["role"], UserRole.USER)
         self.assertTrue(data["user"]["is_active"])
 
         # Verify user was created in DB
         user = User.objects.get(email="newuser@example.com")
         self.assertTrue(user.check_password("SecurePass123"))
+        self.assertEqual(user.username, "newuser")
         profile = Profile.objects.get(user=user)
         self.assertEqual(profile.username, "newuser")
 
@@ -554,6 +571,7 @@ class RBACPermissionTests(TestCase):
             first_user = payload["results"][0]
             self.assertIn("id", first_user)
             self.assertIn("email", first_user)
+            self.assertIn("username", first_user)
             self.assertIn("role", first_user)
             self.assertIn("is_banned", first_user)
             self.assertIn("is_active", first_user)

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -253,6 +253,7 @@ class AdminUsersListAPIView(APIView):
         users = User.objects.all().values(
             "id",
             "email",
+            "username",
             "role",
             "is_banned",
             "is_active",


### PR DESCRIPTION
## Related Issue

Closes #230 

## Description

Adds a dedicated `username` field to `accounts.User` to improve API navigability and querying.  
Includes automatic username generation (same style as profile username generation), data migration for existing users, and API/serializer updates to return `username` directly from `User`.

## Type of Change

- [x] New feature

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code

## Notes

- Added migration to backfill unique usernames for existing users.
- Registration now keeps `User.username` and `Profile.username` aligned.
- Admin user listing now includes `username` for easier filtering/fetching.