### PR TITLE
fix: fixed mobile CORS issue and skills not get issue

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -46,6 +46,18 @@ CORS_ALLOWED_ORIGINS = [
     ).split(",")
     if origin.strip()
 ]
+
+if DEBUG:
+    dev_cors_origins = [
+        "http://localhost:8081",
+        "http://127.0.0.1:8081",
+        "http://localhost:19006",
+        "http://127.0.0.1:19006",
+    ]
+    for origin in dev_cors_origins:
+        if origin not in CORS_ALLOWED_ORIGINS:
+            CORS_ALLOWED_ORIGINS.append(origin)
+
 CORS_ALLOW_CREDENTIALS = True
 
 CSRF_TRUSTED_ORIGINS = [
@@ -56,6 +68,17 @@ CSRF_TRUSTED_ORIGINS = [
     ).split(",")
     if origin.strip()
 ]
+
+if DEBUG:
+    dev_csrf_origins = [
+        "http://localhost:8081",
+        "http://127.0.0.1:8081",
+        "http://localhost:19006",
+        "http://127.0.0.1:19006",
+    ]
+    for origin in dev_csrf_origins:
+        if origin not in CSRF_TRUSTED_ORIGINS:
+            CSRF_TRUSTED_ORIGINS.append(origin)
 
 # Application definition
 

--- a/mobile/constants/api.ts
+++ b/mobile/constants/api.ts
@@ -1,4 +1,12 @@
-const rawBaseUrl = process.env.EXPO_PUBLIC_API_BASE_URL || "http://127.0.0.1:8000";
+import { Platform } from "react-native";
+
+const defaultBaseUrl = Platform.select({
+  // Android emulator maps host machine localhost to 10.0.2.2.
+  android: "http://10.0.2.2:8000",
+  default: "http://127.0.0.1:8000",
+});
+
+const rawBaseUrl = process.env.EXPO_PUBLIC_API_BASE_URL || defaultBaseUrl;
 
 export const API_BASE_URL = rawBaseUrl.endsWith("/")
   ? rawBaseUrl.slice(0, -1)

--- a/mobile/lib/api/config.ts
+++ b/mobile/lib/api/config.ts
@@ -1,9 +1,16 @@
 /**
  * Runtime API configuration for mobile backend calls.
  */
+import { Platform } from "react-native";
+
+const defaultBaseUrl = Platform.select({
+  // Android emulator maps host machine localhost to 10.0.2.2.
+  android: "http://10.0.2.2:8000",
+  default: "http://localhost:8000",
+});
+
 export const API_BASE_URL =
-  process.env.EXPO_PUBLIC_API_BASE_URL?.replace(/\/$/, "") ??
-  "http://localhost:8000";
+  process.env.EXPO_PUBLIC_API_BASE_URL?.replace(/\/$/, "") ?? defaultBaseUrl;
 
 export const API_ACCESS_TOKEN = process.env.EXPO_PUBLIC_ACCESS_TOKEN ?? "";
 


### PR DESCRIPTION
## Related Issue

Closes #(to be filled)

## Description

This PR fixes mobile skill endpoint access issues in local development, especially when running on Android emulator and Expo web.

### What was fixed

1. Mobile API base URL handling for emulator:
- Updated mobile API configuration to use Android emulator host mapping (`10.0.2.2`) instead of localhost loopback when needed.
- This resolves requests like `/api/profiles/skills/` returning empty due to unreachable backend.

2. Local CORS/CSRF development compatibility:
- Expanded local development origins in backend settings (DEBUG mode) to include Expo-related ports (e.g., `8081`, `19006`).
- This resolves browser-side CORS errors during local Expo/web testing.

3. Environment alignment:
- Updated local Expo env usage to point to an emulator-reachable backend URL for Android emulator testing.

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have performed a self-review of my code

## Notes

- For Android emulator, backend URL should be `http://10.0.2.2:8000`.
- For physical device testing, use host machine LAN IP (e.g., `http://192.168.x.x:8000`).
- If backend settings are changed, restart backend service to reload CORS/CSRF configuration.