### PR TITLE
feat(profiles): add recently-added and popular mentor discovery endpoints

### DIFF
--- a/backend/profiles/tests.py
+++ b/backend/profiles/tests.py
@@ -1221,4 +1221,238 @@ class PublicMentorProfilesSearchListAPIViewTests(TestCase):
         payload2 = response2.json()
         second_name = payload2["results"][0]["full_name"]
 
-        self.assertNotEqual(first_name, second_name)
+
+class RecentlyAddedMentorsAPITests(TestCase):
+    """Tests for GET /api/profiles/recently-added/"""
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+
+        self.mentor1_user = User.objects.create_user(
+            email="recent1@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTOR,
+        )
+        self.mentor1_profile = Profile.objects.create(
+            user=self.mentor1_user,
+            display_name="First Mentor",
+            is_visible=True,
+            rating=3,
+        )
+
+        self.mentor2_user = User.objects.create_user(
+            email="recent2@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTOR,
+        )
+        self.mentor2_profile = Profile.objects.create(
+            user=self.mentor2_user,
+            display_name="Second Mentor",
+            is_visible=True,
+            rating=5,
+        )
+
+        self.hidden_mentor_user = User.objects.create_user(
+            email="hidden@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTOR,
+        )
+        self.hidden_mentor_profile = Profile.objects.create(
+            user=self.hidden_mentor_user,
+            display_name="Hidden Mentor",
+            is_visible=False,
+        )
+
+        self.mentee_user = User.objects.create_user(
+            email="mentee_recent@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTEE,
+        )
+        self.mentee_profile = Profile.objects.create(
+            user=self.mentee_user,
+            display_name="Mentee Person",
+            is_visible=True,
+        )
+
+    def test_returns_200(self) -> None:
+        response = self.client.get("/api/profiles/recently-added/")
+        self.assertEqual(response.status_code, 200)
+
+    def test_response_has_results_key(self) -> None:
+        response = self.client.get("/api/profiles/recently-added/")
+        self.assertIn("results", response.json())
+
+    def test_only_visible_mentors_returned(self) -> None:
+        response = self.client.get("/api/profiles/recently-added/")
+        names = [p["full_name"] for p in response.json()["results"]]
+        self.assertNotIn("Hidden Mentor", names)
+        self.assertNotIn("Mentee Person", names)
+
+    def test_sorted_by_created_at_descending(self) -> None:
+        # mentor2 was created after mentor1 so should appear first
+        response = self.client.get("/api/profiles/recently-added/")
+        results = response.json()["results"]
+        self.assertGreaterEqual(len(results), 2)
+        ids = [r["id"] for r in results]
+        self.assertLess(ids.index(str(self.mentor2_profile.id)), ids.index(str(self.mentor1_profile.id)))
+
+    def test_default_limit_is_ten(self) -> None:
+        # Create 12 visible mentors in total (2 already exist)
+        for i in range(10):
+            u = User.objects.create_user(
+                email=f"extra{i}@example.com",
+                password="SecurePass123",
+                app_usage_mode=AppUsageMode.MENTOR,
+            )
+            Profile.objects.create(user=u, display_name=f"Extra {i}", is_visible=True)
+
+        response = self.client.get("/api/profiles/recently-added/")
+        self.assertEqual(len(response.json()["results"]), 10)
+
+    def test_custom_limit(self) -> None:
+        response = self.client.get("/api/profiles/recently-added/", {"limit": 1})
+        self.assertEqual(len(response.json()["results"]), 1)
+
+    def test_limit_capped_at_50(self) -> None:
+        for i in range(60):
+            u = User.objects.create_user(
+                email=f"cap{i}@example.com",
+                password="SecurePass123",
+                app_usage_mode=AppUsageMode.MENTOR,
+            )
+            Profile.objects.create(user=u, display_name=f"Cap {i}", is_visible=True)
+
+        response = self.client.get("/api/profiles/recently-added/", {"limit": 100})
+        self.assertLessEqual(len(response.json()["results"]), 50)
+
+    def test_invalid_limit_returns_400(self) -> None:
+        response = self.client.get("/api/profiles/recently-added/", {"limit": "abc"})
+        self.assertEqual(response.status_code, 400)
+
+    def test_accessible_without_authentication(self) -> None:
+        response = self.client.get("/api/profiles/recently-added/")
+        self.assertEqual(response.status_code, 200)
+
+
+class PopularMentorsAPITests(TestCase):
+    """Tests for GET /api/profiles/popular/"""
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+
+        self.low_rated_user = User.objects.create_user(
+            email="low@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTOR,
+        )
+        self.low_rated_profile = Profile.objects.create(
+            user=self.low_rated_user,
+            display_name="Low Rated",
+            is_visible=True,
+            rating=1,
+            total_mentee_count=5,
+        )
+
+        self.high_rated_user = User.objects.create_user(
+            email="high@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTOR,
+        )
+        self.high_rated_profile = Profile.objects.create(
+            user=self.high_rated_user,
+            display_name="High Rated",
+            is_visible=True,
+            rating=5,
+            total_mentee_count=10,
+        )
+
+        self.hidden_user = User.objects.create_user(
+            email="hiddenpop@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTOR,
+        )
+        self.hidden_profile = Profile.objects.create(
+            user=self.hidden_user,
+            display_name="Hidden Popular",
+            is_visible=False,
+            rating=5,
+        )
+
+        self.mentee_user = User.objects.create_user(
+            email="menteepop@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTEE,
+        )
+        self.mentee_profile = Profile.objects.create(
+            user=self.mentee_user,
+            display_name="Mentee Pop",
+            is_visible=True,
+            rating=5,
+        )
+
+    def test_returns_200(self) -> None:
+        response = self.client.get("/api/profiles/popular/")
+        self.assertEqual(response.status_code, 200)
+
+    def test_response_has_results_key(self) -> None:
+        response = self.client.get("/api/profiles/popular/")
+        self.assertIn("results", response.json())
+
+    def test_only_visible_mentors_returned(self) -> None:
+        response = self.client.get("/api/profiles/popular/")
+        names = [p["full_name"] for p in response.json()["results"]]
+        self.assertNotIn("Hidden Popular", names)
+        self.assertNotIn("Mentee Pop", names)
+
+    def test_sorted_by_rating_descending(self) -> None:
+        response = self.client.get("/api/profiles/popular/")
+        results = response.json()["results"]
+        self.assertGreaterEqual(len(results), 2)
+        ids = [r["id"] for r in results]
+        self.assertLess(
+            ids.index(str(self.high_rated_profile.id)),
+            ids.index(str(self.low_rated_profile.id)),
+        )
+
+    def test_tiebreaker_is_total_mentee_count(self) -> None:
+        # Two mentors with the same rating; the one with more mentees comes first
+        tied_low_user = User.objects.create_user(
+            email="tied_low@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTOR,
+        )
+        tied_low = Profile.objects.create(
+            user=tied_low_user,
+            display_name="Tied Low Mentees",
+            is_visible=True,
+            rating=3,
+            total_mentee_count=2,
+        )
+        tied_high_user = User.objects.create_user(
+            email="tied_high@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTOR,
+        )
+        tied_high = Profile.objects.create(
+            user=tied_high_user,
+            display_name="Tied High Mentees",
+            is_visible=True,
+            rating=3,
+            total_mentee_count=20,
+        )
+
+        response = self.client.get("/api/profiles/popular/")
+        ids = [r["id"] for r in response.json()["results"]]
+        self.assertLess(ids.index(str(tied_high.id)), ids.index(str(tied_low.id)))
+
+    def test_custom_limit(self) -> None:
+        response = self.client.get("/api/profiles/popular/", {"limit": 1})
+        self.assertEqual(len(response.json()["results"]), 1)
+
+    def test_invalid_limit_returns_400(self) -> None:
+        response = self.client.get("/api/profiles/popular/", {"limit": "xyz"})
+        self.assertEqual(response.status_code, 400)
+
+    def test_accessible_without_authentication(self) -> None:
+        response = self.client.get("/api/profiles/popular/")
+        self.assertEqual(response.status_code, 200)

--- a/backend/profiles/urls.py
+++ b/backend/profiles/urls.py
@@ -7,14 +7,18 @@ from .views import (
     AvailabilitySlotCancelBookingAPIView,
     AvailabilitySlotDetailAPIView,
     AvailabilitySlotListCreateAPIView,
+    PopularMentorsListAPIView,
     PublicMentorProfilesSearchListAPIView,
     ProfileByUsernameAPIView,
+    RecentlyAddedMentorsListAPIView,
     SkillListAPIView,
 )
 
 urlpatterns = [
     path("", PublicMentorProfilesSearchListAPIView.as_view(), name="mentor-profiles-search"),
     path("skills/", SkillListAPIView.as_view(), name="skill-list"),
+    path("recently-added/", RecentlyAddedMentorsListAPIView.as_view(), name="mentor-recently-added"),
+    path("popular/", PopularMentorsListAPIView.as_view(), name="mentor-popular"),
     path(
         "<str:username>/availability-slots/",
         AvailabilitySlotListCreateAPIView.as_view(),

--- a/backend/profiles/views.py
+++ b/backend/profiles/views.py
@@ -475,7 +475,10 @@ class RecentlyAddedMentorsListAPIView(APIView):
     permission_classes = [AllowAny]
 
     @extend_schema(
-        responses={200: PublicMentorProfileSearchResultSerializer(many=True)},
+        responses={
+            200: PublicMentorProfileSearchListResponseSerializer,
+            400: OpenApiResponse(description="Invalid `limit` value."),
+        },
         description=(
             "Return the most recently created visible mentor profiles, "
             "sorted by creation date descending. "
@@ -514,7 +517,10 @@ class PopularMentorsListAPIView(APIView):
     permission_classes = [AllowAny]
 
     @extend_schema(
-        responses={200: PublicMentorProfileSearchResultSerializer(many=True)},
+        responses={
+            200: PublicMentorProfileSearchListResponseSerializer,
+            400: OpenApiResponse(description="Invalid `limit` value."),
+        },
         description=(
             "Return the most popular visible mentor profiles, sorted by rating "
             "descending with total mentee count as a tiebreaker. "

--- a/backend/profiles/views.py
+++ b/backend/profiles/views.py
@@ -469,6 +469,84 @@ class AvailabilitySlotCancelBookingAPIView(ProfileLookupMixin, APIView):
         return Response(AvailabilitySlotSerializer(slot).data, status=status.HTTP_200_OK)
 
 
+class RecentlyAddedMentorsListAPIView(APIView):
+    """Public listing of the most recently created visible mentor profiles."""
+
+    permission_classes = [AllowAny]
+
+    @extend_schema(
+        responses={200: PublicMentorProfileSearchResultSerializer(many=True)},
+        description=(
+            "Return the most recently created visible mentor profiles, "
+            "sorted by creation date descending. "
+            "Use `limit` (1–50, default 10) to control the list size."
+        ),
+        tags=["Profiles"],
+    )
+    def get(self, request: Request) -> Response:
+        try:
+            limit = int(request.query_params.get("limit", 10))
+        except (TypeError, ValueError):
+            return Response(
+                {"detail": "`limit` must be an integer."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        limit = max(1, min(limit, 50))
+
+        qs = (
+            Profile.objects.select_related("user")
+            .filter(
+                is_visible=True,
+                user__app_usage_mode=AppUsageMode.MENTOR,
+                user__is_active=True,
+            )
+            .order_by("-created_at")[:limit]
+        )
+
+        serializer = PublicMentorProfileSearchResultSerializer(qs, many=True)
+        return Response({"results": serializer.data}, status=status.HTTP_200_OK)
+
+
+class PopularMentorsListAPIView(APIView):
+    """Public listing of the highest-rated visible mentor profiles."""
+
+    permission_classes = [AllowAny]
+
+    @extend_schema(
+        responses={200: PublicMentorProfileSearchResultSerializer(many=True)},
+        description=(
+            "Return the most popular visible mentor profiles, sorted by rating "
+            "descending with total mentee count as a tiebreaker. "
+            "Use `limit` (1–50, default 10) to control the list size."
+        ),
+        tags=["Profiles"],
+    )
+    def get(self, request: Request) -> Response:
+        try:
+            limit = int(request.query_params.get("limit", 10))
+        except (TypeError, ValueError):
+            return Response(
+                {"detail": "`limit` must be an integer."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        limit = max(1, min(limit, 50))
+
+        qs = (
+            Profile.objects.select_related("user")
+            .filter(
+                is_visible=True,
+                user__app_usage_mode=AppUsageMode.MENTOR,
+                user__is_active=True,
+            )
+            .order_by("-rating", "-total_mentee_count")[:limit]
+        )
+
+        serializer = PublicMentorProfileSearchResultSerializer(qs, many=True)
+        return Response({"results": serializer.data}, status=status.HTTP_200_OK)
+
+
 class PublicMentorProfilesSearchListAPIView(APIView):
     """Public listing of visible mentor profiles with search and filtering."""
 


### PR DESCRIPTION
## Related Issue

Closes #189

## Description

- Added `GET /api/profiles/recently-added/` endpoint returning newest visible mentor profiles sorted by creation date
- Added `GET /api/profiles/popular/` endpoint returning highest-rated visible mentor profiles with mentee count as tiebreaker
- Both endpoints support a `limit` query param (1–50, default 10)
- Hidden profiles and non-mentor accounts are excluded from both lists

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or configuration

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code



