### PR TITLE
feat(profiles): include username in mentor discovery response

### DIFF
--- a/backend/profiles/serializers.py
+++ b/backend/profiles/serializers.py
@@ -351,8 +351,11 @@ class PublicMentorProfileSearchResultSerializer(serializers.ModelSerializer):
     """
 
     full_name = serializers.SerializerMethodField()
+    username = serializers.CharField(read_only=True)
     hidden = serializers.BooleanField(source="is_visible", read_only=True)
-    expertises = serializers.ListField(child=serializers.CharField(), source="skills", read_only=True)
+    expertises = serializers.ListField(
+        child=serializers.CharField(), source="skills", read_only=True
+    )
     picture_url = serializers.URLField(read_only=True)
     location = LocationField(read_only=True)
     show_initials_only = serializers.BooleanField(read_only=True)
@@ -361,6 +364,7 @@ class PublicMentorProfileSearchResultSerializer(serializers.ModelSerializer):
         model = Profile
         fields = (
             "id",
+            "username",
             "full_name",
             "bio",
             "hidden",

--- a/backend/profiles/tests.py
+++ b/backend/profiles/tests.py
@@ -1116,13 +1116,19 @@ class PublicMentorProfilesSearchListAPIViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         payload = response.json()
         self.assertIn("results", payload)
+        self.assertTrue(all("username" in profile for profile in payload["results"]))
 
         returned_names = {p["full_name"] for p in payload["results"]}
+        returned_usernames = {p["username"] for p in payload["results"]}
         # Only visible mentors should be included.
         self.assertIn("Alice Mentor", returned_names)
         self.assertIn("JD", returned_names)  # initials due to show_initials_only
         self.assertIn("Bob Zed", returned_names)
         self.assertNotIn("Private Mentor", returned_names)
+        self.assertIn(self.mentor1_profile.username, returned_usernames)
+        self.assertIn(self.mentor2_profile.username, returned_usernames)
+        self.assertIn(self.mentor3_profile.username, returned_usernames)
+        self.assertNotIn(self.private_mentor_profile.username, returned_usernames)
         # Default discovery is mentors only.
         self.assertNotIn("Mentee Person", returned_names)
 
@@ -1134,6 +1140,7 @@ class PublicMentorProfilesSearchListAPIViewTests(TestCase):
 
         self.assertEqual(payload["count"], 1)
         self.assertEqual(payload["results"][0]["full_name"], "Alice Mentor")
+        self.assertEqual(payload["results"][0]["username"], self.mentor1_profile.username)
 
     def test_filter_by_skill_term(self) -> None:
         """`skill` query param matches profile skills."""


### PR DESCRIPTION
## Related Issue

Closes #285 

## Description

This PR updates the public profiles discovery endpoint to include `username` in each result item.

Specifically:
- Adds `username` to the serializer used by `GET /api/profiles/`.
- Updates discovery endpoint tests to verify `username` is present and matches expected profiles.
- Keeps existing discovery behavior (visibility filtering, initials-only display, pagination, and search) unchanged.

## Type of Change

- [x] New feature

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code

## Notes

- This change is backward-compatible for clients already consuming `GET /api/profiles/`; it only adds a new field (`username`) to each discovery result.