### PR TITLE
fix: merged migrations in profile app

### DIFF
--- a/backend/profiles/migrations/0005_merge_0003_availabilityslot_0004_seed_location_coordinates.py
+++ b/backend/profiles/migrations/0005_merge_0003_availabilityslot_0004_seed_location_coordinates.py
@@ -1,0 +1,17 @@
+"""Merge parallel profiles migration branches.
+
+This migration resolves the conflict created by two independent 0003 migrations:
+- 0003_availabilityslot_booked_at_and_more
+- 0003_convert_location_to_geopoint -> 0004_seed_location_coordinates
+"""
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("profiles", "0003_availabilityslot_booked_at_and_more"),
+        ("profiles", "0004_seed_location_coordinates"),
+    ]
+
+    operations = []


### PR DESCRIPTION
## Related Issue

Closes #245 

## Description

This PR resolves a migration conflict in the profiles app by adding an explicit merge migration so parallel migration branches are combined into a single linear history.  
It prevents conflicting migration heads and allows the migration graph to progress cleanly.

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have performed a self-review of my code

## Notes

Added merge migration: 0005_merge_0003_availabilityslot_0004_seed_location_coordinates.py.