### PR TITLE
feat: Profile Reviews & Review Deletion

### DIFF
--- a/backend/mentorship/services.py
+++ b/backend/mentorship/services.py
@@ -345,6 +345,37 @@ def create_match_feedback(
     return feedback
 
 
+def delete_match_feedback(*, feedback: Feedback) -> None:
+    """Delete feedback and keep mentor review batch visibility semantics intact."""
+    match = feedback.match
+    if feedback.submitted_by != match.mentee:
+        feedback.delete()
+        return
+
+    mentor = match.mentor
+    threshold = max(1, int(getattr(settings, "RATING_UPDATE_THRESHOLD", 5)))
+
+    # Determine whether this feedback was already in a visible threshold batch.
+    mentee_feedback_ids = list(
+        Feedback.objects.filter(match__mentor=mentor).exclude(submitted_by=mentor).order_by("id")
+    )
+    visible_limit = (mentor.review_count // threshold) * threshold
+    feedback_index = next(
+        (idx for idx, item in enumerate(mentee_feedback_ids) if item.id == feedback.id),
+        None,
+    )
+
+    with transaction.atomic():
+        feedback.delete()
+        if feedback_index is None:
+            return
+
+        if feedback_index >= visible_limit:
+            Profile.objects.filter(pk=mentor.pk, review_count__gt=0).update(
+                review_count=F("review_count") - 1
+            )
+
+
 __all__ = [
     "NoActiveBookingError",
     "SameSlotSelectionError",
@@ -356,6 +387,7 @@ __all__ = [
     "reschedule_match_session",
     "deactivate_match",
     "create_match_feedback",
+    "delete_match_feedback",
     "book_match_session",
     "BookingCancelNotAllowedError",
     "SlotNotBookedError",

--- a/backend/mentorship/tests.py
+++ b/backend/mentorship/tests.py
@@ -702,6 +702,10 @@ class FeedbackSubmitAndListAPITests(FeedbackAPIBaseTestCase):
         response = self.anon_client.get(self.feedback_url)
         self.assertEqual(response.status_code, 401)
 
+    def test_unauthenticated_delete_returns_401(self) -> None:
+        response = self.anon_client.delete(self.feedback_url)
+        self.assertEqual(response.status_code, 401)
+
     def test_nonexistent_match_post_returns_404(self) -> None:
         import uuid
 
@@ -724,6 +728,11 @@ class FeedbackSubmitAndListAPITests(FeedbackAPIBaseTestCase):
         response = self.other_client.get(self.feedback_url)
         self.assertEqual(response.status_code, 403)
 
+    def test_unrelated_user_cannot_delete_feedback(self) -> None:
+        Feedback.objects.create(match=self.match, submitted_by=self.mentee_profile, rating=4, text="Good")
+        response = self.other_client.delete(self.feedback_url)
+        self.assertEqual(response.status_code, 403)
+
     def test_mentee_can_submit_feedback(self) -> None:
         response = self.mentee_client.post(
             self.feedback_url, {"rating": 5, "text": "Great mentor!"}, format="json"
@@ -743,6 +752,23 @@ class FeedbackSubmitAndListAPITests(FeedbackAPIBaseTestCase):
         self.mentee_client.post(self.feedback_url, {"rating": 5}, format="json")
         response = self.mentee_client.post(self.feedback_url, {"rating": 3}, format="json")
         self.assertEqual(response.status_code, 400)
+
+    def test_delete_own_feedback_returns_204(self) -> None:
+        Feedback.objects.create(
+            match=self.match,
+            submitted_by=self.mentee_profile,
+            rating=5,
+            text="Delete me",
+        )
+        response = self.mentee_client.delete(self.feedback_url)
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(
+            Feedback.objects.filter(match=self.match, submitted_by=self.mentee_profile).exists()
+        )
+
+    def test_delete_missing_feedback_returns_404(self) -> None:
+        response = self.mentee_client.delete(self.feedback_url)
+        self.assertEqual(response.status_code, 404)
 
     def test_rating_below_1_returns_400(self) -> None:
         response = self.mentee_client.post(self.feedback_url, {"rating": 0}, format="json")
@@ -812,6 +838,53 @@ class FeedbackSubmitAndListAPITests(FeedbackAPIBaseTestCase):
         second_mentee_client.post(second_feedback_url, {"rating": 2}, format="json")
         self.mentor_profile.refresh_from_db()
         self.assertEqual(self.mentor_profile.average_rating, Decimal("3.00"))
+
+    @override_settings(RATING_UPDATE_THRESHOLD=2)
+    def test_delete_visible_feedback_keeps_batch_visibility(self) -> None:
+        """Deleting already visible feedback should not reduce visible batch count."""
+        second_mentee_user = User.objects.create_user(
+            email="mentee.visible2@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTEE,
+        )
+        second_mentee_profile = Profile.objects.create(
+            user=second_mentee_user, display_name="Second Visible Mentee"
+        )
+        second_request = _create_accepted_request(
+            mentor=self.mentor_profile,
+            mentee=second_mentee_profile,
+        )
+        second_match = Match.objects.get(request=second_request)
+        second_feedback_url = f"/api/mentorship/matches/{second_match.id}/feedback/"
+        second_mentee_client = APIClient()
+        second_mentee_client.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {_token_for(second_mentee_user)}"
+        )
+
+        self.mentee_client.post(self.feedback_url, {"rating": 5, "text": "First"}, format="json")
+        second_mentee_client.post(
+            second_feedback_url, {"rating": 4, "text": "Second"}, format="json"
+        )
+
+        self.mentor_profile.refresh_from_db()
+        self.assertEqual(self.mentor_profile.review_count, 2)
+
+        delete_response = self.mentee_client.delete(self.feedback_url)
+        self.assertEqual(delete_response.status_code, 204)
+        self.mentor_profile.refresh_from_db()
+        self.assertEqual(self.mentor_profile.review_count, 2)
+
+    @override_settings(RATING_UPDATE_THRESHOLD=2)
+    def test_delete_hidden_feedback_reduces_pending_batch_count(self) -> None:
+        """Deleting not-yet-visible feedback should remove it from pending threshold progress."""
+        self.mentee_client.post(self.feedback_url, {"rating": 5, "text": "Only one"}, format="json")
+        self.mentor_profile.refresh_from_db()
+        self.assertEqual(self.mentor_profile.review_count, 1)
+
+        delete_response = self.mentee_client.delete(self.feedback_url)
+        self.assertEqual(delete_response.status_code, 204)
+        self.mentor_profile.refresh_from_db()
+        self.assertEqual(self.mentor_profile.review_count, 0)
 
 
 class CancelSessionAPIViewTests(MentorshipRequestAPIBaseTestCase):

--- a/backend/mentorship/tests.py
+++ b/backend/mentorship/tests.py
@@ -770,6 +770,24 @@ class FeedbackSubmitAndListAPITests(FeedbackAPIBaseTestCase):
         response = self.mentee_client.delete(self.feedback_url)
         self.assertEqual(response.status_code, 404)
 
+    def test_delete_mentor_feedback_does_not_change_review_count(self) -> None:
+        self.mentor_client.post(self.feedback_url, {"rating": 4, "text": "Mentor note"}, format="json")
+        self.mentor_profile.refresh_from_db()
+        self.assertEqual(self.mentor_profile.review_count, 0)
+
+        delete_response = self.mentor_client.delete(self.feedback_url)
+        self.assertEqual(delete_response.status_code, 204)
+        self.mentor_profile.refresh_from_db()
+        self.assertEqual(self.mentor_profile.review_count, 0)
+
+    def test_delete_feedback_twice_returns_404_second_time(self) -> None:
+        self.mentee_client.post(self.feedback_url, {"rating": 5, "text": "Delete twice"}, format="json")
+        first_delete = self.mentee_client.delete(self.feedback_url)
+        second_delete = self.mentee_client.delete(self.feedback_url)
+
+        self.assertEqual(first_delete.status_code, 204)
+        self.assertEqual(second_delete.status_code, 404)
+
     def test_rating_below_1_returns_400(self) -> None:
         response = self.mentee_client.post(self.feedback_url, {"rating": 0}, format="json")
         self.assertEqual(response.status_code, 400)

--- a/backend/mentorship/views.py
+++ b/backend/mentorship/views.py
@@ -42,6 +42,7 @@ from .services import (
     create_match_feedback,
     create_mentorship_request,
     deactivate_match,
+    delete_match_feedback,
     reschedule_match_session,
     respond_to_mentorship_request,
 )
@@ -636,3 +637,39 @@ class MatchFeedbackListCreateAPIView(APIView):
             FeedbackSerializer(feedback).data,
             status=status.HTTP_201_CREATED,
         )
+
+    @extend_schema(
+        responses={
+            204: OpenApiResponse(description="Feedback deleted."),
+            401: OpenApiResponse(description="Authentication required."),
+            403: OpenApiResponse(description="Only match participants can delete feedback."),
+            404: OpenApiResponse(description="Match or feedback not found."),
+        },
+        description=(
+            "Delete authenticated participant's own feedback for the given match. "
+            "Deleting pre-threshold feedback removes it from pending batch counts, "
+            "while deleting already visible feedback does not reduce batch visibility."
+        ),
+        tags=["Mentorship"],
+    )
+    def delete(self, request: Request, match_id: str) -> Response:
+        """Delete the caller's own feedback entry for the identified match."""
+        try:
+            profile = Profile.objects.get(user=request.user)
+        except Profile.DoesNotExist:
+            return Response(_NO_PROFILE, status=status.HTTP_404_NOT_FOUND)
+
+        try:
+            match = Match.objects.select_related("mentor", "mentee").get(id=match_id)
+        except Match.DoesNotExist:
+            return Response(_NOT_FOUND, status=status.HTTP_404_NOT_FOUND)
+
+        if profile not in (match.mentor, match.mentee):
+            return Response(_PERMISSION_DENIED, status=status.HTTP_403_FORBIDDEN)
+
+        feedback = Feedback.objects.filter(match=match, submitted_by=profile).first()
+        if feedback is None:
+            return Response(_NOT_FOUND, status=status.HTTP_404_NOT_FOUND)
+
+        delete_match_feedback(feedback=feedback)
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/backend/profiles/tests.py
+++ b/backend/profiles/tests.py
@@ -1166,6 +1166,31 @@ class ProfilePublicReviewsAPITests(TestCase):
             text=text,
         )
 
+    def _create_mentee_client_and_feedback_url(self, idx: int) -> tuple[APIClient, str]:
+        mentee_user = User.objects.create_user(
+            email=f"mentee.reviews.api.{idx}@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTEE,
+        )
+        mentee_profile = Profile.objects.create(
+            user=mentee_user,
+            display_name=f"API Mentee {idx}",
+        )
+        mentorship_request = MentorshipRequest.objects.create(
+            mentor=self.mentor_profile,
+            mentee=mentee_profile,
+            status=MentorshipRequest.Status.ACCEPTED,
+        )
+        match = Match.objects.create(
+            mentor=self.mentor_profile,
+            mentee=mentee_profile,
+            request=mentorship_request,
+        )
+        api_client = APIClient()
+        token = str(RefreshToken.for_user(mentee_user).access_token)
+        api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
+        return api_client, f"/api/mentorship/matches/{match.id}/feedback/"
+
     def test_returns_404_for_missing_profile(self) -> None:
         response = self.api_client.get("/api/profiles/missing-user/reviews/")
         self.assertEqual(response.status_code, 404)
@@ -1241,6 +1266,61 @@ class ProfilePublicReviewsAPITests(TestCase):
         page_1_texts = {item["text"] for item in payload_1["results"]}
         page_2_texts = {item["text"] for item in payload_2["results"]}
         self.assertTrue(page_1_texts.isdisjoint(page_2_texts))
+
+    def test_invalid_pagination_params_return_400(self) -> None:
+        response = self.api_client.get(self.url, {"page": "abc", "pageSize": "x"})
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("must be integers", response.json()["detail"])
+
+    def test_visible_feedback_deletion_keeps_public_reviews_visible(self) -> None:
+        first_client, first_feedback_url = self._create_mentee_client_and_feedback_url(1)
+        second_client, second_feedback_url = self._create_mentee_client_and_feedback_url(2)
+
+        create_first = first_client.post(
+            first_feedback_url,
+            {"rating": 5, "text": "First visible"},
+            format="json",
+        )
+        create_second = second_client.post(
+            second_feedback_url,
+            {"rating": 4, "text": "Second visible"},
+            format="json",
+        )
+        self.assertEqual(create_first.status_code, 201)
+        self.assertEqual(create_second.status_code, 201)
+
+        before_delete = self.api_client.get(self.url)
+        self.assertEqual(before_delete.status_code, 200)
+        self.assertEqual(before_delete.json()["count"], 2)
+
+        delete_first = first_client.delete(first_feedback_url)
+        self.assertEqual(delete_first.status_code, 204)
+
+        after_delete = self.api_client.get(self.url)
+        self.assertEqual(after_delete.status_code, 200)
+        self.assertEqual(after_delete.json()["count"], 1)
+        self.assertEqual(after_delete.json()["results"][0]["text"], "Second visible")
+
+    def test_hidden_feedback_deletion_does_not_make_batch_visible(self) -> None:
+        first_client, first_feedback_url = self._create_mentee_client_and_feedback_url(3)
+        create_first = first_client.post(
+            first_feedback_url,
+            {"rating": 5, "text": "Hidden candidate"},
+            format="json",
+        )
+        self.assertEqual(create_first.status_code, 201)
+
+        before_delete = self.api_client.get(self.url)
+        self.assertEqual(before_delete.status_code, 200)
+        self.assertEqual(before_delete.json()["count"], 0)
+
+        delete_first = first_client.delete(first_feedback_url)
+        self.assertEqual(delete_first.status_code, 204)
+
+        after_delete = self.api_client.get(self.url)
+        self.assertEqual(after_delete.status_code, 200)
+        self.assertEqual(after_delete.json()["count"], 0)
+        self.assertEqual(after_delete.json()["results"], [])
 
 
 class RecentlyAddedMentorsAPITests(TestCase):

--- a/backend/profiles/tests.py
+++ b/backend/profiles/tests.py
@@ -5,13 +5,13 @@ from typing import Any
 
 from django.contrib.auth import get_user_model
 from django.db import IntegrityError, transaction
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 from rest_framework.test import APIClient
 from rest_framework_simplejwt.tokens import RefreshToken
 
 from accounts.models import AppUsageMode
-from mentorship.models import MentorshipRequest
+from mentorship.models import Feedback, Match, MentorshipRequest
 from profiles.models import AvailabilitySlot, Profile, Skill
 
 User: Any = get_user_model()
@@ -1118,6 +1118,129 @@ class MentorPublicRatingAPITests(TestCase):
         response = self.api_client.get(self._url(self.mentor_profile.username))
         self.assertEqual(response.json()["average_rating"], "4.20")
         self.assertEqual(response.json()["review_count"], 5)
+
+
+@override_settings(RATING_UPDATE_THRESHOLD=2)
+class ProfilePublicReviewsAPITests(TestCase):
+    """Tests for GET /api/profiles/{username}/reviews/."""
+
+    def setUp(self) -> None:
+        self.api_client: Any = APIClient()
+
+        self.mentor_user = User.objects.create_user(
+            email="mentor.reviews@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTOR,
+        )
+        self.mentor_profile = Profile.objects.create(
+            user=self.mentor_user,
+            display_name="Reviews Mentor",
+            is_visible=True,
+        )
+        self.url = f"/api/profiles/{self.mentor_profile.username}/reviews/"
+
+    def _create_mentee_feedback(self, idx: int, *, rating: int, text: str) -> Feedback:
+        mentee_user = User.objects.create_user(
+            email=f"mentee.review.{idx}@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTEE,
+        )
+        mentee_profile = Profile.objects.create(
+            user=mentee_user,
+            display_name=f"Mentee {idx}",
+        )
+        mentorship_request = MentorshipRequest.objects.create(
+            mentor=self.mentor_profile,
+            mentee=mentee_profile,
+            status=MentorshipRequest.Status.ACCEPTED,
+        )
+        match = Match.objects.create(
+            mentor=self.mentor_profile,
+            mentee=mentee_profile,
+            request=mentorship_request,
+        )
+        return Feedback.objects.create(
+            match=match,
+            submitted_by=mentee_profile,
+            rating=rating,
+            text=text,
+        )
+
+    def test_returns_404_for_missing_profile(self) -> None:
+        response = self.api_client.get("/api/profiles/missing-user/reviews/")
+        self.assertEqual(response.status_code, 404)
+
+    def test_returns_404_for_invisible_profile(self) -> None:
+        self.mentor_profile.is_visible = False
+        self.mentor_profile.save(update_fields=["is_visible"])
+
+        response = self.api_client.get(self.url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_returns_only_public_text_review_fields(self) -> None:
+        self._create_mentee_feedback(1, rating=5, text="Excellent guidance")
+        self._create_mentee_feedback(2, rating=4, text="Clear explanations")
+        self.mentor_profile.review_count = 2
+        self.mentor_profile.save(update_fields=["review_count"])
+
+        response = self.api_client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["count"], 2)
+        self.assertEqual(len(payload["results"]), 2)
+        first_review = payload["results"][0]
+        self.assertEqual(set(first_review.keys()), {"rating", "text", "created_at"})
+        self.assertNotIn("submitted_by", first_review)
+        self.assertNotIn("match", first_review)
+
+    def test_empty_text_reviews_are_excluded(self) -> None:
+        self._create_mentee_feedback(1, rating=5, text="")
+        self._create_mentee_feedback(2, rating=4, text="Visible text")
+        self.mentor_profile.review_count = 2
+        self.mentor_profile.save(update_fields=["review_count"])
+
+        response = self.api_client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["count"], 1)
+        self.assertEqual([item["text"] for item in payload["results"]], ["Visible text"])
+
+    def test_threshold_gating_hides_incomplete_batch(self) -> None:
+        self._create_mentee_feedback(1, rating=5, text="Only one review")
+        self.mentor_profile.review_count = 1
+        self.mentor_profile.save(update_fields=["review_count"])
+
+        response = self.api_client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["count"], 0)
+        self.assertEqual(payload["results"], [])
+
+    def test_pagination_slices_results(self) -> None:
+        texts = ["Review A", "Review B", "Review C", "Review D"]
+        for idx, text in enumerate(texts, start=1):
+            self._create_mentee_feedback(idx, rating=5, text=text)
+        self.mentor_profile.review_count = 4
+        self.mentor_profile.save(update_fields=["review_count"])
+
+        response_page_1 = self.api_client.get(self.url, {"page": 1, "pageSize": 2})
+        response_page_2 = self.api_client.get(self.url, {"page": 2, "pageSize": 2})
+
+        self.assertEqual(response_page_1.status_code, 200)
+        self.assertEqual(response_page_2.status_code, 200)
+        payload_1 = response_page_1.json()
+        payload_2 = response_page_2.json()
+
+        self.assertEqual(payload_1["count"], 4)
+        self.assertEqual(payload_1["page"], 1)
+        self.assertEqual(payload_1["pageSize"], 2)
+        self.assertEqual(len(payload_1["results"]), 2)
+        self.assertEqual(payload_2["page"], 2)
+        self.assertEqual(len(payload_2["results"]), 2)
+
+        page_1_texts = {item["text"] for item in payload_1["results"]}
+        page_2_texts = {item["text"] for item in payload_2["results"]}
+        self.assertTrue(page_1_texts.isdisjoint(page_2_texts))
 
 
 class RecentlyAddedMentorsAPITests(TestCase):

--- a/backend/profiles/urls.py
+++ b/backend/profiles/urls.py
@@ -10,6 +10,7 @@ from .views import (
     MyAvailabilitySlotListCreateAPIView,
     PopularMentorsListAPIView,
     ProfileByUsernameAPIView,
+    ProfileReviewsByUsernameAPIView,
     ProfileMeAPIView,
     PublicMentorProfilesSearchListAPIView,
     RecentlyAddedMentorsListAPIView,
@@ -50,6 +51,11 @@ urlpatterns = [
         "<str:username>/rating/",
         MentorPublicRatingAPIView.as_view(),
         name="mentor-public-rating",
+    ),
+    path(
+        "<str:username>/reviews/",
+        ProfileReviewsByUsernameAPIView.as_view(),
+        name="profile-reviews",
     ),
     path("<str:username>/", ProfileByUsernameAPIView.as_view(), name="profile-by-username"),
 ]

--- a/backend/profiles/views.py
+++ b/backend/profiles/views.py
@@ -1,5 +1,6 @@
 """Views for profile self-service API endpoints."""
 
+from django.conf import settings
 from django.contrib.gis.geos import Point
 from django.contrib.gis.measure import D
 from django.db import IntegrityError, transaction
@@ -8,6 +9,7 @@ from django.db.models.deletion import ProtectedError
 from django.utils import timezone
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
+from rest_framework import serializers
 from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -15,6 +17,7 @@ from rest_framework.views import APIView
 
 from accounts.models import AppUsageMode
 from accounts.permissions import IsUser
+from mentorship.models import Feedback
 
 from .models import AvailabilitySlot, Profile, Skill
 from .serializers import (
@@ -805,6 +808,85 @@ class MentorPublicRatingAPIView(ProfileLookupMixin, APIView):
                 "username": profile.username,
                 "average_rating": str(profile.average_rating),
                 "review_count": profile.review_count,
+            },
+            status=status.HTTP_200_OK,
+        )
+
+
+class PublicProfileReviewSerializer(serializers.Serializer):
+    """Public-facing text review payload for profile pages."""
+
+    rating = serializers.IntegerField()
+    text = serializers.CharField()
+    created_at = serializers.DateTimeField()
+
+
+class PublicProfileReviewListResponseSerializer(serializers.Serializer):
+    """Paginated response for public profile reviews endpoint."""
+
+    count = serializers.IntegerField()
+    page = serializers.IntegerField()
+    pageSize = serializers.IntegerField()
+    results = PublicProfileReviewSerializer(many=True)
+
+
+class ProfileReviewsByUsernameAPIView(ProfileLookupMixin, APIView):
+    """Return public, anonymous mentee text reviews for a visible mentor profile."""
+
+    permission_classes = [AllowAny]
+
+    @extend_schema(
+        operation_id="profiles_public_reviews",
+        responses={
+            200: PublicProfileReviewListResponseSerializer,
+            400: OpenApiResponse(description="Invalid pagination params."),
+            404: OpenApiResponse(description="Profile not found."),
+        },
+        description=(
+            "Return anonymous text reviews for a visible mentor profile. "
+            "Only complete batches of reviews are exposed based on the configured "
+            "rating update threshold. Supports pagination via `page` and `pageSize`."
+        ),
+        tags=["Profiles"],
+    )
+    def get(self, request: Request, username: str) -> Response:
+        profile = self._get_profile_or_404(username)
+        if profile is None or not profile.is_visible or not self._is_mentor_profile(profile):
+            return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
+
+        try:
+            page = int(request.query_params.get("page", 1))
+            page_size = int(request.query_params.get("pageSize", 6))
+        except (TypeError, ValueError):
+            return Response(
+                {"detail": "`page` and `pageSize` must be integers."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        page = max(page, 1)
+        page_size = max(page_size, 1)
+        page_size = min(page_size, 50)
+
+        threshold = max(1, int(getattr(settings, "RATING_UPDATE_THRESHOLD", 5)))
+        allowed_reviews_count = (profile.review_count // threshold) * threshold
+
+        feedback_qs = (
+            Feedback.objects.filter(match__mentor=profile)
+            .exclude(submitted_by=profile)
+            .exclude(text="")
+            .order_by("id")
+        )
+
+        total = min(feedback_qs.count(), allowed_reviews_count)
+        offset = (page - 1) * page_size
+        items = feedback_qs[:allowed_reviews_count][offset : offset + page_size]
+
+        return Response(
+            {
+                "count": total,
+                "page": page,
+                "pageSize": page_size,
+                "results": PublicProfileReviewSerializer(items, many=True).data,
             },
             status=status.HTTP_200_OK,
         )


### PR DESCRIPTION
## Related Issue

Closes #370

## Description

This PR creates `GET /api/profiles/{username}/reviews/` with anonymity considerations.
This PR additionally creates `DELETE /api/mentorship/matches/{match_id}/feedback/`, check below for why.

Essentially:
- Each review is part of an N (= RATING_UPDATE_THRESHOLD) batch.
- Each review becomes viewable once all N slots in the batch is filled.
- Once a batch is complete, each review in that batch becomes visible at the same time.
- The ordering within a batch should be anonymized but deterministic.

The goal is to keep the authors of each review hidden.

During the implementation, I noticed a potential issue with this approach. While not implemented during this PR, if feedback deletion were to be implemented in the future (deletion by review author is not the only option after all - admins might need to delete problematic reviews too), this batch method would need to be redesigned. Hence I went ahead and implemented the deletion mechanism in this PR to prevent future issues. Current deletion method works like this:
- This PR additionally creates `DELETE /api/mentorship/matches/{match_id}/feedback/`
- If deleted feedback was already in a visible batch, do not decrement `mentor.review_count`.
- If deleted feedback was still in hidden/pending batch progress, decrement `mentor.review_count` by 1.

If the decision is to keep feedback deletion as a separate issue, or entirely unimplemented, feel free to revert to the first commit. The 2nd commit deals only in the deletion issue, and the 3rd commit adds more overall testing. It is possible to only add tests related to the first part from the 3rd commit, which I would be happy to provide.

One alternative for deletion that wouldn't cause a conflict with the batch method is to replace the text of deleted reviews with blank, or to add a separate field indicating deletion for frontend filtering. These options expose that a deletion was made, however, which was why I created the deletion logic. They would still work with the batch method if we choose to revert the deletion logic in this PR.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or configuration

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code

## Notes

Check description for out-of-scope DELETE implementation.
Failing tests are likely due to the refactor that happend while notification and private messaging PRs were in waiting and are not related to this PR.