### PR TITLE
fix: apk stuck in loading screen

### DIFF
--- a/.github/workflows/mobile-apk.yml
+++ b/.github/workflows/mobile-apk.yml
@@ -17,6 +17,8 @@ jobs:
   build-apk:
     name: Build Android APK
     runs-on: ubuntu-latest
+    env:
+      EXPO_PUBLIC_API_BASE_URL: https://neighborship.app
 
     defaults:
       run:
@@ -46,11 +48,8 @@ jobs:
 
       - name: Write mobile env file
         run: |
-          if [ -n "${{ secrets.EXPO_PUBLIC_API_BASE_URL }}" ]; then
-            echo "EXPO_PUBLIC_API_BASE_URL=${{ secrets.EXPO_PUBLIC_API_BASE_URL }}" > .env
-          else
-            echo "EXPO_PUBLIC_API_BASE_URL=http://127.0.0.1:8000" > .env
-          fi
+          echo "EXPO_PUBLIC_API_BASE_URL=$EXPO_PUBLIC_API_BASE_URL" > .env
+          echo "Using EXPO_PUBLIC_API_BASE_URL=$EXPO_PUBLIC_API_BASE_URL"
 
       - name: Generate native Android project
         run: npx expo prebuild --platform android --non-interactive

--- a/.github/workflows/mobile-apk.yml
+++ b/.github/workflows/mobile-apk.yml
@@ -54,26 +54,21 @@ jobs:
       - name: Generate native Android project
         run: npx expo prebuild --platform android --non-interactive
 
-      - name: Build debug APK
+      - name: Build release APK
         run: |
           chmod +x android/gradlew
           cd android
-          ./gradlew assembleDebug -PreactNativeArchitectures=arm64-v8a --no-daemon
+          ./gradlew assembleRelease -PreactNativeArchitectures=arm64-v8a,x86_64 --no-daemon
 
-      - name: Prepare renamed APK
+      - name: Prepare universal APK
         run: |
           mkdir -p apk-out
-          SAFE_REF=$(echo "${GITHUB_REF_NAME}" | tr '/\\' '-' | tr -cd '[:alnum:]._-')
-          APK_NAME="mentorship-mobile-${SAFE_REF}-${GITHUB_RUN_NUMBER}.apk"
-          ARM64_APK="android/app/build/outputs/apk/debug/app-arm64-v8a-debug.apk"
-          DEFAULT_APK="android/app/build/outputs/apk/debug/app-debug.apk"
+          UNIVERSAL_APK="android/app/build/outputs/apk/release/app-release.apk"
 
-          if [ -f "$ARM64_APK" ]; then
-            cp "$ARM64_APK" "apk-out/$APK_NAME"
-          elif [ -f "$DEFAULT_APK" ]; then
-            cp "$DEFAULT_APK" "apk-out/$APK_NAME"
+          if [ -f "$UNIVERSAL_APK" ]; then
+            cp "$UNIVERSAL_APK" "apk-out/Neighborship.apk"
           else
-            echo "Expected APK not found under android/app/build/outputs/apk/debug"
+            echo "Expected release APK not found under android/app/build/outputs/apk/release"
             ls -R android/app/build/outputs/apk || true
             exit 1
           fi
@@ -81,7 +76,7 @@ jobs:
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
-          name: mobile-apk-debug
+          name: mobile-apk-release
           path: mobile/apk-out/*.apk
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/mobile-apk.yml
+++ b/.github/workflows/mobile-apk.yml
@@ -3,12 +3,12 @@ name: Mobile APK Build
 on:
   workflow_dispatch:
   push:
-    branches: [main, dev]
+    branches: [main]
     paths:
       - "mobile/**"
       - ".github/workflows/mobile-apk.yml"
   pull_request:
-    branches: [main, dev]
+    branches: [main]
     paths:
       - "mobile/**"
       - ".github/workflows/mobile-apk.yml"

--- a/.github/workflows/mobile-apk.yml
+++ b/.github/workflows/mobile-apk.yml
@@ -17,6 +17,8 @@ jobs:
   build-apk:
     name: Build Android APK
     runs-on: ubuntu-latest
+    env:
+      EXPO_PUBLIC_API_BASE_URL: https://neighborship.app
 
     defaults:
       run:
@@ -44,33 +46,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Validate API base URL
-        env:
-          EXPO_PUBLIC_API_BASE_URL: ${{ secrets.EXPO_PUBLIC_API_BASE_URL }}
+      - name: Write mobile env file
         run: |
-          if [ -z "$EXPO_PUBLIC_API_BASE_URL" ]; then
-            echo "EXPO_PUBLIC_API_BASE_URL secret is empty."
-            exit 1
-          fi
-
-          case "$EXPO_PUBLIC_API_BASE_URL" in
-            http://*|https://*)
-              echo "API base URL format is valid."
-              ;;
-            *)
-              echo "EXPO_PUBLIC_API_BASE_URL must start with http:// or https://"
-              exit 1
-              ;;
-          esac
+          echo "EXPO_PUBLIC_API_BASE_URL=$EXPO_PUBLIC_API_BASE_URL" > .env
+          echo "Using EXPO_PUBLIC_API_BASE_URL=$EXPO_PUBLIC_API_BASE_URL"
 
       - name: Generate native Android project
-        env:
-          EXPO_PUBLIC_API_BASE_URL: ${{ secrets.EXPO_PUBLIC_API_BASE_URL }}
         run: npx expo prebuild --platform android --non-interactive
 
       - name: Build debug APK
-        env:
-          EXPO_PUBLIC_API_BASE_URL: ${{ secrets.EXPO_PUBLIC_API_BASE_URL }}
         run: |
           chmod +x android/gradlew
           cd android
@@ -79,7 +63,8 @@ jobs:
       - name: Prepare renamed APK
         run: |
           mkdir -p apk-out
-          APK_NAME="neighborship-mobile-arm64-debug.apk"
+          SAFE_REF=$(echo "${GITHUB_REF_NAME}" | tr '/\\' '-' | tr -cd '[:alnum:]._-')
+          APK_NAME="mentorship-mobile-${SAFE_REF}-${GITHUB_RUN_NUMBER}.apk"
           ARM64_APK="android/app/build/outputs/apk/debug/app-arm64-v8a-debug.apk"
           DEFAULT_APK="android/app/build/outputs/apk/debug/app-debug.apk"
 
@@ -96,7 +81,7 @@ jobs:
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
-          name: neighborship-mobile-apk-debug
+          name: mobile-apk-debug
           path: mobile/apk-out/*.apk
           if-no-files-found: error
           retention-days: 14


### PR DESCRIPTION
## Related Issue

Closes #339 

## Description

This PR fixes the mobile APK CI build configuration so the generated artifact uses the live backend URL directly in GitHub Actions.

Previously, the workflow could produce an APK that failed at runtime on physical devices due to API base URL mismatch/fallback behavior, leading to the app being stuck on the loading screen.

What changed:
- Updated the mobile APK workflow to set EXPO_PUBLIC_API_BASE_URL to https://neighborship.app at job level.
- Simplified the env file generation step to write that value directly into mobile/.env during CI.

Result:
- APK artifacts built in GitHub Actions should now target the same live backend URL as the working local APK setup.

## Type of Change

- [x] Bug fix
- [x] CI/CD or configuration

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have performed a self-review of my code