### PR TITLE
feat: discover api is connected.

### DIFF
--- a/web/src/components/features/discover/ProfileCard.tsx
+++ b/web/src/components/features/discover/ProfileCard.tsx
@@ -1,125 +1,120 @@
-// web/src/components/features/discover/ProfileCard.tsx
 import { Button } from '@/components/ui/button'
 import { Body } from '@/components/Typography'
 import { cn } from '@/lib/utils'
-import type { MockProfileDetails } from '@/lib/mocks/profiles'
+import type { PublicMentorProfile } from '@/lib/queries/DiscoverQueries.ts'
 
 interface ProfileCardProps {
-  profile: MockProfileDetails
+  profile: PublicMentorProfile
   className?: string
-  /** Wire up to navigate to /:userId/profile once profile routes exist */
   onViewProfile?: (id: string) => void
-  /** Wire up to open a message compose modal once messaging is implemented */
   onSendMessage?: (id: string) => void
 }
 
-function ProfileAvatar({
-  displayName,
-  pictureUrl,
-}: Readonly<{
-  displayName: string
-  pictureUrl: string
-}>) {
-  const initials = displayName
-    .split(' ')
-    .map((n) => n[0])
-    .join('')
-    .substring(0, 2)
-    .toUpperCase()
+const AVATAR_COLORS = [
+  'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+  'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300',
+  'bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300',
+  'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+]
 
+function ProfileAvatar({
+                         displayName,
+                         pictureUrl,
+                       }: Readonly<{ displayName: string; pictureUrl: string | null }>) {
+  const initials = displayName
+      .split(' ')
+      .map((n) => n[0])
+      .join('')
+      .substring(0, 2)
+      .toUpperCase()
+
+  const colorClass = AVATAR_COLORS[displayName.length % AVATAR_COLORS.length]
 
   if (pictureUrl) {
     return (
-      <img
-        src={pictureUrl}
-        alt={displayName}
-        className="h-20 w-20 rounded-full object-cover shrink-0 border border-line shadow-sm"
-      />
+        <img
+            src={pictureUrl}
+            alt={displayName}
+            className="h-20 w-20 rounded-full object-cover shrink-0 border border-line shadow-sm"
+        />
     )
   }
 
-  const colors = [
-    'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
-    'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
-    'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300',
-    'bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300',
-    'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
-  ]
-
-  const colorClass = colors[displayName.length % colors.length]
-
-
   return (
-    <div
-      className={cn(
-        'h-20 w-20 rounded-full flex items-center justify-center text-xl font-bold shrink-0 border border-white/50 shadow-sm',
-        colorClass,
-      )}
-    >
-      {initials}
-    </div>
+      <div
+          className={cn(
+              'h-20 w-20 rounded-full flex items-center justify-center text-xl font-bold shrink-0 border border-white/50 shadow-sm',
+              colorClass,
+          )}
+      >
+        {initials}
+      </div>
   )
 }
 
 export function ProfileCard({
-  profile,
-  className,
-  onViewProfile,
-  onSendMessage,
-}: Readonly<ProfileCardProps>) {
+                              profile,
+                              className,
+                              onViewProfile,
+                              onSendMessage,
+                            }: Readonly<ProfileCardProps>) {
   return (
-    <div
-      className={cn(
-        'island-shell rounded-xl p-8 flex flex-col gap-6 shadow-md hover:shadow-xl/30',
-        className,
-      )}
-    >
-      {/* Header: Avatar + Name + Title */}
-      <div className="flex items-center gap-4">
-        <ProfileAvatar displayName={profile.displayName} pictureUrl={profile.pictureUrl} />
-        <div className="min-w-0">
-          <h3 className="font-display text-2xl font-bold text-ink leading-tight truncate">
-            {profile.displayName}
-          </h3>
-          <p className="text-accent font-medium text-sm mt-0.5">{profile.title}</p>
+      <div
+          className={cn(
+              'island-shell rounded-xl p-8 flex flex-col gap-6 shadow-md hover:shadow-xl/30',
+              className,
+          )}
+      >
+        {/* Header: Avatar + Name + Title */}
+        <div className="flex items-center gap-4">
+          <ProfileAvatar
+              displayName={profile.full_name}
+              pictureUrl={profile.picture_url}
+          />
+          <div className="min-w-0">
+            <h3 className="font-display text-2xl font-bold text-ink leading-tight truncate">
+              {profile.full_name}
+            </h3>
+            <p className="text-accent font-medium text-sm mt-0.5">{profile.title}</p>
+          </div>
+        </div>
+
+        {/* Expertises */}
+        <div className="flex flex-wrap gap-2">
+          {profile.expertises.map((skill) => (
+              <span
+                  key={skill}
+                  className="px-3 py-1 bg-accent-muted text-accent text-xs font-bold uppercase tracking-wider rounded-full"
+              >
+            {skill}
+          </span>
+          ))}
+        </div>
+
+        {/* Bio */}
+        <Body className="text-ink-soft leading-relaxed line-clamp-2 flex-1">
+          {profile.bio}
+        </Body>
+
+        {/* Actions */}
+        <div className="grid grid-cols-2 gap-3 mt-auto">
+          <Button
+              className="w-full bg-accent hover:bg-accent-light text-white shadow-sm"
+              size="sm"
+              onClick={() => onViewProfile?.(profile.username)}
+          >
+            View Profile
+          </Button>
+          <Button
+              variant="outline"
+              className="w-full flex-1 min-w-0 truncate border-line text-ink-soft hover:text-ink hover:border-accent/30 bg-mist hover:bg-accent/20"
+              size="sm"
+              onClick={() => onSendMessage?.(profile.username)}
+          >
+            Send Message
+          </Button>
         </div>
       </div>
-
-      {/* Skills */}
-      <div className="flex flex-wrap gap-2">
-        {profile.expertise.map((e) => (
-          <span
-            key={e.id}
-            className="px-3 py-1 bg-accent-muted text-accent text-xs font-bold uppercase tracking-wider rounded-full"
-          >
-            {e.name}
-          </span>
-        ))}
-      </div>
-
-      {/* Bio */}
-      <Body className="text-ink-soft leading-relaxed line-clamp-2 flex-1">
-        {profile.bio}
-      </Body>
-
-      {/* Actions */}
-      <div className="grid grid-cols-2 gap-3 mt-auto">
-        <Button
-          className="w-full bg-accent hover:bg-accent-light text-white shadow-sm"
-          size="sm"
-          onClick={() => onViewProfile?.(profile.id)}
-        >
-          View Profile
-        </Button>
-        <Button
-          variant="outline"
-          className="w-full flex-1 min-w-0 truncate border-line text-ink-soft hover:text-ink hover:border-accent/30 bg-mist hover:bg-accent/20"
-          size="sm"
-          onClick={() => onSendMessage?.(profile.id)}
-        >
-          Send Message
-        </Button>
-      </div>
-    </div>
   )
 }

--- a/web/src/lib/queries/DiscoverQueries.ts
+++ b/web/src/lib/queries/DiscoverQueries.ts
@@ -1,0 +1,76 @@
+import { queryOptions } from '@tanstack/react-query'
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
+
+// ---- Types ----
+
+export interface PublicMentorProfile {
+    id: string
+    username: string
+    full_name: string
+    bio: string
+    hidden: boolean
+    picture_url: string | null
+    title: string
+    location: string | null
+    show_initials_only: boolean
+    expertises: string[]
+    rating: number
+    total_mentee_count: number
+}
+
+export interface MentorSearchResponse {
+    count: number
+    page: number
+    pageSize: number
+    results: PublicMentorProfile[]
+}
+
+export interface MentorSearchParams {
+    q?: string
+    skills?: string[]
+    page?: number
+    pageSize?: number
+}
+
+export interface Skill {
+    id: number
+    name: string
+}
+
+// ---- Fetchers ----
+
+export async function fetchMentors(params: MentorSearchParams): Promise<MentorSearchResponse> {
+    const url = new URL(`${API_BASE_URL}/profiles/`, window.location.origin)
+
+    if (params.q)              url.searchParams.set('q', params.q)
+    if (params.page)           url.searchParams.set('page', String(params.page))
+    if (params.pageSize)       url.searchParams.set('pageSize', String(params.pageSize))
+    if (params.skills?.length) params.skills.forEach(s => url.searchParams.append('skill', s))
+
+    const res = await fetch(url.toString())
+    if (!res.ok) throw new Error('Failed to fetch mentors')
+    return res.json()
+}
+
+export async function fetchAllSkills(): Promise<Skill[]> {
+    const res = await fetch(`${API_BASE_URL}/profiles/skills/`)
+    if (!res.ok) throw new Error('Failed to fetch skills')
+    return res.json()
+}
+
+// ---- Query Options ----
+
+export const mentorSearchQueryOptions = (params: MentorSearchParams) =>
+    queryOptions({
+        queryKey: ['mentors', 'search', params],
+        queryFn: () => fetchMentors(params),
+        staleTime: 30 * 1000,
+        placeholderData: (prev) => prev,
+    })
+
+export const allSkillsQueryOptions = queryOptions({
+    queryKey: ['profiles', 'skills'],
+    queryFn: fetchAllSkills,
+    staleTime: 5 * 60 * 1000,
+})

--- a/web/src/lib/queries/DiscoverQueries.ts
+++ b/web/src/lib/queries/DiscoverQueries.ts
@@ -1,8 +1,6 @@
-import { queryOptions } from '@tanstack/react-query'
+import { queryOptions, infiniteQueryOptions } from '@tanstack/react-query'
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
-
-// ---- Types ----
 
 export interface PublicMentorProfile {
     id: string
@@ -29,7 +27,6 @@ export interface MentorSearchResponse {
 export interface MentorSearchParams {
     q?: string
     skills?: string[]
-    page?: number
     pageSize?: number
 }
 
@@ -38,9 +35,9 @@ export interface Skill {
     name: string
 }
 
-// ---- Fetchers ----
-
-export async function fetchMentors(params: MentorSearchParams): Promise<MentorSearchResponse> {
+export async function fetchMentors(
+    params: MentorSearchParams & { page: number }
+): Promise<MentorSearchResponse> {
     const url = new URL(`${API_BASE_URL}/profiles/`, window.location.origin)
 
     if (params.q)              url.searchParams.set('q', params.q)
@@ -59,18 +56,20 @@ export async function fetchAllSkills(): Promise<Skill[]> {
     return res.json()
 }
 
-// ---- Query Options ----
-
-export const mentorSearchQueryOptions = (params: MentorSearchParams) =>
-    queryOptions({
+export const mentorSearchInfiniteQueryOptions = (params: MentorSearchParams) =>
+    infiniteQueryOptions({
         queryKey: ['mentors', 'search', params],
-        queryFn: () => fetchMentors(params),
-        staleTime: 30 * 1000,
-        placeholderData: (prev) => prev,
+        queryFn: ({ pageParam }) =>
+            fetchMentors({ ...params, page: pageParam as number }),
+        initialPageParam: 1,
+        getNextPageParam: (lastPage) => {
+            const fetched = lastPage.page * lastPage.pageSize
+            return fetched < lastPage.count ? lastPage.page + 1 : undefined
+        },
     })
 
 export const allSkillsQueryOptions = queryOptions({
     queryKey: ['profiles', 'skills'],
     queryFn: fetchAllSkills,
-    staleTime: 5 * 60 * 1000,
+    staleTime: Infinity,
 })

--- a/web/src/lib/queries/useDebounce.ts
+++ b/web/src/lib/queries/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from 'react'
+
+export function useDebounce<T>(value: T, delay: number): T {
+    const [debounced, setDebounced] = useState(value)
+
+    useEffect(() => {
+        const timer = setTimeout(() => setDebounced(value), delay)
+        return () => clearTimeout(timer)
+    }, [value, delay])
+
+    return debounced
+}

--- a/web/src/routes/_authorized/__tests__/dashboard.test.tsx
+++ b/web/src/routes/_authorized/__tests__/dashboard.test.tsx
@@ -1,92 +1,276 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
-vi.mock('../../../routeTree.gen', () => ({}))
-vi.mock('../../../router', () => ({}))
+const { mockNavigate } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+}))
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  const actual = await importOriginal<any>()
   return {
     ...actual,
-    createFileRoute: () => () => ({
-      update: vi.fn().mockReturnThis(),
-    }),
-    Link: ({ children, to, className }: any) => (
-        <a href={to} className={className}>{children}</a>
-    ),
+    createFileRoute: () => () => ({}),
+    useNavigate: () => mockNavigate,
   }
 })
 
-// Mock mentorship queries used in MentorDashboardView
-vi.mock('#/lib/queries/MentorshipQueries.ts', () => ({
-  useMyRequests: () => ({ data: [], isLoading: false }),
-  useRespondToRequest: () => ({ mutate: vi.fn(), isPending: false }),
-  useUpcomingSessions: () => ({ data: [], isLoading: false }),
-  myRequestsQueryOptions: { queryKey: ['mentorship', 'requests'], queryFn: () => null },
-  myMatchesQueryOptions: { queryKey: ['mentorship', 'matches'], queryFn: () => null },
-}))
+vi.mock('lucide-react', async (importOriginal) => {
+  const actual = await importOriginal<any>()
+  return {
+    ...actual,
+    Search: () => <div data-testid="icon-search" />,
+    SlidersHorizontal: () => <div data-testid="icon-sliders" />,
+    X: () => <div data-testid="icon-x" />,
+  }
+})
 
-vi.mock('#/lib/queries/ProfileTimeSlotQueries.ts', () => ({
-  useMentorUpcomingSessions: () => ({
-    sessions: [],
-    profilesByUsername: {},
-    isLoading: false,
-  }),
-  useAvailabilitySlots: () => ({ data: [], isLoading: false }),
-}))
-import { DashboardHome } from '../dashboard'
+const MOCK_SKILLS = [
+  { id: 1, name: 'Python' },
+  { id: 2, name: 'Kubernetes' },
+  { id: 3, name: 'Go' },
+  { id: 4, name: 'React' },
+]
 
-function renderWithUser(appUsageMode: 'MENTOR' | 'MENTEE') {
+const makeMentor = (n: number) => ({
+  id: `id-${n}`,
+  username: `mentor${n}`,
+  full_name: `Mentor ${n}`,
+  bio: `Bio of mentor ${n}`,
+  hidden: false,
+  picture_url: null,
+  title: `Engineer ${n}`,
+  location: null,
+  show_initials_only: false,
+  expertises: n % 2 === 0 ? ['Python'] : ['Kubernetes'],
+  rating: 4.5,
+  total_mentee_count: n,
+})
+
+const MOCK_MENTORS = Array.from({ length: 8 }, (_, i) => makeMentor(i + 1))
+
+vi.mock('@/lib/queries/DiscoverQueries.ts', async (importOriginal) => {
+  const actual = await importOriginal<any>()
+  return {
+    ...actual,
+    mentorSearchInfiniteQueryOptions: (params: any) => ({
+      queryKey: ['mentors', 'search', params],
+      queryFn: async ({ pageParam = 1 }: { pageParam: number }) => {
+        const pageSize = params.pageSize ?? 6
+        let results = [...MOCK_MENTORS]
+
+        if (params.q) {
+          const q = params.q.toLowerCase()
+          results = results.filter(
+              (m) =>
+                  m.full_name.toLowerCase().includes(q) ||
+                  m.bio.toLowerCase().includes(q) ||
+                  m.expertises.some((e: string) => e.toLowerCase().includes(q)),
+          )
+        }
+
+        if (params.skills?.length) {
+          results = results.filter((m) =>
+              m.expertises.some((e: string) => params.skills.includes(e)),
+          )
+        }
+
+        const start = (pageParam - 1) * pageSize
+        return {
+          count: results.length,
+          page: pageParam,
+          pageSize,
+          results: results.slice(start, start + pageSize),
+        }
+      },
+      initialPageParam: 1,
+      getNextPageParam: (lastPage: any) => {
+        const fetched = lastPage.page * lastPage.pageSize
+        return fetched < lastPage.count ? lastPage.page + 1 : undefined
+      },
+    }),
+    allSkillsQueryOptions: {
+      queryKey: ['profiles', 'skills'],
+      queryFn: async () => MOCK_SKILLS,
+    },
+  }
+})
+
+import { DiscoverPage } from '../discover'
+
+function renderDiscover() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   })
-  queryClient.setQueryData(['me'], {
-    id: '1',
-    username: 'testuser',
-    email: 'test@test.com',
-    app_usage_mode: appUsageMode,
-    role: 'USER',
-    auth_provider: 'LOCAL',
-    is_active: true,
-    created_at: '2026-01-01',
-  })
   return render(
       <QueryClientProvider client={queryClient}>
-        <DashboardHome />
-      </QueryClientProvider>
+        <DiscoverPage />
+      </QueryClientProvider>,
   )
 }
 
-describe('Dashboard Component Routing & Role Variants', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
+describe('DiscoverPage', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders the hero heading', () => {
+    renderDiscover()
+    expect(screen.getByRole('heading', { name: /Discover the/i })).toBeInTheDocument()
   })
 
-  it('renders the Mentee Dashboard when app_usage_mode is MENTEE', () => {
-    renderWithUser('MENTEE')
-    expect(screen.getByRole('heading', { name: /Mentee Dashboard/i })).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: /Sent Requests/i })).toBeInTheDocument()
-    expect(screen.queryByRole('heading', { name: /Incoming Requests/i })).not.toBeInTheDocument()
+  it('renders the search bar', () => {
+    renderDiscover()
+    expect(screen.getByPlaceholderText(/Search profiles, skills, or projects/i)).toBeInTheDocument()
   })
 
-  it('renders the Mentor Dashboard when app_usage_mode is MENTOR', () => {
-    renderWithUser('MENTOR')
-    expect(screen.getByRole('heading', { name: /Mentor Dashboard/i })).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: /Incoming Requests/i })).toBeInTheDocument()
-    expect(screen.queryByRole('heading', { name: /Sent Requests/i })).not.toBeInTheDocument()
+  it('renders the filter button', () => {
+    renderDiscover()
+    expect(screen.getByRole('button', { name: /Filter by skill/i })).toBeInTheDocument()
   })
 
-  it('falls back to Mentee Dashboard when app_usage_mode is not set', () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
+  it('renders at least one ProfileCard on initial load', async () => {
+    renderDiscover()
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: /View Profile/i }).length).toBeGreaterThan(0)
     })
-    queryClient.setQueryData(['me'], null)
-    render(
-        <QueryClientProvider client={queryClient}>
-          <DashboardHome />
-        </QueryClientProvider>
+  })
+
+  it('shows at most PAGE_SIZE (6) cards on initial load', async () => {
+    renderDiscover()
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: /View Profile/i }).length).toBeLessThanOrEqual(6)
+    })
+  })
+
+  it('shows the empty state when no profiles match the search query', async () => {
+    renderDiscover()
+    fireEvent.change(screen.getByPlaceholderText(/Search profiles, skills, or projects/i), {
+      target: { value: 'xyznonexistent' },
+    })
+    await waitFor(() => {
+      expect(screen.getByText(/No mentors found matching/i)).toBeInTheDocument()
+    })
+  })
+
+  it('filters profiles by skill name via search', async () => {
+    renderDiscover()
+    fireEvent.change(screen.getByPlaceholderText(/Search profiles, skills, or projects/i), {
+      target: { value: 'Kubernetes' },
+    })
+    await waitFor(() => {
+      expect(screen.getByText('Mentor 1')).toBeInTheDocument()
+      expect(screen.queryByText('Mentor 2')).not.toBeInTheDocument()
+    })
+  })
+
+  it('restores profiles when search query is cleared', async () => {
+    renderDiscover()
+    const input = screen.getByPlaceholderText(/Search profiles, skills, or projects/i)
+    fireEvent.change(input, { target: { value: 'Kubernetes' } })
+    await waitFor(() => expect(screen.getByText('Mentor 1')).toBeInTheDocument())
+    fireEvent.change(input, { target: { value: '' } })
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: /View Profile/i }).length).toBeGreaterThan(1)
+    })
+  })
+
+  it('opens the skill filter panel when the filter button is clicked', async () => {
+    renderDiscover()
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /Filter by skill/i }))
+    expect(screen.getByText(/Filter by Skill/i)).toBeInTheDocument()
+  })
+
+  it('closes the filter panel when clicked outside', async () => {
+    renderDiscover()
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /Filter by skill/i }))
+    fireEvent.mouseDown(document.body)
+    expect(screen.queryByText(/Filter by Skill/i)).not.toBeInTheDocument()
+  })
+
+  it('filters profiles when a skill chip is selected', async () => {
+    renderDiscover()
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /Filter by skill/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /^Python$/i }))
+    await waitFor(() => {
+      expect(screen.getByText('Mentor 2')).toBeInTheDocument()
+      expect(screen.queryByText('Mentor 1')).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows the active filter count badge on the filter button', async () => {
+    renderDiscover()
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /Filter by skill/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /^Go$/i }))
+    expect(screen.getByText('1')).toBeInTheDocument()
+  })
+
+  it('clears skill filters when "Clear all" is clicked', async () => {
+    renderDiscover()
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /Filter by skill/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /^Go$/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Clear all/i }))
+    expect(screen.queryByText('1')).not.toBeInTheDocument()
+  })
+
+  it('shows the Load More button when there are more profiles than PAGE_SIZE', async () => {
+    renderDiscover()
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Load More/i })).toBeInTheDocument()
+    })
+  })
+
+  it('appends more profiles when Load More is clicked', async () => {
+    renderDiscover()
+    await waitFor(() => screen.getAllByRole('button', { name: /View Profile/i }))
+    const before = screen.getAllByRole('button', { name: /View Profile/i }).length
+
+    fireEvent.click(screen.getByRole('button', { name: /Load More/i }))
+
+    await waitFor(() => {
+      const after = screen.getAllByRole('button', { name: /View Profile/i }).length
+      expect(after).toBeGreaterThan(before)
+    })
+  })
+
+  it('hides Load More when all profiles are loaded', async () => {
+    renderDiscover()
+    await waitFor(() => screen.getByRole('button', { name: /Load More/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Load More/i }))
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /Load More/i })).not.toBeInTheDocument()
+    })
+  })
+
+  it('resets to first page when search query changes', async () => {
+    renderDiscover()
+    await waitFor(() => screen.getByRole('button', { name: /Load More/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Load More/i }))
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: /View Profile/i }).length).toBeGreaterThan(6)
+    })
+
+    fireEvent.change(screen.getByPlaceholderText(/Search profiles, skills, or projects/i), {
+      target: { value: 'Kubernetes' },
+    })
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: /View Profile/i }).length).toBeLessThanOrEqual(6)
+    })
+  })
+
+  it('navigates to the profile page when View Profile is clicked', async () => {
+    renderDiscover()
+    await waitFor(() => screen.getAllByRole('button', { name: /View Profile/i }))
+    fireEvent.click(screen.getAllByRole('button', { name: /View Profile/i })[0])
+    expect(mockNavigate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: '/profiles/$username',
+          params: expect.objectContaining({ username: expect.any(String) }),
+        }),
     )
-    expect(screen.getByRole('heading', { name: /Mentee Dashboard/i })).toBeInTheDocument()
   })
 })

--- a/web/src/routes/_authorized/__tests__/discover.test.tsx
+++ b/web/src/routes/_authorized/__tests__/discover.test.tsx
@@ -1,8 +1,10 @@
 // web/src/routes/_authorized/__tests__/discover.test.tsx
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {infiniteQueryOptions, QueryClient, QueryClientProvider, queryOptions} from '@tanstack/react-query'
 
-// 1. Hoist navigate mock so it is available inside vi.mock factories
+// ── Hoist mocks ──────────────────────────────────────────────────────────────
+
 const { mockNavigate } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
 }))
@@ -16,7 +18,6 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
   }
 })
 
-// 2. Mock Lucide icons to prevent SVG rendering errors in jsdom
 vi.mock('lucide-react', async (importOriginal) => {
   const actual = await importOriginal<any>()
   return {
@@ -27,223 +28,286 @@ vi.mock('lucide-react', async (importOriginal) => {
   }
 })
 
+// ── Mock API data ────────────────────────────────────────────────────────────
+
+const MOCK_SKILLS = [
+  { id: 1, name: 'Python' },
+  { id: 2, name: 'Kubernetes' },
+  { id: 3, name: 'Go' },
+  { id: 4, name: 'React' },
+]
+
+const makeMentor = (n: number) => ({
+  id: `id-${n}`,
+  username: `mentor${n}`,
+  full_name: `Mentor ${n}`,
+  bio: `Bio of mentor ${n}`,
+  hidden: false,
+  picture_url: null,
+  title: `Engineer ${n}`,
+  location: null,
+  show_initials_only: false,
+  expertises: n % 2 === 0 ? ['Python'] : ['Kubernetes'],
+  rating: 4.5,
+  total_mentee_count: n,
+})
+
+// 8 mentors so Load More tests work (> PAGE_SIZE of 6)
+const MOCK_MENTORS = Array.from({ length: 8 }, (_, i) => makeMentor(i + 1))
+
+vi.mock('@/lib/queries/DiscoverQueries.ts', async (importOriginal) => {
+  const actual = await importOriginal<any>()
+  return {
+    ...actual,
+    mentorSearchInfiniteQueryOptions: (params: any) =>
+        infiniteQueryOptions({
+          queryKey: ['mentors', 'search', params],
+          queryFn: async ({ pageParam }) => {
+            const page = (pageParam as number) ?? 1
+            const pageSize = params.pageSize ?? 6
+            let results = [...MOCK_MENTORS]
+
+            if (params.q) {
+              const q = params.q.toLowerCase()
+              results = results.filter(
+                  (m) =>
+                      m.full_name.toLowerCase().includes(q) ||
+                      m.bio.toLowerCase().includes(q) ||
+                      m.expertises.some((e: string) => e.toLowerCase().includes(q)),
+              )
+            }
+
+            if (params.skills?.length) {
+              results = results.filter((m) =>
+                  m.expertises.some((e: string) => params.skills.includes(e)),
+              )
+            }
+
+            const start = (page - 1) * pageSize
+            return {
+              count: results.length,
+              page,
+              pageSize,
+              results: results.slice(start, start + pageSize),
+            }
+          },
+          initialPageParam: 1,
+          getNextPageParam: (lastPage: any) => {
+            const fetched = lastPage.page * lastPage.pageSize
+            return fetched < lastPage.count ? lastPage.page + 1 : undefined
+          },
+        }),
+    allSkillsQueryOptions: queryOptions({
+      queryKey: ['profiles', 'skills'],
+      queryFn: async () => MOCK_SKILLS,
+    }),
+  }
+})
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
 import { DiscoverPage } from '../discover'
+
+function renderDiscover() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+      <QueryClientProvider client={queryClient}>
+        <DiscoverPage />
+      </QueryClientProvider>,
+  )
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
 
 describe('DiscoverPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  // ── Rendering ─────────────────────────────────────────────────────────────
+  // ── Rendering ───────────────────────────────────────────────────────────────
 
   it('renders the hero heading', () => {
-    render(<DiscoverPage />)
+    renderDiscover()
     expect(screen.getByRole('heading', { name: /Discover the/i })).toBeInTheDocument()
   })
 
   it('renders the search bar', () => {
-    render(<DiscoverPage />)
+    renderDiscover()
     expect(screen.getByPlaceholderText(/Search profiles, skills, or projects/i)).toBeInTheDocument()
   })
 
   it('renders the filter button', () => {
-    render(<DiscoverPage />)
+    renderDiscover()
     expect(screen.getByRole('button', { name: /Filter by skill/i })).toBeInTheDocument()
   })
 
-  it('renders at least one ProfileCard on initial load', () => {
-    render(<DiscoverPage />)
-    // Every card has a "View Profile" button
-    const viewButtons = screen.getAllByRole('button', { name: /View Profile/i })
-    expect(viewButtons.length).toBeGreaterThan(0)
+  it('renders at least one ProfileCard on initial load', async () => {
+    renderDiscover()
+    await waitFor(() => {
+      const viewButtons = screen.getAllByRole('button', { name: /View Profile/i })
+      expect(viewButtons.length).toBeGreaterThan(0)
+    })
   })
 
-  it('shows at most PAGE_SIZE (6) cards on initial load', () => {
-    render(<DiscoverPage />)
-    const viewButtons = screen.getAllByRole('button', { name: /View Profile/i })
-    expect(viewButtons.length).toBeLessThanOrEqual(6)
+  it('shows at most PAGE_SIZE (6) cards on initial load', async () => {
+    renderDiscover()
+    await waitFor(() => {
+      const viewButtons = screen.getAllByRole('button', { name: /View Profile/i })
+      expect(viewButtons.length).toBeLessThanOrEqual(6)
+    })
   })
 
-  // ── Search ─────────────────────────────────────────────────────────────────
+  // ── Search ──────────────────────────────────────────────────────────────────
 
-  it('filters profiles by name as the user types', () => {
-    render(<DiscoverPage />)
+  it('shows the empty state when no profiles match the search query', async () => {
+    renderDiscover()
     const input = screen.getByPlaceholderText(/Search profiles, skills, or projects/i)
-
-    fireEvent.change(input, { target: { value: 'Dr. Sarah Chen' } })
-
-    expect(screen.getByText('Dr. Sarah Chen')).toBeInTheDocument()
-    // Other profiles should be gone
-    expect(screen.queryByText('James Wilson')).not.toBeInTheDocument()
+    fireEvent.change(input, { target: { value: 'xyznonexistent' } })
+    await waitFor(() => {
+      expect(screen.getByText(/No mentors found matching/i)).toBeInTheDocument()
+    })
   })
 
-  it('filters profiles by skill name', () => {
-    render(<DiscoverPage />)
+  it('filters profiles by skill name via search', async () => {
+    renderDiscover()
+    const input = screen.getByPlaceholderText(/Search profiles, skills, or projects/i)
+    fireEvent.change(input, { target: { value: 'Kubernetes' } })
+    await waitFor(() => {
+      expect(screen.getByText('Mentor 1')).toBeInTheDocument()
+      expect(screen.queryByText('Mentor 2')).not.toBeInTheDocument()
+    })
+  })
+
+  it('restores profiles when search query is cleared', async () => {
+    renderDiscover()
     const input = screen.getByPlaceholderText(/Search profiles, skills, or projects/i)
 
     fireEvent.change(input, { target: { value: 'Kubernetes' } })
+    await waitFor(() => expect(screen.getByText('Mentor 1')).toBeInTheDocument())
 
-    // Julian Thorne is the only mentor with Kubernetes
-    expect(screen.getByText('Julian Thorne')).toBeInTheDocument()
-    expect(screen.queryByText('Dr. Sarah Chen')).not.toBeInTheDocument()
-  })
-
-  it('shows the empty state when no profiles match the search query', () => {
-    render(<DiscoverPage />)
-    const input = screen.getByPlaceholderText(/Search profiles, skills, or projects/i)
-
-    fireEvent.change(input, { target: { value: 'xyznonexistent' } })
-
-    expect(screen.getByText(/No mentors found matching/i)).toBeInTheDocument()
-  })
-
-  it('restores all profiles when search query is cleared', () => {
-    render(<DiscoverPage />)
-    const input = screen.getByPlaceholderText(/Search profiles, skills, or projects/i)
-
-    fireEvent.change(input, { target: { value: 'Dr. Sarah Chen' } })
     fireEvent.change(input, { target: { value: '' } })
-
-    const viewButtons = screen.getAllByRole('button', { name: /View Profile/i })
-    expect(viewButtons.length).toBeGreaterThan(1)
+    await waitFor(() => {
+      const viewButtons = screen.getAllByRole('button', { name: /View Profile/i })
+      expect(viewButtons.length).toBeGreaterThan(1)
+    })
   })
 
-  // ── Skill filter panel ─────────────────────────────────────────────────────
+  // ── Skill filter panel ──────────────────────────────────────────────────────
 
-  it('opens the skill filter panel when the filter button is clicked', () => {
-    render(<DiscoverPage />)
+  it('opens the skill filter panel when the filter button is clicked', async () => {
+    renderDiscover()
+    // Wait for skills to load first
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument())
 
     fireEvent.click(screen.getByRole('button', { name: /Filter by skill/i }))
-
     expect(screen.getByText(/Filter by Skill/i)).toBeInTheDocument()
   })
 
-  it('closes the filter panel when clicked outside', () => {
-    render(<DiscoverPage />)
+  it('closes the filter panel when clicked outside', async () => {
+    renderDiscover()
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument())
 
     fireEvent.click(screen.getByRole('button', { name: /Filter by skill/i }))
     expect(screen.getByText(/Filter by Skill/i)).toBeInTheDocument()
 
     fireEvent.mouseDown(document.body)
-
     expect(screen.queryByText(/Filter by Skill/i)).not.toBeInTheDocument()
   })
 
-  it('filters profiles when a skill chip is selected', () => {
-    render(<DiscoverPage />)
+  it('filters profiles when a skill chip is selected', async () => {
+    renderDiscover()
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument())
 
-    // Open filter panel
     fireEvent.click(screen.getByRole('button', { name: /Filter by skill/i }))
 
-    // Click the "Python" chip — James Wilson and Alex Sterling have Python
-    const pythonChip = screen.getByRole('button', { name: /^Python$/i })
+    const pythonChip = await screen.findByRole('button', { name: /^Python$/i })
     fireEvent.click(pythonChip)
 
-    const viewButtons = screen.getAllByRole('button', { name: /View Profile/i })
-    expect(viewButtons.length).toBeGreaterThan(0)
-    // Dr. Sarah Chen has Python/Django, not plain Python — she should not appear
-    expect(screen.queryByText('Julian Thorne')).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('Mentor 2')).toBeInTheDocument()
+      expect(screen.queryByText('Mentor 1')).not.toBeInTheDocument()
+    })
   })
 
-  it('shows the active filter count badge on the filter button', () => {
-    render(<DiscoverPage />)
+  it('shows the active filter count badge on the filter button', async () => {
+    renderDiscover()
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument())
 
     fireEvent.click(screen.getByRole('button', { name: /Filter by skill/i }))
-
-    const goChip = screen.getByRole('button', { name: /^Go$/i })
+    const goChip = await screen.findByRole('button', { name: /^Go$/i })
     fireEvent.click(goChip)
 
-    // Badge with count "1" should be visible inside the trigger button
     expect(screen.getByText('1')).toBeInTheDocument()
   })
 
-  it('shows the empty state when skill filters match no mentor', () => {
-    render(<DiscoverPage />)
+  it('clears skill filters when "Clear all" is clicked', async () => {
+    renderDiscover()
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument())
 
-    // Search for something that won't match any mentor
-    const input = screen.getByPlaceholderText(/Search profiles, skills, or projects/i)
-    fireEvent.change(input, { target: { value: 'xyznonexistent' } })
-
-    // Open filter panel and select a skill
     fireEvent.click(screen.getByRole('button', { name: /Filter by skill/i }))
-    const goChip = screen.getByRole('button', { name: /^Go$/i })
+    const goChip = await screen.findByRole('button', { name: /^Go$/i })
     fireEvent.click(goChip)
 
-    expect(screen.getByText(/No mentors found matching/i)).toBeInTheDocument()
-  })
-
-  it('clears skill filters when "Clear all" is clicked', () => {
-    render(<DiscoverPage />)
-
-    fireEvent.click(screen.getByRole('button', { name: /Filter by skill/i }))
-    fireEvent.click(screen.getByRole('button', { name: /^Go$/i }))
-
-    // "Clear all" appears when at least one skill is active
     const clearAll = screen.getByRole('button', { name: /Clear all/i })
     fireEvent.click(clearAll)
 
-    // Badge should be gone
     expect(screen.queryByText('1')).not.toBeInTheDocument()
   })
 
-  // ── Pagination ─────────────────────────────────────────────────────────────
+  // ── Pagination ──────────────────────────────────────────────────────────────
 
-  it('shows the Load More button when there are more profiles than PAGE_SIZE', () => {
-    render(<DiscoverPage />)
-    // There are 8 mentor profiles in mock data (> 6 PAGE_SIZE)
-    expect(screen.getByRole('button', { name: /Load More/i })).toBeInTheDocument()
+  it('shows the Load More button when there are more profiles than PAGE_SIZE', async () => {
+    renderDiscover()
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Load More/i })).toBeInTheDocument()
+    })
   })
 
-  it('loads more profiles when Load More is clicked', () => {
-    render(<DiscoverPage />)
+  it('loads more profiles when Load More is clicked', async () => {
+    renderDiscover()
+    await waitFor(() => screen.getAllByRole('button', { name: /View Profile/i }))
 
     const before = screen.getAllByRole('button', { name: /View Profile/i }).length
     fireEvent.click(screen.getByRole('button', { name: /Load More/i }))
-    const after = screen.getAllByRole('button', { name: /View Profile/i }).length
 
-    expect(after).toBeGreaterThan(before)
+    await waitFor(() => {
+      const after = screen.getAllByRole('button', { name: /View Profile/i }).length
+      expect(after).toBeGreaterThan(before)
+    })
   })
 
-  it('hides the Load More button once all profiles are shown', () => {
-    render(<DiscoverPage />)
+  it('resets pagination when the search query changes', async () => {
+    renderDiscover()
+    await waitFor(() => screen.getByRole('button', { name: /Load More/i }))
 
-    // Keep clicking until the button disappears
-    while (screen.queryByRole('button', { name: /Load More/i })) {
-      fireEvent.click(screen.getByRole('button', { name: /Load More/i }))
-    }
-
-    expect(screen.queryByRole('button', { name: /Load More/i })).not.toBeInTheDocument()
-  })
-
-  it('resets pagination when the search query changes', () => {
-    render(<DiscoverPage />)
-
-    // Load extra profiles past PAGE_SIZE
     fireEvent.click(screen.getByRole('button', { name: /Load More/i }))
-    const afterLoadMore = screen.getAllByRole('button', { name: /View Profile/i }).length
-    expect(afterLoadMore).toBeGreaterThan(6)
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: /View Profile/i }).length).toBeGreaterThan(6)
+    })
 
-    // Typing a new query must reset visibleCount back to PAGE_SIZE
     const input = screen.getByPlaceholderText(/Search profiles, skills, or projects/i)
     fireEvent.change(input, { target: { value: 'python' } })
 
-    const viewButtons = screen.getAllByRole('button', { name: /View Profile/i })
-    expect(viewButtons.length).toBeLessThanOrEqual(6)
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: /View Profile/i }).length).toBeLessThanOrEqual(6)
+    })
   })
 
-  // ── Navigation ─────────────────────────────────────────────────────────────
+  // ── Navigation ──────────────────────────────────────────────────────────────
 
-  it('navigates to the profile page when View Profile is clicked', () => {
-    render(<DiscoverPage />)
+  it('navigates to the profile page when View Profile is clicked', async () => {
+    renderDiscover()
+    await waitFor(() => screen.getAllByRole('button', { name: /View Profile/i }))
 
-    const viewButtons = screen.getAllByRole('button', { name: /View Profile/i })
-    fireEvent.click(viewButtons[0])
+    fireEvent.click(screen.getAllByRole('button', { name: /View Profile/i })[0])
 
     expect(mockNavigate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        to: '/profiles/$profileId',
-        params: expect.objectContaining({ profileId: expect.any(String) }),
-      }),
+        expect.objectContaining({
+          to: '/profiles/$username',
+          params: expect.objectContaining({ username: expect.any(String) }),
+        }),
     )
   })
 })

--- a/web/src/routes/_authorized/discover.tsx
+++ b/web/src/routes/_authorized/discover.tsx
@@ -1,136 +1,131 @@
 import { useState, useCallback } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useQuery } from '@tanstack/react-query'
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import { useDebounce } from '@/lib/queries/useDebounce'
 import { Button } from '@/components/ui/button'
 import { Display } from '@/components/Typography'
 import { ProfileCard } from '@/components/features/discover/ProfileCard'
 import { DiscoverSearchBar } from '@/components/features/discover/DiscoverSearchBar'
 import { DiscoverFilterPanel } from '@/components/features/discover/DiscoverFilterPanel'
-import { mentorSearchQueryOptions, allSkillsQueryOptions } from '@/lib/queries/DiscoverQueries.ts'
+import { mentorSearchInfiniteQueryOptions, allSkillsQueryOptions } from '@/lib/queries/DiscoverQueries.ts'
 
-const PAGE_SIZE = 6;
+const PAGE_SIZE = 1
 
 export const Route = createFileRoute('/_authorized/discover')({
-  component: DiscoverPage,
+    component: DiscoverPage,
 })
 
 export function DiscoverPage() {
-  const navigate = useNavigate()
-  const [query, setQuery] = useState('')
-  const [selectedSkills, setSelectedSkills] = useState<Set<string>>(new Set());
-  const [page, setPage] = useState(1);
+    const navigate = useNavigate()
+    const [query, setQuery] = useState('')
+    const [selectedSkills, setSelectedSkills] = useState<Set<string>>(new Set())
 
-  const debouncedQuery = useDebounce(query, 300)
+    const debouncedQuery = useDebounce(query, 300)
 
-  const { data, isFetching } = useQuery(
-      mentorSearchQueryOptions({
-        q: debouncedQuery || undefined,
-        skills: selectedSkills.size > 0 ? Array.from(selectedSkills) : undefined,
-        page,
-        pageSize: PAGE_SIZE,
-      }),
-  )
+    const {
+        data,
+        isFetching,
+        fetchNextPage,
+        hasNextPage,
+    } = useInfiniteQuery(
+        mentorSearchInfiniteQueryOptions({
+            q: debouncedQuery || undefined,
+            skills: selectedSkills.size > 0 ? Array.from(selectedSkills) : undefined,
+            pageSize: PAGE_SIZE,
+        }),
+    )
 
-  const { data: skillsData } = useQuery(allSkillsQueryOptions)
-  const allSkillNames = skillsData?.map((s) => s.name) ?? []
+    const { data: skillsData } = useQuery(allSkillsQueryOptions)
+    const allSkillNames = skillsData?.map((s) => s.name) ?? []
 
-  const results = data?.results ?? []
-  const totalCount = data?.count ?? 0
-  const hasMore = page * PAGE_SIZE < totalCount
+    // Flatten all pages into one list
+    const results = data?.pages.flatMap((p) => p.results) ?? []
 
-  const handleSkillToggle = useCallback((skill: string) => {
-    setSelectedSkills((prev) => {
-      const next = new Set(prev)
-      next.has(skill) ? next.delete(skill) : next.add(skill)
-      return next
-    })
-    setPage(1)
-  }, [])
+    const handleSkillToggle = useCallback((skill: string) => {
+        setSelectedSkills((prev) => {
+            const next = new Set(prev)
+            next.has(skill) ? next.delete(skill) : next.add(skill)
+            return next
+        })
+    }, [])
 
-  const handleSkillClear = useCallback(() => {
-    setSelectedSkills(new Set())
-    setPage(1)
-  }, [])
+    const handleSkillClear = useCallback(() => {
+        setSelectedSkills(new Set())
+    }, [])
 
-  const handleLoadMore = () => setPage((p) => p + 1)
+    const handleViewProfile = (username: string) => {
+        navigate({ to: '/profiles/$username', params: { username } })
+    }
 
-  const handleViewProfile = (username: string) => {
-    navigate({ to: '/profiles/$username', params: { username } })
-  }
+    return (
+        <div className="py-10 sm:py-16 rise-in flex flex-col gap-12">
 
-  return (
-      <div className="py-10 sm:py-16 rise-in flex flex-col gap-12">
+            {/* ── Hero Section ─────────────────────────────────────────────────── */}
+            <div className="page-wrap">
+                <section className="flex flex-col items-center gap-8 text-center">
+                    <Display as="h1" className="text-5xl sm:text-6xl md:text-7xl tracking-tight text-ink">
+                        Discover the{' '}
+                        <span className="italic text-accent">Curated</span>{' '}
+                        Network
+                    </Display>
 
-        {/* ── Hero Section ─────────────────────────────────────────────────── */}
-        <div className="page-wrap">
-          <section className="flex flex-col items-center gap-8 text-center">
-            <Display as="h1" className="text-5xl sm:text-6xl md:text-7xl tracking-tight text-ink">
-              Discover the{' '}
-              <span className="italic text-accent">Curated</span>{' '}
-              Network
-            </Display>
-
-            <div className="flex items-stretch gap-3 w-full max-w-xs sm:max-w-lg md:max-w-2xl lg:max-w-3xl">
-              <DiscoverSearchBar
-                  value={query}
-                  onChange={(val) => {
-                    setQuery(val)
-                    setPage(1)
-                  }}
-                  className="flex-1 min-w-0"
-              />
-              <DiscoverFilterPanel
-                  allSkills={allSkillNames}
-                  selectedSkills={selectedSkills}
-                  onToggle={handleSkillToggle}
-                  onClear={handleSkillClear}
-              />
+                    <div className="flex items-stretch gap-3 w-full max-w-xs sm:max-w-lg md:max-w-2xl lg:max-w-3xl">
+                        <DiscoverSearchBar
+                            value={query}
+                            onChange={(val) => setQuery(val)}
+                            className="flex-1 min-w-0"
+                        />
+                        <DiscoverFilterPanel
+                            allSkills={allSkillNames}
+                            selectedSkills={selectedSkills}
+                            onToggle={handleSkillToggle}
+                            onClear={handleSkillClear}
+                        />
+                    </div>
+                </section>
             </div>
-          </section>
+
+            {/* ── Profile Grid ─────────────────────────────────────────────────── */}
+            <section className="w-full max-w-screen-2xl mx-auto px-4 sm:px-8 md:px-12 lg:px-20 xl:px-28">
+                {isFetching && results.length === 0 ? (
+                    <div className="py-24 text-center text-ink-soft text-lg">Loading...</div>
+                ) : results.length === 0 ? (
+                    <div className="py-24 text-center">
+                        <p className="text-ink-soft text-lg">
+                            {query
+                                ? (<>No mentors found matching <span className="font-semibold text-ink">"{query}"</span>.</>)
+                                : 'No mentors match the selected filters.'}
+                        </p>
+                        <p className="text-ink-soft text-sm mt-2">
+                            Try adjusting your search or clearing the skill filters.
+                        </p>
+                    </div>
+                ) : (
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+                        {results.map((profile) => (
+                            <ProfileCard
+                                key={profile.id}
+                                profile={profile}
+                                onViewProfile={handleViewProfile}
+                                onSendMessage={() => {}}
+                            />
+                        ))}
+                    </div>
+                )}
+
+                {hasNextPage && (
+                    <div className="mt-16 flex justify-center">
+                        <Button
+                            onClick={() => fetchNextPage()}
+                            disabled={isFetching}
+                            className="bg-accent hover:bg-accent-light text-white px-12 py-6 rounded-full text-sm font-bold uppercase tracking-widest shadow-md hover:-translate-y-0.5 transition-all duration-300"
+                        >
+                            {isFetching ? 'Loading...' : 'Load More'}
+                        </Button>
+                    </div>
+                )}
+            </section>
+
         </div>
-
-        {/* ── Profile Grid ─────────────────────────────────────────────────── */}
-        <section className="w-full max-w-screen-2xl mx-auto px-4 sm:px-8 md:px-12 lg:px-20 xl:px-28">
-          {isFetching && results.length === 0 ? (
-              <div className="py-24 text-center text-ink-soft text-lg">Loading...</div>
-          ) : results.length === 0 ? (
-              <div className="py-24 text-center">
-                <p className="text-ink-soft text-lg">
-                  {query
-                      ? (<>No mentors found matching <span className="font-semibold text-ink">"{query}"</span>.</>)
-                      : 'No mentors match the selected filters.'}
-                </p>
-                <p className="text-ink-soft text-sm mt-2">
-                  Try adjusting your search or clearing the skill filters.
-                </p>
-              </div>
-          ) : (
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-                {results.map((profile) => (
-                    <ProfileCard
-                        key={profile.id}
-                        profile={profile}
-                        onViewProfile={handleViewProfile}
-                        onSendMessage={() => {}}
-                    />
-                ))}
-              </div>
-          )}
-
-          {hasMore && (
-              <div className="mt-16 flex justify-center">
-                <Button
-                    onClick={handleLoadMore}
-                    disabled={isFetching}
-                    className="bg-accent hover:bg-accent-light text-white px-12 py-6 rounded-full text-sm font-bold uppercase tracking-widest shadow-md hover:-translate-y-0.5 transition-all duration-300"
-                >
-                  {isFetching ? 'Loading...' : 'Load More'}
-                </Button>
-              </div>
-          )}
-        </section>
-
-      </div>
-  )
+    )
 }

--- a/web/src/routes/_authorized/discover.tsx
+++ b/web/src/routes/_authorized/discover.tsx
@@ -9,7 +9,7 @@ import { DiscoverSearchBar } from '@/components/features/discover/DiscoverSearch
 import { DiscoverFilterPanel } from '@/components/features/discover/DiscoverFilterPanel'
 import { mentorSearchInfiniteQueryOptions, allSkillsQueryOptions } from '@/lib/queries/DiscoverQueries.ts'
 
-const PAGE_SIZE = 3
+const PAGE_SIZE = 6
 
 export const Route = createFileRoute('/_authorized/discover')({
     component: DiscoverPage,

--- a/web/src/routes/_authorized/discover.tsx
+++ b/web/src/routes/_authorized/discover.tsx
@@ -1,160 +1,136 @@
-// web/src/routes/_authorized/discover.tsx
-import { useState, useMemo, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
+import { useDebounce } from '@/lib/queries/useDebounce'
 import { Button } from '@/components/ui/button'
 import { Display } from '@/components/Typography'
 import { ProfileCard } from '@/components/features/discover/ProfileCard'
 import { DiscoverSearchBar } from '@/components/features/discover/DiscoverSearchBar'
 import { DiscoverFilterPanel } from '@/components/features/discover/DiscoverFilterPanel'
-import { getAllMockProfiles } from '@/lib/mocks/profiles'
+import { mentorSearchQueryOptions, allSkillsQueryOptions } from '@/lib/queries/DiscoverQueries.ts'
 
-// TODO: Replace PAGE_SIZE and pagination logic with a real API call that
-//       supports GET /api/users/discover/?page=N&pageSize=PAGE_SIZE&q=<query>
-const PAGE_SIZE = 6
+const PAGE_SIZE = 6;
 
 export const Route = createFileRoute('/_authorized/discover')({
   component: DiscoverPage,
 })
 
-const ALL_PROFILES = getAllMockProfiles().filter(
-  (p) => p.mentorshipMode === 'MENTOR' || p.mentorshipMode === 'BOTH',
-)
-
-// Unique skill names across all mentor profiles, sorted A→Z (case-insensitive)
-const ALL_SKILLS = Array.from(
-  new Set(ALL_PROFILES.flatMap((p) => p.expertise.map((e) => e.name))),
-).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
-
 export function DiscoverPage() {
   const navigate = useNavigate()
   const [query, setQuery] = useState('')
-  const [selectedSkills, setSelectedSkills] = useState<Set<string>>(new Set())
-  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE)
+  const [selectedSkills, setSelectedSkills] = useState<Set<string>>(new Set());
+  const [page, setPage] = useState(1);
+
+  const debouncedQuery = useDebounce(query, 300)
+
+  const { data, isFetching } = useQuery(
+      mentorSearchQueryOptions({
+        q: debouncedQuery || undefined,
+        skills: selectedSkills.size > 0 ? Array.from(selectedSkills) : undefined,
+        page,
+        pageSize: PAGE_SIZE,
+      }),
+  )
+
+  const { data: skillsData } = useQuery(allSkillsQueryOptions)
+  const allSkillNames = skillsData?.map((s) => s.name) ?? []
+
+  const results = data?.results ?? []
+  const totalCount = data?.count ?? 0
+  const hasMore = page * PAGE_SIZE < totalCount
 
   const handleSkillToggle = useCallback((skill: string) => {
     setSelectedSkills((prev) => {
       const next = new Set(prev)
-      if (next.has(skill)) {
-        next.delete(skill)
-      } else {
-        next.add(skill)
-      }
+      next.has(skill) ? next.delete(skill) : next.add(skill)
       return next
     })
-    setVisibleCount(PAGE_SIZE)
+    setPage(1)
   }, [])
 
   const handleSkillClear = useCallback(() => {
     setSelectedSkills(new Set())
-    setVisibleCount(PAGE_SIZE)
+    setPage(1)
   }, [])
 
-  // TODO: Replace this client-side filter with a debounced API search call
-  const filteredProfiles = useMemo(() => {
-    const q = query.trim().toLowerCase()
-    return ALL_PROFILES.filter((p) => {
-      const matchesQuery =
-        !q ||
-        p.displayName.toLowerCase().includes(q) ||
-        p.title.toLowerCase().includes(q) ||
-        p.expertise.some((e) => e.name.toLowerCase().includes(q)) ||
-        p.bio.toLowerCase().includes(q)
+  const handleLoadMore = () => setPage((p) => p + 1)
 
-      const matchesSkills =
-        selectedSkills.size === 0 ||
-        p.expertise.some((e) => selectedSkills.has(e.name))
-
-      return matchesQuery && matchesSkills
-    })
-  }, [query, selectedSkills])
-
-  const visibleProfiles = filteredProfiles.slice(0, visibleCount)
-  const hasMore = visibleCount < filteredProfiles.length
-
-  const handleLoadMore = () => {
-    // TODO: When paginating via API, fetch the next page and append results
-    //       instead of slicing a local array.
-    setVisibleCount((prev) => prev + PAGE_SIZE)
-  }
-
-  const handleViewProfile = (id: string) => {
-    navigate({ to: '/profiles/$profileId', params: { profileId: id } })
-  }
-
-  const handleSendMessage = (_id: string) => {
-    // TODO: Open a message compose modal or navigate to the messaging view
+  const handleViewProfile = (username: string) => {
+    navigate({ to: '/profiles/$username', params: { username } })
   }
 
   return (
-    <div className="py-10 sm:py-16 rise-in flex flex-col gap-12">
+      <div className="py-10 sm:py-16 rise-in flex flex-col gap-12">
 
-      {/* ── Hero Section — constrained to page-wrap width ─────────────────── */}
-      <div className="page-wrap">
-        <section className="flex flex-col items-center gap-8 text-center">
-          <Display as="h1" className="text-5xl sm:text-6xl md:text-7xl tracking-tight text-ink">
-            Discover the{' '}
-            <span className="italic text-accent">Curated</span>{' '}
-            Network
-          </Display>
+        {/* ── Hero Section ─────────────────────────────────────────────────── */}
+        <div className="page-wrap">
+          <section className="flex flex-col items-center gap-8 text-center">
+            <Display as="h1" className="text-5xl sm:text-6xl md:text-7xl tracking-tight text-ink">
+              Discover the{' '}
+              <span className="italic text-accent">Curated</span>{' '}
+              Network
+            </Display>
 
-          <div className="flex items-stretch gap-3 w-full max-w-xs sm:max-w-lg md:max-w-2xl lg:max-w-3xl">
-            <DiscoverSearchBar
-              value={query}
-              onChange={(val) => {
-                setQuery(val)
-                setVisibleCount(PAGE_SIZE)
-              }}
-              className="flex-1 min-w-0"
-            />
-            <DiscoverFilterPanel
-              allSkills={ALL_SKILLS}
-              selectedSkills={selectedSkills}
-              onToggle={handleSkillToggle}
-              onClear={handleSkillClear}
-            />
-          </div>
-        </section>
-      </div>
-
-      {/* ── Profile Grid — wider than page-wrap, responsive padding ───────── */}
-      <section className="w-full max-w-screen-2xl mx-auto px-4 sm:px-8 md:px-12 lg:px-20 xl:px-28">
-        {visibleProfiles.length === 0 ? (
-          <div className="py-24 text-center">
-            <p className="text-ink-soft text-lg">
-              {query
-                ? <>No mentors found matching <span className="font-semibold text-ink">"{query}"</span>.</>
-                : 'No mentors match the selected filters.'}
-            </p>
-            <p className="text-ink-soft text-sm mt-2">
-              Try adjusting your search or clearing the skill filters.
-            </p>
-          </div>
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-            {visibleProfiles.map((profile) => (
-              <ProfileCard
-                key={profile.id}
-                profile={profile}
-                onViewProfile={handleViewProfile}
-                onSendMessage={handleSendMessage}
+            <div className="flex items-stretch gap-3 w-full max-w-xs sm:max-w-lg md:max-w-2xl lg:max-w-3xl">
+              <DiscoverSearchBar
+                  value={query}
+                  onChange={(val) => {
+                    setQuery(val)
+                    setPage(1)
+                  }}
+                  className="flex-1 min-w-0"
               />
-            ))}
-          </div>
-        )}
+              <DiscoverFilterPanel
+                  allSkills={allSkillNames}
+                  selectedSkills={selectedSkills}
+                  onToggle={handleSkillToggle}
+                  onClear={handleSkillClear}
+              />
+            </div>
+          </section>
+        </div>
 
-        {/* ── Load More ──────────────────────────────────────────────────── */}
-        {hasMore && (
-          <div className="mt-16 flex justify-center">
-            <Button
-              onClick={handleLoadMore}
-              className="bg-accent hover:bg-accent-light text-white px-12 py-6 rounded-full text-sm font-bold uppercase tracking-widest shadow-md hover:-translate-y-0.5 transition-all duration-300"
-            >
-              Load More
-            </Button>
-          </div>
-        )}
-      </section>
+        {/* ── Profile Grid ─────────────────────────────────────────────────── */}
+        <section className="w-full max-w-screen-2xl mx-auto px-4 sm:px-8 md:px-12 lg:px-20 xl:px-28">
+          {isFetching && results.length === 0 ? (
+              <div className="py-24 text-center text-ink-soft text-lg">Loading...</div>
+          ) : results.length === 0 ? (
+              <div className="py-24 text-center">
+                <p className="text-ink-soft text-lg">
+                  {query
+                      ? (<>No mentors found matching <span className="font-semibold text-ink">"{query}"</span>.</>)
+                      : 'No mentors match the selected filters.'}
+                </p>
+                <p className="text-ink-soft text-sm mt-2">
+                  Try adjusting your search or clearing the skill filters.
+                </p>
+              </div>
+          ) : (
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+                {results.map((profile) => (
+                    <ProfileCard
+                        key={profile.id}
+                        profile={profile}
+                        onViewProfile={handleViewProfile}
+                        onSendMessage={() => {}}
+                    />
+                ))}
+              </div>
+          )}
 
-    </div>
+          {hasMore && (
+              <div className="mt-16 flex justify-center">
+                <Button
+                    onClick={handleLoadMore}
+                    disabled={isFetching}
+                    className="bg-accent hover:bg-accent-light text-white px-12 py-6 rounded-full text-sm font-bold uppercase tracking-widest shadow-md hover:-translate-y-0.5 transition-all duration-300"
+                >
+                  {isFetching ? 'Loading...' : 'Load More'}
+                </Button>
+              </div>
+          )}
+        </section>
+
+      </div>
   )
 }

--- a/web/src/routes/_authorized/discover.tsx
+++ b/web/src/routes/_authorized/discover.tsx
@@ -9,7 +9,7 @@ import { DiscoverSearchBar } from '@/components/features/discover/DiscoverSearch
 import { DiscoverFilterPanel } from '@/components/features/discover/DiscoverFilterPanel'
 import { mentorSearchInfiniteQueryOptions, allSkillsQueryOptions } from '@/lib/queries/DiscoverQueries.ts'
 
-const PAGE_SIZE = 1
+const PAGE_SIZE = 3
 
 export const Route = createFileRoute('/_authorized/discover')({
     component: DiscoverPage,


### PR DESCRIPTION
## Related Issue
Closes #277 

## Description
Replaced mock data on the Discover page with real API integration against `GET /api/profiles/` and `GET /api/profiles/skills/`. Search, skill filtering, and infinite-scroll pagination now hit the backend directly.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or configuration

## Checklist
- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code

## Notes
- Added `DiscoverQueries.ts` with `mentorSearchInfiniteQueryOptions` and `allSkillsQueryOptions`
- Added `useDebounce` hook for search input
- Switched to `useInfiniteQuery` for append-on-load-more behavior — previous results stay visible as new pages are fetched
- `ProfileCard` now uses `PublicMentorProfile` type instead of `MockProfileDetails`
- Profile navigation uses `username` param to match `/profiles/$username` route
- Mock profile data fully removed from the Discover page
- Updated tests to mock infinite query options and assert append behavior