### PR TITLE
feat(mentorship): add session cancel and reschedule API endpoints

### DIFF
--- a/backend/mentorship/serializers.py
+++ b/backend/mentorship/serializers.py
@@ -147,6 +147,12 @@ class RespondToRequestSerializer(serializers.Serializer):
     action = serializers.ChoiceField(choices=["accept", "reject"])
 
 
+class RescheduleSessionSerializer(serializers.Serializer):
+    """Write serializer for rescheduling a session to a new availability slot."""
+
+    new_slot_id = serializers.UUIDField()
+
+
 class MatchSerializer(serializers.ModelSerializer):
     """Read serializer for mentorship matches."""
 

--- a/backend/mentorship/tests.py
+++ b/backend/mentorship/tests.py
@@ -618,4 +618,184 @@ class MyUpcomingSessionsListAPIViewTests(MentorshipRequestAPIBaseTestCase):
 
         response = self.mentee_client.get(self.UPCOMING_SESSIONS_ME_URL)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data, [])
+
+
+class CancelSessionAPIViewTests(MentorshipRequestAPIBaseTestCase):
+    """Tests for POST /api/mentorship/sessions/<match_id>/cancel/"""
+
+    def _setup_active_match_with_booking(self):
+        """Create an accepted request with a booked slot and return (match, request_obj)."""
+        request_obj = MentorshipRequest.objects.create(
+            mentor=self.mentor_profile,
+            mentee=self.mentee_profile,
+            slot=self.mentor_slot,
+            status=MentorshipRequest.Status.ACCEPTED,
+        )
+        self.mentor_slot.mark_booked(self.mentee_user)
+        match = Match.objects.get(request=request_obj)
+        return match, request_obj
+
+    def _cancel_url(self, match_id) -> str:
+        return f"/api/mentorship/sessions/{match_id}/cancel/"
+
+    def test_mentee_can_cancel(self) -> None:
+        match, _ = self._setup_active_match_with_booking()
+        response = self.mentee_client.post(self._cancel_url(match.id))
+        self.assertEqual(response.status_code, 200)
+        self.mentor_slot.refresh_from_db()
+        self.assertFalse(self.mentor_slot.is_booked)
+
+    def test_mentor_can_cancel(self) -> None:
+        match, _ = self._setup_active_match_with_booking()
+        response = self.mentor_client.post(self._cancel_url(match.id))
+        self.assertEqual(response.status_code, 200)
+        self.mentor_slot.refresh_from_db()
+        self.assertFalse(self.mentor_slot.is_booked)
+
+    def test_slot_reference_cleared_after_cancel(self) -> None:
+        match, request_obj = self._setup_active_match_with_booking()
+        self.mentee_client.post(self._cancel_url(match.id))
+        request_obj.refresh_from_db()
+        self.assertIsNone(request_obj.slot)
+
+    def test_unrelated_user_cannot_cancel(self) -> None:
+        match, _ = self._setup_active_match_with_booking()
+        response = self.other_client.post(self._cancel_url(match.id))
+        self.assertEqual(response.status_code, 403)
+
+    def test_unauthenticated_returns_401(self) -> None:
+        match, _ = self._setup_active_match_with_booking()
+        response = self.anon_client.post(self._cancel_url(match.id))
+        self.assertEqual(response.status_code, 401)
+
+    def test_cancel_unbooked_slot_returns_400(self) -> None:
+        request_obj = MentorshipRequest.objects.create(
+            mentor=self.mentor_profile,
+            mentee=self.mentee_profile,
+            slot=self.mentor_slot,
+            status=MentorshipRequest.Status.ACCEPTED,
+        )
+        match = Match.objects.get(request=request_obj)
+        # Slot is not booked
+        response = self.mentee_client.post(self._cancel_url(match.id))
+        self.assertEqual(response.status_code, 400)
+
+    def test_nonexistent_match_returns_404(self) -> None:
+        import uuid
+        response = self.mentee_client.post(self._cancel_url(uuid.uuid4()))
+        self.assertEqual(response.status_code, 404)
+
+
+class RescheduleSessionAPIViewTests(MentorshipRequestAPIBaseTestCase):
+    """Tests for POST /api/mentorship/sessions/<match_id>/reschedule/"""
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Create a second slot on the mentor for rescheduling
+        new_start = timezone.now() + timedelta(days=5)
+        self.mentor_slot_2 = AvailabilitySlot.objects.create(
+            profile=self.mentor_profile,
+            start_at=new_start,
+            end_at=new_start + timedelta(hours=1),
+        )
+
+    def _setup_active_match_with_booking(self):
+        request_obj = MentorshipRequest.objects.create(
+            mentor=self.mentor_profile,
+            mentee=self.mentee_profile,
+            slot=self.mentor_slot,
+            status=MentorshipRequest.Status.ACCEPTED,
+        )
+        self.mentor_slot.mark_booked(self.mentee_user)
+        match = Match.objects.get(request=request_obj)
+        return match, request_obj
+
+    def _reschedule_url(self, match_id) -> str:
+        return f"/api/mentorship/sessions/{match_id}/reschedule/"
+
+    def test_mentee_can_reschedule(self) -> None:
+        match, _ = self._setup_active_match_with_booking()
+        response = self.mentee_client.post(
+            self._reschedule_url(match.id),
+            {"new_slot_id": str(self.mentor_slot_2.id)},
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_old_slot_freed_after_reschedule(self) -> None:
+        match, _ = self._setup_active_match_with_booking()
+        self.mentee_client.post(
+            self._reschedule_url(match.id),
+            {"new_slot_id": str(self.mentor_slot_2.id)},
+        )
+        self.mentor_slot.refresh_from_db()
+        self.assertFalse(self.mentor_slot.is_booked)
+
+    def test_new_slot_booked_after_reschedule(self) -> None:
+        match, _ = self._setup_active_match_with_booking()
+        self.mentee_client.post(
+            self._reschedule_url(match.id),
+            {"new_slot_id": str(self.mentor_slot_2.id)},
+        )
+        self.mentor_slot_2.refresh_from_db()
+        self.assertTrue(self.mentor_slot_2.is_booked)
+
+    def test_request_slot_updated_after_reschedule(self) -> None:
+        match, request_obj = self._setup_active_match_with_booking()
+        self.mentee_client.post(
+            self._reschedule_url(match.id),
+            {"new_slot_id": str(self.mentor_slot_2.id)},
+        )
+        request_obj.refresh_from_db()
+        self.assertEqual(request_obj.slot, self.mentor_slot_2)
+
+    def test_mentor_cannot_reschedule(self) -> None:
+        match, _ = self._setup_active_match_with_booking()
+        response = self.mentor_client.post(
+            self._reschedule_url(match.id),
+            {"new_slot_id": str(self.mentor_slot_2.id)},
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_unauthenticated_returns_401(self) -> None:
+        match, _ = self._setup_active_match_with_booking()
+        response = self.anon_client.post(
+            self._reschedule_url(match.id),
+            {"new_slot_id": str(self.mentor_slot_2.id)},
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_same_slot_returns_400(self) -> None:
+        match, _ = self._setup_active_match_with_booking()
+        response = self.mentee_client.post(
+            self._reschedule_url(match.id),
+            {"new_slot_id": str(self.mentor_slot.id)},
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_slot_belonging_to_different_mentor_returns_404(self) -> None:
+        match, _ = self._setup_active_match_with_booking()
+        # other_mentor_slot belongs to other_profile, not the match's mentor
+        response = self.mentee_client.post(
+            self._reschedule_url(match.id),
+            {"new_slot_id": str(self.other_mentor_slot.id)},
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_already_booked_slot_returns_400(self) -> None:
+        match, _ = self._setup_active_match_with_booking()
+        # Book the second slot with someone else
+        self.mentor_slot_2.mark_booked(self.other_user)
+        response = self.mentee_client.post(
+            self._reschedule_url(match.id),
+            {"new_slot_id": str(self.mentor_slot_2.id)},
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_nonexistent_match_returns_404(self) -> None:
+        import uuid
+        response = self.mentee_client.post(
+            self._reschedule_url(uuid.uuid4()),
+            {"new_slot_id": str(self.mentor_slot_2.id)},
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.data["detail"], "Not found.")

--- a/backend/mentorship/tests.py
+++ b/backend/mentorship/tests.py
@@ -682,6 +682,7 @@ class CancelSessionAPIViewTests(MentorshipRequestAPIBaseTestCase):
 
     def test_nonexistent_match_returns_404(self) -> None:
         import uuid
+
         response = self.mentee_client.post(self._cancel_url(uuid.uuid4()))
         self.assertEqual(response.status_code, 404)
 
@@ -791,8 +792,32 @@ class RescheduleSessionAPIViewTests(MentorshipRequestAPIBaseTestCase):
         )
         self.assertEqual(response.status_code, 400)
 
+    def test_failed_reschedule_keeps_existing_booking(self) -> None:
+        """Failed reschedule must keep the current slot booking and request slot unchanged."""
+        match, request_obj = self._setup_active_match_with_booking()
+        self.mentor_slot_2.mark_booked(self.other_user)
+
+        response = self.mentee_client.post(
+            self._reschedule_url(match.id),
+            {"new_slot_id": str(self.mentor_slot_2.id)},
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+        self.mentor_slot.refresh_from_db()
+        self.assertTrue(self.mentor_slot.is_booked)
+        self.assertEqual(self.mentor_slot.booked_by, self.mentee_user)
+
+        self.mentor_slot_2.refresh_from_db()
+        self.assertTrue(self.mentor_slot_2.is_booked)
+        self.assertEqual(self.mentor_slot_2.booked_by, self.other_user)
+
+        request_obj.refresh_from_db()
+        self.assertEqual(request_obj.slot, self.mentor_slot)
+
     def test_nonexistent_match_returns_404(self) -> None:
         import uuid
+
         response = self.mentee_client.post(
             self._reschedule_url(uuid.uuid4()),
             {"new_slot_id": str(self.mentor_slot_2.id)},

--- a/backend/mentorship/urls.py
+++ b/backend/mentorship/urls.py
@@ -3,10 +3,12 @@
 from django.urls import path
 
 from .views import (
+    CancelSessionAPIView,
     CreateRequestAPIView,
     MyMatchesListAPIView,
     MyRequestsListAPIView,
     MyUpcomingSessionsListAPIView,
+    RescheduleSessionAPIView,
     RespondToRequestAPIView,
 )
 
@@ -23,5 +25,15 @@ urlpatterns = [
         "sessions/me/upcoming/",
         MyUpcomingSessionsListAPIView.as_view(),
         name="mentorship-upcoming-session-list",
+    ),
+    path(
+        "sessions/<uuid:match_id>/cancel/",
+        CancelSessionAPIView.as_view(),
+        name="mentorship-session-cancel",
+    ),
+    path(
+        "sessions/<uuid:match_id>/reschedule/",
+        RescheduleSessionAPIView.as_view(),
+        name="mentorship-session-reschedule",
     ),
 ]

--- a/backend/mentorship/views.py
+++ b/backend/mentorship/views.py
@@ -16,9 +16,11 @@ from accounts.models import AppUsageMode
 from accounts.permissions import IsUser
 from profiles.models import AvailabilitySlot, Profile
 from profiles.services import (
+    BookingCancelNotAllowedError,
     OwnSlotBookingError,
     SlotAlreadyBookedError,
     SlotInPastError,
+    SlotNotBookedError,
     book_availability_slot,
     cancel_availability_booking,
 )
@@ -265,9 +267,9 @@ class CancelSessionAPIView(APIView):
             return Response(_NO_PROFILE, status=status.HTTP_404_NOT_FOUND)
 
         try:
-            match = Match.objects.select_related(
-                "mentor", "mentee", "request__slot"
-            ).get(id=match_id, is_active=True)
+            match = Match.objects.select_related("mentor", "mentee", "request__slot").get(
+                id=match_id, is_active=True
+            )
         except Match.DoesNotExist:
             return Response(_NOT_FOUND, status=status.HTTP_404_NOT_FOUND)
 
@@ -283,12 +285,22 @@ class CancelSessionAPIView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        with transaction.atomic():
-            cancel_availability_booking(
-                profile=match.mentor,
-                slot_id=slot.id,
-                actor=request.user,
+        try:
+            with transaction.atomic():
+                cancel_availability_booking(
+                    profile=match.mentor,
+                    slot_id=slot.id,
+                    actor=request.user,
+                )
+        except SlotNotBookedError:
+            return Response(
+                {"detail": "This session has no active booking to cancel."},
+                status=status.HTTP_400_BAD_REQUEST,
             )
+        except BookingCancelNotAllowedError:
+            return Response(_PERMISSION_DENIED, status=status.HTTP_403_FORBIDDEN)
+        except AvailabilitySlot.DoesNotExist:
+            return Response(_NOT_FOUND, status=status.HTTP_404_NOT_FOUND)
 
         mentorship_request.refresh_from_db()
         return Response(
@@ -325,9 +337,9 @@ class RescheduleSessionAPIView(APIView):
             return Response(_NO_PROFILE, status=status.HTTP_404_NOT_FOUND)
 
         try:
-            match = Match.objects.select_related(
-                "mentor", "mentee", "request__slot"
-            ).get(id=match_id, is_active=True)
+            match = Match.objects.select_related("mentor", "mentee", "request__slot").get(
+                id=match_id, is_active=True
+            )
         except Match.DoesNotExist:
             return Response(_NOT_FOUND, status=status.HTTP_404_NOT_FOUND)
 
@@ -352,35 +364,43 @@ class RescheduleSessionAPIView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        with transaction.atomic():
-            if old_slot is not None and old_slot.is_booked:
-                cancel_availability_booking(
-                    profile=match.mentor,
-                    slot_id=old_slot.id,
-                    actor=request.user,
-                )
+        try:
+            with transaction.atomic():
+                if old_slot is not None and old_slot.is_booked:
+                    cancel_availability_booking(
+                        profile=match.mentor,
+                        slot_id=old_slot.id,
+                        actor=request.user,
+                    )
 
-            try:
                 book_availability_slot(
                     profile=match.mentor,
                     slot_id=new_slot.id,
                     actor=request.user,
                 )
-            except SlotAlreadyBookedError:
-                return Response(
-                    {"detail": "New slot is already booked."},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-            except SlotInPastError:
-                return Response(
-                    {"detail": "New slot is in the past."},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-            except OwnSlotBookingError:
-                return Response(_PERMISSION_DENIED, status=status.HTTP_403_FORBIDDEN)
-
-            mentorship_request.slot = new_slot
-            mentorship_request.save(update_fields=["slot"])
+                mentorship_request.slot = new_slot
+                mentorship_request.save(update_fields=["slot"])
+        except SlotNotBookedError:
+            return Response(
+                {"detail": "Current slot is no longer booked."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        except BookingCancelNotAllowedError:
+            return Response(_PERMISSION_DENIED, status=status.HTTP_403_FORBIDDEN)
+        except SlotAlreadyBookedError:
+            return Response(
+                {"detail": "New slot is already booked."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        except SlotInPastError:
+            return Response(
+                {"detail": "New slot is in the past."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        except OwnSlotBookingError:
+            return Response(_PERMISSION_DENIED, status=status.HTTP_403_FORBIDDEN)
+        except AvailabilitySlot.DoesNotExist:
+            return Response(_NOT_FOUND, status=status.HTTP_404_NOT_FOUND)
 
         mentorship_request.refresh_from_db()
         return Response(

--- a/backend/mentorship/views.py
+++ b/backend/mentorship/views.py
@@ -20,6 +20,7 @@ from profiles.services import (
     SlotAlreadyBookedError,
     SlotInPastError,
     book_availability_slot,
+    cancel_availability_booking,
 )
 
 from .models import Match, MentorshipRequest
@@ -27,6 +28,7 @@ from .serializers import (
     MatchSerializer,
     MentorshipRequestCreateSerializer,
     MentorshipRequestSerializer,
+    RescheduleSessionSerializer,
     RespondToRequestSerializer,
     UpcomingMenteeSessionSerializer,
 )
@@ -233,6 +235,158 @@ class MyMatchesListAPIView(APIView):
         )
 
         return Response(MatchSerializer(qs, many=True).data, status=status.HTTP_200_OK)
+
+
+class CancelSessionAPIView(APIView):
+    """Cancel a booked session for an active match."""
+
+    permission_classes = [IsUser]
+
+    @extend_schema(
+        request=None,
+        responses={
+            200: MentorshipRequestSerializer,
+            400: OpenApiResponse(description="Session is not booked or already cancelled."),
+            401: OpenApiResponse(description="Authentication required."),
+            403: OpenApiResponse(description="Only the mentor or mentee of this match can cancel."),
+            404: OpenApiResponse(description="Match not found."),
+        },
+        description=(
+            "Cancel the booked session for an active match. "
+            "Both the mentor and the mentee can cancel. "
+            "The slot is freed and the match's request slot reference is cleared."
+        ),
+        tags=["Mentorship"],
+    )
+    def post(self, request: Request, match_id: str) -> Response:
+        try:
+            profile = Profile.objects.get(user=request.user)
+        except Profile.DoesNotExist:
+            return Response(_NO_PROFILE, status=status.HTTP_404_NOT_FOUND)
+
+        try:
+            match = Match.objects.select_related(
+                "mentor", "mentee", "request__slot"
+            ).get(id=match_id, is_active=True)
+        except Match.DoesNotExist:
+            return Response(_NOT_FOUND, status=status.HTTP_404_NOT_FOUND)
+
+        if profile not in (match.mentor, match.mentee):
+            return Response(_PERMISSION_DENIED, status=status.HTTP_403_FORBIDDEN)
+
+        mentorship_request = match.request
+        slot = mentorship_request.slot
+
+        if slot is None or not slot.is_booked:
+            return Response(
+                {"detail": "This session has no active booking to cancel."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        with transaction.atomic():
+            cancel_availability_booking(
+                profile=match.mentor,
+                slot_id=slot.id,
+                actor=request.user,
+            )
+
+        mentorship_request.refresh_from_db()
+        return Response(
+            MentorshipRequestSerializer(mentorship_request).data,
+            status=status.HTTP_200_OK,
+        )
+
+
+class RescheduleSessionAPIView(APIView):
+    """Reschedule a booked session to a new availability slot."""
+
+    permission_classes = [IsUser]
+
+    @extend_schema(
+        request=RescheduleSessionSerializer,
+        responses={
+            200: MentorshipRequestSerializer,
+            400: OpenApiResponse(description="New slot is invalid or unavailable."),
+            401: OpenApiResponse(description="Authentication required."),
+            403: OpenApiResponse(description="Only the mentee can reschedule."),
+            404: OpenApiResponse(description="Match or new slot not found."),
+        },
+        description=(
+            "Reschedule the session for an active match to a new mentor availability slot. "
+            "Only the mentee can reschedule. "
+            "The old slot is freed and the new slot is booked atomically."
+        ),
+        tags=["Mentorship"],
+    )
+    def post(self, request: Request, match_id: str) -> Response:
+        try:
+            profile = Profile.objects.get(user=request.user)
+        except Profile.DoesNotExist:
+            return Response(_NO_PROFILE, status=status.HTTP_404_NOT_FOUND)
+
+        try:
+            match = Match.objects.select_related(
+                "mentor", "mentee", "request__slot"
+            ).get(id=match_id, is_active=True)
+        except Match.DoesNotExist:
+            return Response(_NOT_FOUND, status=status.HTTP_404_NOT_FOUND)
+
+        if profile != match.mentee:
+            return Response(_PERMISSION_DENIED, status=status.HTTP_403_FORBIDDEN)
+
+        serializer = RescheduleSessionSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        new_slot_id = serializer.validated_data["new_slot_id"]
+
+        try:
+            new_slot = AvailabilitySlot.objects.get(id=new_slot_id, profile=match.mentor)
+        except AvailabilitySlot.DoesNotExist:
+            return Response(_NOT_FOUND, status=status.HTTP_404_NOT_FOUND)
+
+        mentorship_request = match.request
+        old_slot = mentorship_request.slot
+
+        if new_slot == old_slot:
+            return Response(
+                {"detail": "New slot is the same as the current slot."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        with transaction.atomic():
+            if old_slot is not None and old_slot.is_booked:
+                cancel_availability_booking(
+                    profile=match.mentor,
+                    slot_id=old_slot.id,
+                    actor=request.user,
+                )
+
+            try:
+                book_availability_slot(
+                    profile=match.mentor,
+                    slot_id=new_slot.id,
+                    actor=request.user,
+                )
+            except SlotAlreadyBookedError:
+                return Response(
+                    {"detail": "New slot is already booked."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            except SlotInPastError:
+                return Response(
+                    {"detail": "New slot is in the past."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            except OwnSlotBookingError:
+                return Response(_PERMISSION_DENIED, status=status.HTTP_403_FORBIDDEN)
+
+            mentorship_request.slot = new_slot
+            mentorship_request.save(update_fields=["slot"])
+
+        mentorship_request.refresh_from_db()
+        return Response(
+            MentorshipRequestSerializer(mentorship_request).data,
+            status=status.HTTP_200_OK,
+        )
 
 
 class MyUpcomingSessionsListAPIView(APIView):

--- a/backend/profiles/views.py
+++ b/backend/profiles/views.py
@@ -448,7 +448,11 @@ class AvailabilitySlotCancelBookingAPIView(ProfileLookupMixin, APIView):
             403: OpenApiResponse(description="Permission denied."),
             404: OpenApiResponse(description="Availability slot not found."),
         },
-        description="Cancel a mentor availability slot booking.",
+        description=(
+            "Cancel a mentor availability slot booking by slot ID. "
+            "For accepted mentorship sessions tied to a match, prefer "
+            "`POST /api/mentorship/sessions/{match_id}/cancel/`."
+        ),
         tags=["Profiles"],
     )
     def post(self, request: Request, username: str, slot_id: str) -> Response:


### PR DESCRIPTION
## Related Issue

Closes #185 

## Description

Adds two new endpoints for managing booked mentorship sessions:

- `POST /api/mentorship/sessions/<match_id>/cancel/` — cancels a booked session. Both the mentor and the mentee can cancel. The slot is freed and the request's slot reference is cleared.
- `POST /api/mentorship/sessions/<match_id>/reschedule/` — reschedules a session to a new mentor availability slot. Only the mentee can reschedule. The old slot is freed and the new slot is booked atomically.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or configuration

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code

## Notes

- Cancel and reschedule are implemented as separate endpoints for clarity.
- Reschedule uses an atomic transaction: old slot is released and new slot is booked in a single DB transaction to prevent race conditions.
- 17 new tests added covering permissions, slot state transitions, and error cases.