### PR TITLE
feat: standardize mobile feedback, confirmation, and registration UX

### DIFF
--- a/mobile/__tests__/app/schedule.test.tsx
+++ b/mobile/__tests__/app/schedule.test.tsx
@@ -1,13 +1,11 @@
 import ScheduleScreen from "@/app/(tabs)/schedule";
 import { fireEvent, render } from "@testing-library/react-native";
 import React from "react";
-import { Alert } from "react-native";
 import { act } from "react-test-renderer";
 
 const mockMeetingSessionsQuery = jest.fn();
 const mockCancelSessionMutation = jest.fn();
 const mockRescheduleSessionMutation = jest.fn();
-const mockSubmitFeedbackMutation = jest.fn();
 const mockAvailabilitySlotsQuery = jest.fn();
 
 jest.mock("@expo/vector-icons", () => ({ Ionicons: "View" }));
@@ -76,10 +74,6 @@ jest.mock("@/lib/queries/mentorship", () => {
       mutateAsync: mockRescheduleSessionMutation,
       isPending: false,
     }),
-    useSubmitMatchFeedbackMutation: () => ({
-      mutateAsync: mockSubmitFeedbackMutation,
-      isPending: false,
-    }),
     useRespondToMentorshipRequestMutation: () => ({
       mutateAsync: jest.fn(),
       isPending: false,
@@ -96,8 +90,6 @@ jest.mock("@/lib/auth/store", () => ({
       },
     }),
 }));
-
-jest.spyOn(Alert, "alert");
 
 describe("ScheduleScreen", () => {
   const today = new Date().toISOString().slice(0, 10);
@@ -168,50 +160,6 @@ describe("ScheduleScreen", () => {
 
     expect(getByText("with Ada Lovelace")).toBeTruthy();
     expect(getByText("Cancel")).toBeTruthy();
-  });
-
-  it("handles the Leave Feedback transition from the modal", async () => {
-    jest.setSystemTime(new Date(2026, 3, 17, 12, 0, 0));
-    mockMeetingSessionsQuery.mockReturnValue({
-      data: [
-        {
-          session_id: "session-past",
-          match_id: "match-past",
-          source_slot_id: "slot-past",
-          mentor: {
-            id: "mentor-1",
-            username: "mentor_ada",
-            display_name: "Ada Lovelace",
-          },
-          mentee: {
-            id: "mentee-1",
-            username: "student",
-            display_name: "Student",
-          },
-          scheduled_start_at: `${today}T09:00:00`,
-          scheduled_end_at: `${today}T10:00:00`,
-          status: "COMPLETED",
-          display_status: "COMPLETED",
-          my_role: "MENTEE",
-          allowed_actions: [],
-          canceled_by_role: null,
-          cancel_reason: "",
-          created_at: `${today}T08:00:00`,
-          updated_at: `${today}T08:00:00`,
-        },
-      ],
-    });
-
-    const { getByTestId, findByText, queryByText } = render(<ScheduleScreen />);
-
-    fireEvent.press(getByTestId("session-card-Ada Lovelace"));
-    fireEvent.press(await findByText("Leave Feedback"));
-    act(() => {
-      jest.runAllTimers();
-    });
-
-    // Session details modal should close after selecting feedback.
-    expect(queryByText("Leave Feedback")).toBeNull();
   });
 
   it("closes the reschedule sheet after a successful reschedule", async () => {

--- a/mobile/__tests__/components/connections/ConnectionActionsSheet.test.tsx
+++ b/mobile/__tests__/components/connections/ConnectionActionsSheet.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { ConnectionActionsSheet } from "@/components/connections/ConnectionActionsSheet";
+
+jest.mock("@expo/vector-icons", () => ({ Ionicons: "View" }));
+
+describe("ConnectionActionsSheet", () => {
+  it("opens the themed remove confirmation and confirms removal", () => {
+    const onRemoveConnection = jest.fn();
+    const { getByText } = render(
+      <ConnectionActionsSheet
+        visible={true}
+        name="Jane Doe"
+        onClose={jest.fn()}
+        onViewProfile={jest.fn()}
+        onRemoveConnection={onRemoveConnection}
+      />,
+    );
+
+    fireEvent.press(getByText("Remove Connection"));
+
+    expect(getByText("Remove Jane Doe?")).toBeTruthy();
+    expect(
+      getByText("This will end the active mentorship connection."),
+    ).toBeTruthy();
+
+    fireEvent.press(getByText("Remove"));
+
+    expect(onRemoveConnection).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/__tests__/components/dashboard/FeedbackBottomSheet.test.tsx
+++ b/mobile/__tests__/components/dashboard/FeedbackBottomSheet.test.tsx
@@ -19,7 +19,6 @@ describe("FeedbackBottomSheet", () => {
         onClose={mockOnClose}
         onSubmit={mockOnSubmit}
         otherUserName="Jane Doe"
-        yourRole="Mentee"
       />
     );
 
@@ -34,7 +33,6 @@ describe("FeedbackBottomSheet", () => {
         onClose={mockOnClose}
         onSubmit={mockOnSubmit}
         otherUserName="Jane Doe"
-        yourRole="Mentee"
       />
     );
 
@@ -52,7 +50,6 @@ describe("FeedbackBottomSheet", () => {
         onClose={mockOnClose}
         onSubmit={mockOnSubmit}
         otherUserName="Jane Doe"
-        yourRole="Mentee"
       />
     );
 
@@ -67,7 +64,6 @@ describe("FeedbackBottomSheet", () => {
         onClose={mockOnClose}
         onSubmit={mockOnSubmit}
         otherUserName="Jane Doe"
-        yourRole="Mentee"
       />
     );
 
@@ -81,7 +77,6 @@ describe("FeedbackBottomSheet", () => {
         onClose={mockOnClose}
         onSubmit={mockOnSubmit}
         otherUserName="Jane Doe"
-        yourRole="Mentee"
       />
     );
 

--- a/mobile/__tests__/components/dashboard/FeedbackBottomSheet.test.tsx
+++ b/mobile/__tests__/components/dashboard/FeedbackBottomSheet.test.tsx
@@ -13,7 +13,7 @@ describe("FeedbackBottomSheet", () => {
   });
 
   it("renders correctly when visible", () => {
-    const { getByText } = render(
+    const { getByText, queryByText } = render(
       <FeedbackBottomSheet
         visible={true}
         onClose={mockOnClose}
@@ -24,6 +24,8 @@ describe("FeedbackBottomSheet", () => {
 
     expect(getByText("Submit Review")).toBeTruthy();
     expect(getByText("Cancel")).toBeTruthy();
+    expect(queryByText("As Mentee")).toBeNull();
+    expect(queryByText("As Mentor")).toBeNull();
   });
 
   it("shows an error if submitting without a rating", async () => {

--- a/mobile/__tests__/components/dashboard/SessionDetailsModal.test.tsx
+++ b/mobile/__tests__/components/dashboard/SessionDetailsModal.test.tsx
@@ -24,7 +24,7 @@ describe("SessionDetailsModal Component", () => {
     isSessionStarted: true,
   };
 
-  // Set up fake timers for the setTimeout in your Reschedule/Feedback buttons
+  // Set up fake timers for the setTimeout in the Reschedule button
   beforeEach(() => {
     jest.useFakeTimers();
     jest.clearAllMocks();
@@ -82,29 +82,17 @@ describe("SessionDetailsModal Component", () => {
     expect(mockOnReschedule).toHaveBeenCalled();
   });
 
-  it("shows Leave Feedback and hides Reschedule/Cancel for Completed sessions", () => {
-    const mockOnLeaveFeedback = jest.fn();
-    
-    const { getByText, queryByText } = render(
+  it("hides action buttons for completed sessions", () => {
+    const { queryByText } = render(
       <SessionDetailsModal
         visible={true}
         session={completedSession as any}
         onClose={jest.fn()}
-        onLeaveFeedback={mockOnLeaveFeedback}
       />,
     );
 
-    // Leave Feedback should be visible
-    expect(getByText("Leave Feedback")).toBeTruthy();
-    
-    // Reschedule and Cancel should NOT be visible
     expect(queryByText("Reschedule")).toBeNull();
     expect(queryByText("Cancel")).toBeNull();
-
-    // Pressing Leave Feedback
-    fireEvent.press(getByText("Leave Feedback"));
-    jest.runAllTimers(); // fast forward 300ms
-    expect(mockOnLeaveFeedback).toHaveBeenCalled();
   });
 
   it("does not render content when visible is false", () => {

--- a/mobile/__tests__/components/dashboard/SessionDetailsModal.test.tsx
+++ b/mobile/__tests__/components/dashboard/SessionDetailsModal.test.tsx
@@ -15,8 +15,7 @@ describe("SessionDetailsModal Component", () => {
     status: "Upcoming",
     topic: "System Design Interview Prep",
     myRole: "Mentee",
-    location: "Campus Library, Room 4B",
-    isSessionStarted: false, 
+    isSessionStarted: false,
   };
 
   const completedSession = {
@@ -36,7 +35,7 @@ describe("SessionDetailsModal Component", () => {
   });
 
   it("renders the session details correctly when visible", () => {
-    const { getByText } = render(
+    const { getByText, queryByText } = render(
       <SessionDetailsModal
         visible={true}
         session={mockSession as any}
@@ -49,11 +48,13 @@ describe("SessionDetailsModal Component", () => {
     expect(getByText("System Design Interview Prep")).toBeTruthy();
     expect(getByText("with Ahmet Yılmaz")).toBeTruthy();
     expect(getByText("14:00 - 15:00")).toBeTruthy();
-    expect(getByText("Campus Library, Room 4B")).toBeTruthy();
-
     // Verify our action buttons are present for Upcoming sessions
     expect(getByText("Reschedule")).toBeTruthy();
     expect(getByText("Cancel")).toBeTruthy();
+    expect(queryByText("Platform")).toBeNull();
+    expect(queryByText("Location")).toBeNull();
+    expect(queryByText("Join Video Call")).toBeNull();
+    expect(queryByText("Get Directions")).toBeNull();
   });
 
   it("triggers onClose and onReschedule when the Reschedule button is pressed", () => {

--- a/mobile/__tests__/components/profile/BookingModal.test.tsx
+++ b/mobile/__tests__/components/profile/BookingModal.test.tsx
@@ -1,14 +1,10 @@
 import { fireEvent, render, waitFor } from "@testing-library/react-native";
 import React from "react";
-import { Alert } from "react-native";
 
 import { BookingModal } from "@/components/profile/BookingModal";
 
 // Mock the icons to prevent font-loading warnings
 jest.mock("@expo/vector-icons", () => ({ Ionicons: "View" }));
-
-// Spy on Alert to test validation popups
-jest.spyOn(Alert, "alert");
 
 describe("BookingModal Component", () => {
   const mockOffering = {
@@ -57,7 +53,7 @@ describe("BookingModal Component", () => {
     expect(getByText("60 min • Senior")).toBeTruthy();
   });
 
-  it("shows validation alert if user tries to submit without selecting a time", () => {
+  it("shows inline validation if user tries to submit without selecting a time", () => {
     const mockOnSubmit = jest.fn();
     const { getByText } = render(
       <BookingModal
@@ -71,10 +67,7 @@ describe("BookingModal Component", () => {
 
     fireEvent.press(getByText("Continue"));
 
-    expect(Alert.alert).toHaveBeenCalledWith(
-      "Missing Information",
-      expect.any(String),
-    );
+    expect(getByText("Please select a date for the session.")).toBeTruthy();
     expect(mockOnSubmit).not.toHaveBeenCalled();
   });
 

--- a/mobile/__tests__/components/profile/EditAvailabilityModal.test.tsx
+++ b/mobile/__tests__/components/profile/EditAvailabilityModal.test.tsx
@@ -1,6 +1,5 @@
 import { act, fireEvent, render } from "@testing-library/react-native";
 import React from "react";
-import { Alert } from "react-native";
 
 import { EditAvailabilityModal } from "@/components/profile/EditAvailabilityModal";
 
@@ -92,10 +91,7 @@ describe("EditAvailabilityModal", () => {
     expect(onChanged).toHaveBeenCalled();
   });
 
-  it("alerts when trying to deactivate a booked slot", () => {
-    const alertSpy = jest
-      .spyOn(Alert, "alert")
-      .mockImplementation(() => undefined);
+  it("shows inline error when trying to deactivate a booked slot", () => {
     const monday = toDateString(getMonday(new Date()));
 
     const { getByText } = render(
@@ -117,9 +113,10 @@ describe("EditAvailabilityModal", () => {
 
     fireEvent.press(getByText("09:00 - 10:00"));
 
-    expect(alertSpy).toHaveBeenCalledWith(
-      "Cannot Make Slot Unavailable",
-      expect.stringContaining("planned session"),
+    expect(
+      getByText(
+        "This slot has 0 planned session(s). Cancelling accepted sessions from availability editing is not supported by the current backend.",
+      ),
     );
   });
 });

--- a/mobile/__tests__/components/profile/RegistrationProfileSetupSheet.test.tsx
+++ b/mobile/__tests__/components/profile/RegistrationProfileSetupSheet.test.tsx
@@ -6,7 +6,7 @@ import { RegistrationProfileSetupSheet } from "@/components/profile/Registration
 jest.mock("@expo/vector-icons", () => ({ Ionicons: "View" }));
 
 describe("RegistrationProfileSetupSheet", () => {
-  it("shows generated username as read-only onboarding context", () => {
+  it("shows username preview as read-only onboarding context", () => {
     const { getByText } = render(
       <RegistrationProfileSetupSheet
         visible={true}
@@ -25,7 +25,7 @@ describe("RegistrationProfileSetupSheet", () => {
     expect(getByText("@new_user")).toBeTruthy();
     expect(
       getByText(
-        "Your username is generated during registration. It is shown here for reference and cannot be edited in the current backend flow.",
+        "This is the username preview for your account. The backend still assigns the final username during registration, so it may change slightly if that handle is already taken, and it cannot be edited in the current flow.",
       ),
     ).toBeTruthy();
   });

--- a/mobile/__tests__/components/profile/RegistrationProfileSetupSheet.test.tsx
+++ b/mobile/__tests__/components/profile/RegistrationProfileSetupSheet.test.tsx
@@ -7,7 +7,7 @@ jest.mock("@expo/vector-icons", () => ({ Ionicons: "View" }));
 
 describe("RegistrationProfileSetupSheet", () => {
   it("shows username preview as read-only onboarding context", () => {
-    const { getByText } = render(
+    const { getByText, queryByLabelText } = render(
       <RegistrationProfileSetupSheet
         visible={true}
         role="mentor"
@@ -23,10 +23,7 @@ describe("RegistrationProfileSetupSheet", () => {
 
     expect(getByText("Username")).toBeTruthy();
     expect(getByText("@new_user")).toBeTruthy();
-    expect(
-      getByText(
-        "This is the username preview for your account. The backend still assigns the final username during registration, so it may change slightly if that handle is already taken, and it cannot be edited in the current flow.",
-      ),
-    ).toBeTruthy();
+    expect(getByText("Display Name")).toBeTruthy();
+    expect(queryByLabelText("Username")).toBeNull();
   });
 });

--- a/mobile/__tests__/components/profile/RegistrationProfileSetupSheet.test.tsx
+++ b/mobile/__tests__/components/profile/RegistrationProfileSetupSheet.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+
+import { RegistrationProfileSetupSheet } from "@/components/profile/RegistrationProfileSetupSheet";
+
+jest.mock("@expo/vector-icons", () => ({ Ionicons: "View" }));
+
+describe("RegistrationProfileSetupSheet", () => {
+  it("shows generated username as read-only onboarding context", () => {
+    const { getByText } = render(
+      <RegistrationProfileSetupSheet
+        visible={true}
+        role="mentor"
+        username="new_user"
+        skills={[]}
+        isLoadingSkills={false}
+        isSubmitting={false}
+        submitError=""
+        onClose={jest.fn()}
+        onSubmit={jest.fn()}
+      />,
+    );
+
+    expect(getByText("Username")).toBeTruthy();
+    expect(getByText("@new_user")).toBeTruthy();
+    expect(
+      getByText(
+        "Your username is generated during registration. It is shown here for reference and cannot be edited in the current backend flow.",
+      ),
+    ).toBeTruthy();
+  });
+});

--- a/mobile/__tests__/components/ui/ConfirmationSheet.test.tsx
+++ b/mobile/__tests__/components/ui/ConfirmationSheet.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { ConfirmationSheet } from "@/components/ui/ConfirmationSheet";
+
+jest.mock("@expo/vector-icons", () => ({ Ionicons: "View" }));
+
+describe("ConfirmationSheet", () => {
+  it("renders title, message, and action labels", () => {
+    const { getByText } = render(
+      <ConfirmationSheet
+        visible={true}
+        title="Remove connection?"
+        message="This will end the mentorship connection."
+        confirmLabel="Remove"
+        cancelLabel="Keep"
+        onConfirm={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+
+    expect(getByText("Remove connection?")).toBeTruthy();
+    expect(getByText("This will end the mentorship connection.")).toBeTruthy();
+    expect(getByText("Remove")).toBeTruthy();
+    expect(getByText("Keep")).toBeTruthy();
+  });
+
+  it("calls handlers for confirm and cancel", () => {
+    const onConfirm = jest.fn();
+    const onCancel = jest.fn();
+    const { getByText } = render(
+      <ConfirmationSheet
+        visible={true}
+        title="Discard changes?"
+        message="Your unsaved changes will be lost."
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    );
+
+    fireEvent.press(getByText("Confirm"));
+    fireEvent.press(getByText("Cancel"));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/__tests__/components/ui/ErrorBanner.test.tsx
+++ b/mobile/__tests__/components/ui/ErrorBanner.test.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+
+import { ErrorBanner } from "@/components/ui/ErrorBanner";
+
+jest.mock("@expo/vector-icons", () => ({ Ionicons: "View" }));
+
+describe("ErrorBanner", () => {
+  it("renders title and message", () => {
+    const { getByText } = render(
+      <ErrorBanner
+        title="Registration failed"
+        message="A user with this email already exists."
+      />,
+    );
+
+    expect(getByText("Registration failed")).toBeTruthy();
+    expect(getByText("A user with this email already exists.")).toBeTruthy();
+  });
+
+  it("does not render for an empty message", () => {
+    const { queryByText } = render(<ErrorBanner message="   " />);
+
+    expect(queryByText("Something went wrong")).toBeNull();
+  });
+});

--- a/mobile/__tests__/components/ui/SuccessCard.test.tsx
+++ b/mobile/__tests__/components/ui/SuccessCard.test.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+
+import { SuccessCard } from "@/components/ui/SuccessCard";
+
+jest.mock("@expo/vector-icons", () => ({ Ionicons: "View" }));
+
+describe("SuccessCard", () => {
+  it("renders the default success title and message", () => {
+    const { getByText } = render(
+      <SuccessCard message="Your session was updated." />,
+    );
+
+    expect(getByText("Success")).toBeTruthy();
+    expect(getByText("Your session was updated.")).toBeTruthy();
+  });
+});

--- a/mobile/app/(tabs)/connections.tsx
+++ b/mobile/app/(tabs)/connections.tsx
@@ -307,25 +307,12 @@ function MentorConnections({ onOpenFeedback, onError }: ConnectionViewProps) {
           }
           const target = managedMentee;
           setManagedMentee(null);
-          Alert.alert(
-            `Remove ${target.name}?`,
-            "This will end the active mentorship connection.",
-            [
-              { text: "Cancel", style: "cancel" },
-              {
-                text: "Remove",
-                style: "destructive",
-                onPress: () => {
-                  void deactivateConnection({
-                    matchIds: target.matchIds,
-                    name: target.name,
-                    mutateAsync: deactivateMatchMutation.mutateAsync,
-                    onError,
-                  });
-                },
-              },
-            ],
-          );
+          void deactivateConnection({
+            matchIds: target.matchIds,
+            name: target.name,
+            mutateAsync: deactivateMatchMutation.mutateAsync,
+            onError,
+          });
         }}
       />
 
@@ -604,25 +591,12 @@ function MenteeConnections({ onOpenFeedback, onError }: ConnectionViewProps) {
           }
           const target = managedMentor;
           setManagedMentor(null);
-          Alert.alert(
-            `Remove ${target.name}?`,
-            "This will end the active mentorship connection.",
-            [
-              { text: "Cancel", style: "cancel" },
-              {
-                text: "Remove",
-                style: "destructive",
-                onPress: () => {
-                  void deactivateConnection({
-                    matchIds: target.matchIds,
-                    name: target.name,
-                    mutateAsync: deactivateMatchMutation.mutateAsync,
-                    onError,
-                  });
-                },
-              },
-            ],
-          );
+          void deactivateConnection({
+            matchIds: target.matchIds,
+            name: target.name,
+            mutateAsync: deactivateMatchMutation.mutateAsync,
+            onError,
+          });
         }}
       />
 
@@ -849,7 +823,6 @@ export default function ConnectionsScreen() {
         onClose={() => setFeedbackConnection(null)}
         onSubmit={handleFeedbackSubmit}
         otherUserName={feedbackConnection?.userName || ""}
-        yourRole={feedbackConnection?.role || "Mentee"}
         isSubmitting={submitFeedbackMutation.isPending}
       />
     </View>

--- a/mobile/app/(tabs)/connections.tsx
+++ b/mobile/app/(tabs)/connections.tsx
@@ -2,7 +2,6 @@ import { useRouter, type Href } from "expo-router";
 import React, { useMemo, useState } from "react";
 import {
   ActivityIndicator,
-  Alert,
   ScrollView,
   Text,
   TouchableOpacity,
@@ -26,6 +25,7 @@ import { RequestDetailSheet } from "@/components/connections/RequestDetailSheet"
 import { RequestCard } from "@/components/dashboard/RequestCard";
 import { RequestDetailsModal } from "@/components/dashboard/RequestDetailsModal";
 import { ErrorBanner } from "@/components/ui/ErrorBanner";
+import { SuccessCard } from "@/components/ui/SuccessCard";
 
 import { useAuthStore } from "@/lib/auth/store";
 import {
@@ -69,12 +69,13 @@ async function deactivateConnection(params: {
   name: string;
   mutateAsync: (matchId: string) => Promise<unknown>;
   onError?: (message: string) => void;
+  onSuccess?: (message: string) => void;
 }): Promise<void> {
   try {
     for (const matchId of params.matchIds) {
       await params.mutateAsync(matchId);
     }
-    Alert.alert("Connection Removed", `${params.name} has been removed.`);
+    params.onSuccess?.(`${params.name} has been removed.`);
   } catch (error) {
     params.onError?.(
       error instanceof Error
@@ -127,6 +128,7 @@ type ConnectionViewProps = Readonly<{
     myRole: "Mentor" | "Mentee",
   ) => void;
   onError: (message: string) => void;
+  onSuccess: (message: string) => void;
 }>;
 
 function pushUserProfile(
@@ -140,7 +142,11 @@ function pushUserProfile(
 // Mentor View
 // ---------------------------------------------------------------------------
 
-function MentorConnections({ onOpenFeedback, onError }: ConnectionViewProps) {
+function MentorConnections({
+  onOpenFeedback,
+  onError,
+  onSuccess,
+}: ConnectionViewProps) {
   const router = useRouter();
   const currentUsername = useAuthStore((state) => state.user?.username);
   const [selectedRequest, setSelectedRequest] =
@@ -312,6 +318,7 @@ function MentorConnections({ onOpenFeedback, onError }: ConnectionViewProps) {
             name: target.name,
             mutateAsync: deactivateMatchMutation.mutateAsync,
             onError,
+            onSuccess,
           });
         }}
       />
@@ -450,7 +457,11 @@ function MentorConnections({ onOpenFeedback, onError }: ConnectionViewProps) {
 // Mentee View
 // ---------------------------------------------------------------------------
 
-function MenteeConnections({ onOpenFeedback, onError }: ConnectionViewProps) {
+function MenteeConnections({
+  onOpenFeedback,
+  onError,
+  onSuccess,
+}: ConnectionViewProps) {
   const router = useRouter();
   const currentUsername = useAuthStore((state) => state.user?.username);
   const [showAllMentors, setShowAllMentors] = useState(false);
@@ -596,6 +607,7 @@ function MenteeConnections({ onOpenFeedback, onError }: ConnectionViewProps) {
             name: target.name,
             mutateAsync: deactivateMatchMutation.mutateAsync,
             onError,
+            onSuccess,
           });
         }}
       />
@@ -749,19 +761,21 @@ export default function ConnectionsScreen() {
     role: "Mentor" | "Mentee";
   } | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   const handleFeedbackSubmit = async (rating: number, text?: string) => {
     if (!feedbackConnection?.matchId) return;
 
     try {
       setActionError(null);
+      setSuccessMessage(null);
       await submitFeedbackMutation.mutateAsync({
         matchId: feedbackConnection.matchId,
         rating,
         text,
       });
       setFeedbackConnection(null);
-      Alert.alert("Review Submitted", "Thank you for your feedback!");
+      setSuccessMessage("Thank you for your feedback!");
     } catch (error) {
       setActionError(
         error instanceof Error ? error.message : "Could not submit feedback.",
@@ -801,9 +815,16 @@ export default function ConnectionsScreen() {
           </View>
         ) : null}
 
+        {successMessage ? (
+          <View className="mb-4">
+            <SuccessCard message={successMessage} />
+          </View>
+        ) : null}
+
         {isMentor ? (
           <MentorConnections
             onError={setActionError}
+            onSuccess={setSuccessMessage}
             onOpenFeedback={(matchId, name, role) =>
               setFeedbackConnection({ matchId, userName: name, role })
             }
@@ -811,6 +832,7 @@ export default function ConnectionsScreen() {
         ) : (
           <MenteeConnections
             onError={setActionError}
+            onSuccess={setSuccessMessage}
             onOpenFeedback={(matchId, name, role) =>
               setFeedbackConnection({ matchId, userName: name, role })
             }

--- a/mobile/app/(tabs)/connections.tsx
+++ b/mobile/app/(tabs)/connections.tsx
@@ -25,6 +25,7 @@ import {
 import { RequestDetailSheet } from "@/components/connections/RequestDetailSheet";
 import { RequestCard } from "@/components/dashboard/RequestCard";
 import { RequestDetailsModal } from "@/components/dashboard/RequestDetailsModal";
+import { ErrorBanner } from "@/components/ui/ErrorBanner";
 
 import { useAuthStore } from "@/lib/auth/store";
 import {
@@ -67,6 +68,7 @@ async function deactivateConnection(params: {
   matchIds: string[];
   name: string;
   mutateAsync: (matchId: string) => Promise<unknown>;
+  onError?: (message: string) => void;
 }): Promise<void> {
   try {
     for (const matchId of params.matchIds) {
@@ -74,8 +76,7 @@ async function deactivateConnection(params: {
     }
     Alert.alert("Connection Removed", `${params.name} has been removed.`);
   } catch (error) {
-    Alert.alert(
-      "Remove Failed",
+    params.onError?.(
       error instanceof Error
         ? error.message
         : "Could not remove this connection.",
@@ -125,6 +126,7 @@ type ConnectionViewProps = Readonly<{
     name: string,
     myRole: "Mentor" | "Mentee",
   ) => void;
+  onError: (message: string) => void;
 }>;
 
 function pushUserProfile(
@@ -138,7 +140,7 @@ function pushUserProfile(
 // Mentor View
 // ---------------------------------------------------------------------------
 
-function MentorConnections({ onOpenFeedback }: ConnectionViewProps) {
+function MentorConnections({ onOpenFeedback, onError }: ConnectionViewProps) {
   const router = useRouter();
   const currentUsername = useAuthStore((state) => state.user?.username);
   const [selectedRequest, setSelectedRequest] =
@@ -230,8 +232,7 @@ function MentorConnections({ onOpenFeedback }: ConnectionViewProps) {
     try {
       await respondMutation.mutateAsync({ requestId: id, action: "accept" });
     } catch (error) {
-      Alert.alert(
-        "Action Failed",
+      onError(
         error instanceof Error
           ? error.message
           : "Something went wrong. Please try again.",
@@ -247,8 +248,7 @@ function MentorConnections({ onOpenFeedback }: ConnectionViewProps) {
           action: "reject",
         });
       } catch (error) {
-        Alert.alert(
-          "Action Failed",
+        onError(
           error instanceof Error
             ? error.message
             : "Something went wrong. Please try again.",
@@ -320,6 +320,7 @@ function MentorConnections({ onOpenFeedback }: ConnectionViewProps) {
                     matchIds: target.matchIds,
                     name: target.name,
                     mutateAsync: deactivateMatchMutation.mutateAsync,
+                    onError,
                   });
                 },
               },
@@ -372,9 +373,7 @@ function MentorConnections({ onOpenFeedback }: ConnectionViewProps) {
 
         {requestsLoading && <ActivityIndicator className="mt-4" />}
         {requestsError && (
-          <Text className="text-[13px] text-error text-center mt-2">
-            Failed to load requests.
-          </Text>
+          <ErrorBanner message="Failed to load requests." />
         )}
         {pendingRequests.length > 0 && (
           <ScrollView
@@ -430,9 +429,7 @@ function MentorConnections({ onOpenFeedback }: ConnectionViewProps) {
 
         {matchesLoading && <ActivityIndicator className="mt-4" />}
         {matchesError && (
-          <Text className="text-[13px] text-error text-center mt-2">
-            Failed to load mentees.
-          </Text>
+          <ErrorBanner message="Failed to load mentees." />
         )}
         {displayedMentees.map((mentee) => (
           <MenteeCard
@@ -466,7 +463,7 @@ function MentorConnections({ onOpenFeedback }: ConnectionViewProps) {
 // Mentee View
 // ---------------------------------------------------------------------------
 
-function MenteeConnections({ onOpenFeedback }: ConnectionViewProps) {
+function MenteeConnections({ onOpenFeedback, onError }: ConnectionViewProps) {
   const router = useRouter();
   const currentUsername = useAuthStore((state) => state.user?.username);
   const [showAllMentors, setShowAllMentors] = useState(false);
@@ -620,6 +617,7 @@ function MenteeConnections({ onOpenFeedback }: ConnectionViewProps) {
                     matchIds: target.matchIds,
                     name: target.name,
                     mutateAsync: deactivateMatchMutation.mutateAsync,
+                    onError,
                   });
                 },
               },
@@ -672,9 +670,7 @@ function MenteeConnections({ onOpenFeedback }: ConnectionViewProps) {
 
         {requestsLoading && <ActivityIndicator className="mt-4" />}
         {requestsError && (
-          <Text className="text-[13px] text-error text-center mt-2">
-            Failed to load requests.
-          </Text>
+          <ErrorBanner message="Failed to load requests." />
         )}
         {pendingRequests.length > 0 && (
           <ScrollView
@@ -734,9 +730,7 @@ function MenteeConnections({ onOpenFeedback }: ConnectionViewProps) {
 
         {matchesLoading && <ActivityIndicator className="mt-4" />}
         {matchesError && (
-          <Text className="text-[13px] text-error text-center mt-2">
-            Failed to load mentors.
-          </Text>
+          <ErrorBanner message="Failed to load mentors." />
         )}
         {displayedMentors.map((mentor) => (
           <MenteeCard
@@ -780,11 +774,13 @@ export default function ConnectionsScreen() {
     userName: string;
     role: "Mentor" | "Mentee";
   } | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   const handleFeedbackSubmit = async (rating: number, text?: string) => {
     if (!feedbackConnection?.matchId) return;
 
     try {
+      setActionError(null);
       await submitFeedbackMutation.mutateAsync({
         matchId: feedbackConnection.matchId,
         rating,
@@ -793,8 +789,7 @@ export default function ConnectionsScreen() {
       setFeedbackConnection(null);
       Alert.alert("Review Submitted", "Thank you for your feedback!");
     } catch (error) {
-      Alert.alert(
-        "Feedback Failed",
+      setActionError(
         error instanceof Error ? error.message : "Could not submit feedback.",
       );
     }
@@ -826,14 +821,22 @@ export default function ConnectionsScreen() {
         }}
         showsVerticalScrollIndicator={false}
       >
+        {actionError ? (
+          <View className="mb-4">
+            <ErrorBanner message={actionError} />
+          </View>
+        ) : null}
+
         {isMentor ? (
           <MentorConnections
+            onError={setActionError}
             onOpenFeedback={(matchId, name, role) =>
               setFeedbackConnection({ matchId, userName: name, role })
             }
           />
         ) : (
           <MenteeConnections
+            onError={setActionError}
             onOpenFeedback={(matchId, name, role) =>
               setFeedbackConnection({ matchId, userName: name, role })
             }

--- a/mobile/app/(tabs)/discover.tsx
+++ b/mobile/app/(tabs)/discover.tsx
@@ -14,6 +14,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { DiscoverFilterModal } from "@/components/discover/DiscoverFilterModal";
 import { DiscoverSearchBar } from "@/components/discover/DiscoverSearchBar";
 import { MentorCard } from "@/components/discover/MentorCard";
+import { ErrorBanner } from "@/components/ui/ErrorBanner";
 import {
   DEMO_DISCOVER_PROFILES,
   DEMO_DISCOVER_SKILLS,
@@ -235,11 +236,7 @@ export default function DiscoverScreen() {
     );
   } else if (errorText) {
     bodyContent = (
-      <View className="bg-error-container dark:bg-red-950 border border-error dark:border-red-800 rounded-xl p-4">
-        <Text className="text-error dark:text-red-200 font-semibold">
-          {errorText}
-        </Text>
-      </View>
+      <ErrorBanner message={errorText} />
     );
   } else if (profiles.length === 0) {
     bodyContent = (

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -10,6 +10,7 @@ import { RequestDetailsModal } from "@/components/dashboard/RequestDetailsModal"
 import { RescheduleBottomSheet } from "@/components/dashboard/RescheduleBottomSheet";
 import { SessionCard } from "@/components/dashboard/SessionCard";
 import { SessionDetailsModal } from "@/components/dashboard/SessionDetailsModal";
+import { ErrorBanner } from "@/components/ui/ErrorBanner";
 
 import { Colors } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
@@ -57,6 +58,10 @@ export default function DashboardScreen() {
     () => mapMeetingSessionsToDashboard(meetingSessionsQuery.data ?? []),
     [meetingSessionsQuery.data],
   );
+  const queryError =
+    (requestsQuery.isError && "Failed to load mentorship requests.") ||
+    (meetingSessionsQuery.isError && "Failed to load upcoming sessions.") ||
+    null;
 
   // State for Modals
   const [selectedRequest, setSelectedRequest] =
@@ -64,6 +69,7 @@ export default function DashboardScreen() {
   const [selectedSession, setSelectedSession] =
     useState<DashboardSessionItem | null>(null);
   const [showRescheduleSheet, setShowRescheduleSheet] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
   const [rescheduleSessionId, setRescheduleSessionId] = useState<string | null>(
     null,
   );
@@ -84,6 +90,7 @@ export default function DashboardScreen() {
     }
 
     try {
+      setActionError(null);
       await respondMutation.mutateAsync({
         requestId: selectedRequest.requestId,
         action,
@@ -92,8 +99,7 @@ export default function DashboardScreen() {
       requestsQuery.refetch();
       meetingSessionsQuery.refetch();
     } catch (error) {
-      Alert.alert(
-        "Request Action Failed",
+      setActionError(
         error instanceof Error
           ? error.message
           : "Could not update request status.",
@@ -120,12 +126,12 @@ export default function DashboardScreen() {
     }
 
     try {
+      setActionError(null);
       await cancelSessionMutation.mutateAsync(selectedSession.sessionId);
       setSelectedSession(null);
       Alert.alert("Session Cancelled", "The session was cancelled.");
     } catch (error) {
-      Alert.alert(
-        "Cancel Failed",
+      setActionError(
         error instanceof Error
           ? error.message
           : "Could not cancel the session.",
@@ -135,13 +141,12 @@ export default function DashboardScreen() {
 
   const handleRescheduleSession = () => {
     if (selectedSession?.myRole !== "Mentee") {
-      Alert.alert("Not Available", "Only mentees can reschedule sessions.");
+      setActionError("Only mentees can reschedule sessions.");
       return;
     }
 
     if (!selectedSession.sessionId || !selectedMentorUsername) {
-      Alert.alert(
-        "Cannot Reschedule",
+      setActionError(
         "Could not resolve session details. Please refresh and try again.",
       );
       return;
@@ -178,6 +183,18 @@ export default function DashboardScreen() {
         showsVerticalScrollIndicator={false}
         contentContainerStyle={{ paddingBottom: 160 }}
       >
+        {queryError ? (
+          <View className="mb-4">
+            <ErrorBanner message={queryError} />
+          </View>
+        ) : null}
+
+        {actionError ? (
+          <View className="mb-4">
+            <ErrorBanner message={actionError} />
+          </View>
+        ) : null}
+
         {/* Requests Section */}
         <View className="mb-6">
           <View className="flex-row justify-between items-center mb-3 mt-2">
@@ -293,13 +310,13 @@ export default function DashboardScreen() {
                 newSlotId,
               })
               .then(() => {
+                setActionError(null);
                 setSelectedSession(null);
                 setShowRescheduleSheet(false);
                 Alert.alert("Session Rescheduled", "Your session was updated.");
               })
               .catch((error) => {
-                Alert.alert(
-                  "Reschedule Failed",
+                setActionError(
                   error instanceof Error
                     ? error.message
                     : "Could not reschedule this session.",

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -1,7 +1,7 @@
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import { useMemo, useState } from "react";
-import { Alert, ScrollView, Text, TouchableOpacity, View } from "react-native";
+import { ScrollView, Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 // Import the components for the dashboard
@@ -11,6 +11,7 @@ import { RescheduleBottomSheet } from "@/components/dashboard/RescheduleBottomSh
 import { SessionCard } from "@/components/dashboard/SessionCard";
 import { SessionDetailsModal } from "@/components/dashboard/SessionDetailsModal";
 import { ErrorBanner } from "@/components/ui/ErrorBanner";
+import { SuccessCard } from "@/components/ui/SuccessCard";
 
 import { Colors } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
@@ -70,6 +71,7 @@ export default function DashboardScreen() {
     useState<DashboardSessionItem | null>(null);
   const [showRescheduleSheet, setShowRescheduleSheet] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [rescheduleSessionId, setRescheduleSessionId] = useState<string | null>(
     null,
   );
@@ -91,6 +93,7 @@ export default function DashboardScreen() {
 
     try {
       setActionError(null);
+      setSuccessMessage(null);
       await respondMutation.mutateAsync({
         requestId: selectedRequest.requestId,
         action,
@@ -98,6 +101,11 @@ export default function DashboardScreen() {
       setSelectedRequest(null);
       requestsQuery.refetch();
       meetingSessionsQuery.refetch();
+      setSuccessMessage(
+        action === "accept"
+          ? "Request accepted successfully."
+          : "Request rejected successfully.",
+      );
     } catch (error) {
       setActionError(
         error instanceof Error
@@ -127,9 +135,10 @@ export default function DashboardScreen() {
 
     try {
       setActionError(null);
+      setSuccessMessage(null);
       await cancelSessionMutation.mutateAsync(selectedSession.sessionId);
       setSelectedSession(null);
-      Alert.alert("Session Cancelled", "The session was cancelled.");
+      setSuccessMessage("The session was cancelled.");
     } catch (error) {
       setActionError(
         error instanceof Error
@@ -155,6 +164,7 @@ export default function DashboardScreen() {
     setRescheduleSessionId(selectedSession.sessionId);
     setRescheduleSessionMentorUsername(selectedMentorUsername);
     setRescheduleCurrentSlotId(selectedSession.id);
+    setSuccessMessage(null);
     setShowRescheduleSheet(true);
   };
 
@@ -186,6 +196,12 @@ export default function DashboardScreen() {
         {queryError ? (
           <View className="mb-4">
             <ErrorBanner message={queryError} />
+          </View>
+        ) : null}
+
+        {successMessage ? (
+          <View className="mb-4">
+            <SuccessCard message={successMessage} />
           </View>
         ) : null}
 
@@ -274,8 +290,7 @@ export default function DashboardScreen() {
         onAccept={() => handleRespond("accept")}
         onReject={() => handleRespond("reject")}
         onCancelOutgoing={() => {
-          Alert.alert(
-            "Not Supported Yet",
+          setActionError(
             "Outgoing request cancellation is not available on the current API.",
           );
         }}
@@ -311,9 +326,9 @@ export default function DashboardScreen() {
               })
               .then(() => {
                 setActionError(null);
+                setSuccessMessage("Your session was updated.");
                 setSelectedSession(null);
                 setShowRescheduleSheet(false);
-                Alert.alert("Session Rescheduled", "Your session was updated.");
               })
               .catch((error) => {
                 setActionError(

--- a/mobile/app/(tabs)/profile.tsx
+++ b/mobile/app/(tabs)/profile.tsx
@@ -14,6 +14,7 @@ import { EditSkillsModal } from "@/components/profile/EditSkillsModal";
 import { ProfileHeader } from "@/components/profile/ProfileHeader";
 import { SkillsCloud } from "@/components/profile/SkillsCloud";
 import { ViewAllSkillsModal } from "@/components/profile/ViewAllSkillsModal";
+import { ErrorBanner } from "@/components/ui/ErrorBanner";
 
 import { API_BASE_URL } from "@/constants/api";
 import { useAuthStore } from "@/lib/auth/store";
@@ -84,6 +85,7 @@ export default function ProfileScreen() {
   }, [authUser?.username]);
 
   const [availableSkills, setAvailableSkills] = useState<string[]>([]);
+  const [pageError, setPageError] = useState<string | null>(null);
   const [isAvailabilityModalOpen, setAvailabilityModalOpen] = useState(false);
   const [isEditProfileModalOpen, setEditProfileModalOpen] = useState(false);
 
@@ -117,6 +119,7 @@ export default function ProfileScreen() {
         if (!mounted) {
           return;
         }
+        setPageError(null);
 
         setUserData((prev) => ({
           ...prev,
@@ -130,6 +133,7 @@ export default function ProfileScreen() {
         if (!mounted) {
           return;
         }
+        setPageError("Failed to load profile.");
       });
 
     return () => {
@@ -232,6 +236,7 @@ export default function ProfileScreen() {
     }
 
     try {
+      setPageError(null);
       const response = await updateProfileMutation.mutateAsync({
         username: currentUsername,
         display_name: updatedData.name,
@@ -242,8 +247,7 @@ export default function ProfileScreen() {
         bio: response.bio || updatedData.bio,
       });
     } catch (error) {
-      Alert.alert(
-        "Profile Update Failed",
+      setPageError(
         error instanceof Error
           ? error.message
           : "Could not update profile details.",
@@ -262,13 +266,13 @@ export default function ProfileScreen() {
     }
 
     try {
+      setPageError(null);
       await updateProfileMutation.mutateAsync({
         username: currentUsername,
         skills: nextSkills,
       });
     } catch (error) {
-      Alert.alert(
-        "Skill Update Failed",
+      setPageError(
         error instanceof Error ? error.message : "Could not update skills.",
       );
     }
@@ -312,6 +316,12 @@ export default function ProfileScreen() {
         showsVerticalScrollIndicator={false}
         contentContainerStyle={{ paddingBottom: 160 }}
       >
+        {pageError ? (
+          <View className="px-4 pt-4">
+            <ErrorBanner message={pageError} />
+          </View>
+        ) : null}
+
         <ProfileHeader
           name={userData.name}
           bio={userData.bio}

--- a/mobile/app/(tabs)/profile.tsx
+++ b/mobile/app/(tabs)/profile.tsx
@@ -1,7 +1,7 @@
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import React, { useEffect, useMemo, useState } from "react";
-import { Alert, ScrollView, Text, TouchableOpacity, View } from "react-native";
+import { ScrollView, Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { AvailabilityPreview } from "@/components/profile/AvailabilityPreview";

--- a/mobile/app/(tabs)/schedule.tsx
+++ b/mobile/app/(tabs)/schedule.tsx
@@ -8,6 +8,7 @@ import { RescheduleBottomSheet } from "@/components/dashboard/RescheduleBottomSh
 import { SessionCard } from "@/components/dashboard/SessionCard";
 import { SessionDetailsModal } from "@/components/dashboard/SessionDetailsModal";
 import { ErrorBanner } from "@/components/ui/ErrorBanner";
+import { SuccessCard } from "@/components/ui/SuccessCard";
 
 import { Colors } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
@@ -20,7 +21,7 @@ import {
   useRescheduleSessionMutation,
 } from "@/lib/queries/mentorship";
 import React, { useMemo, useState } from "react";
-import { Alert, ScrollView, Text, View } from "react-native";
+import { ScrollView, Text, View } from "react-native";
 import { Calendar, DateData } from "react-native-calendars";
 import {
   SafeAreaView,
@@ -61,6 +62,7 @@ export default function ScheduleScreen() {
     useState<ScheduleSession | null>(null);
   const [showRescheduleSheet, setShowRescheduleSheet] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [rescheduleSessionId, setRescheduleSessionId] = useState<string | null>(
     null,
   );
@@ -105,12 +107,12 @@ export default function ScheduleScreen() {
       })
       .then(() => {
         setActionError(null);
+        setSuccessMessage("Your session was updated.");
         setSelectedSession(null);
         setShowRescheduleSheet(false);
         setRescheduleSessionId(null);
         setRescheduleMentorUsername("");
         setRescheduleCurrentSlotId("");
-        Alert.alert("Session Rescheduled", "Your session was updated.");
       })
       .catch((error) => {
         setActionError(
@@ -183,6 +185,12 @@ export default function ScheduleScreen() {
         {queryError ? (
           <View className="px-4 mb-4">
             <ErrorBanner message={queryError} />
+          </View>
+        ) : null}
+
+        {successMessage ? (
+          <View className="px-4 mb-4">
+            <SuccessCard message={successMessage} />
           </View>
         ) : null}
 
@@ -281,8 +289,8 @@ export default function ScheduleScreen() {
             .mutateAsync(selectedSession.sessionId)
             .then(() => {
               setActionError(null);
+              setSuccessMessage("The session was cancelled.");
               setSelectedSession(null);
-              Alert.alert("Session Cancelled", "The session was cancelled.");
             })
             .catch((error) => {
               setActionError(
@@ -317,10 +325,7 @@ export default function ScheduleScreen() {
         onLeaveFeedback={() => {
           // Navigate to feedback screen or show feedback modal
           setSelectedSession(null);
-          Alert.alert(
-            "Leave Feedback",
-            "Feedback submission feature coming soon.",
-          );
+          setActionError("Feedback submission feature coming soon.");
         }}
       />
     </SafeAreaView>

--- a/mobile/app/(tabs)/schedule.tsx
+++ b/mobile/app/(tabs)/schedule.tsx
@@ -42,8 +42,6 @@ type ScheduleSession = {
   status: "Pending" | "Upcoming" | "Completed";
   topic: string;
   myRole: string;
-  location?: string;
-  meetingUrl?: string;
 };
 
 const formatFriendlyDate = (dateString: string) => {

--- a/mobile/app/(tabs)/schedule.tsx
+++ b/mobile/app/(tabs)/schedule.tsx
@@ -322,11 +322,6 @@ export default function ScheduleScreen() {
           setRescheduleCurrentSlotId(selectedSession.slotId);
           setShowRescheduleSheet(true);
         }}
-        onLeaveFeedback={() => {
-          // Navigate to feedback screen or show feedback modal
-          setSelectedSession(null);
-          setActionError("Feedback submission feature coming soon.");
-        }}
       />
     </SafeAreaView>
   );

--- a/mobile/app/(tabs)/schedule.tsx
+++ b/mobile/app/(tabs)/schedule.tsx
@@ -7,6 +7,7 @@
 import { RescheduleBottomSheet } from "@/components/dashboard/RescheduleBottomSheet";
 import { SessionCard } from "@/components/dashboard/SessionCard";
 import { SessionDetailsModal } from "@/components/dashboard/SessionDetailsModal";
+import { ErrorBanner } from "@/components/ui/ErrorBanner";
 
 import { Colors } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
@@ -59,6 +60,7 @@ export default function ScheduleScreen() {
   const [selectedSession, setSelectedSession] =
     useState<ScheduleSession | null>(null);
   const [showRescheduleSheet, setShowRescheduleSheet] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
   const [rescheduleSessionId, setRescheduleSessionId] = useState<string | null>(
     null,
   );
@@ -87,6 +89,9 @@ export default function ScheduleScreen() {
       ),
     [meetingSessionsQuery.data],
   );
+  const queryError = meetingSessionsQuery.isError
+    ? "Failed to load upcoming sessions."
+    : null;
 
   const mentorAvailabilityForReschedule = useAvailabilitySlotsQuery(
     rescheduleMentorUsername,
@@ -99,6 +104,7 @@ export default function ScheduleScreen() {
         newSlotId,
       })
       .then(() => {
+        setActionError(null);
         setSelectedSession(null);
         setShowRescheduleSheet(false);
         setRescheduleSessionId(null);
@@ -107,8 +113,7 @@ export default function ScheduleScreen() {
         Alert.alert("Session Rescheduled", "Your session was updated.");
       })
       .catch((error) => {
-        Alert.alert(
-          "Reschedule Failed",
+        setActionError(
           error instanceof Error
             ? error.message
             : "Could not reschedule this session.",
@@ -175,6 +180,18 @@ export default function ScheduleScreen() {
       </View>
 
       <ScrollView className="flex-1 pt-4" showsVerticalScrollIndicator={false}>
+        {queryError ? (
+          <View className="px-4 mb-4">
+            <ErrorBanner message={queryError} />
+          </View>
+        ) : null}
+
+        {actionError ? (
+          <View className="px-4 mb-4">
+            <ErrorBanner message={actionError} />
+          </View>
+        ) : null}
+
         <View className="mx-4 mb-6 shadow-sm rounded-2xl border border-divider dark:border-divider-dark bg-surface-card dark:bg-surface-card-dark p-2">
           <Calendar
             current={TODAY}
@@ -254,8 +271,7 @@ export default function ScheduleScreen() {
         }
         onCancelSession={() => {
           if (!selectedSession?.sessionId) {
-            Alert.alert(
-              "Cannot Cancel",
+            setActionError(
               "Could not resolve this session's match. Please refresh and try again.",
             );
             return;
@@ -264,12 +280,12 @@ export default function ScheduleScreen() {
           cancelSessionMutation
             .mutateAsync(selectedSession.sessionId)
             .then(() => {
+              setActionError(null);
               setSelectedSession(null);
               Alert.alert("Session Cancelled", "The session was cancelled.");
             })
             .catch((error) => {
-              Alert.alert(
-                "Cancellation Failed",
+              setActionError(
                 error instanceof Error
                   ? error.message
                   : "Could not cancel this session.",
@@ -280,15 +296,14 @@ export default function ScheduleScreen() {
           if (!selectedSession) return;
 
           if (selectedSession.myRole !== "Mentee") {
-            Alert.alert("Not Allowed", "Only mentees can reschedule sessions.");
+            setActionError("Only mentees can reschedule sessions.");
             return;
           }
 
           const mentorUsername = selectedSession.mentorUsername;
 
           if (!selectedSession.sessionId || !mentorUsername) {
-            Alert.alert(
-              "Cannot Reschedule",
+            setActionError(
               "Could not resolve session details. Please refresh and try again.",
             );
             return;

--- a/mobile/app/(tabs)/user/[username].tsx
+++ b/mobile/app/(tabs)/user/[username].tsx
@@ -21,6 +21,7 @@ import {
 import { ProfileHeader } from "@/components/profile/ProfileHeader";
 import { SkillsCloud } from "@/components/profile/SkillsCloud";
 import { ViewAllSkillsModal } from "@/components/profile/ViewAllSkillsModal";
+import { ErrorBanner } from "@/components/ui/ErrorBanner";
 import { API_BASE_URL } from "@/constants/api";
 import { useAuthStore } from "@/lib/auth/store";
 import {
@@ -101,6 +102,7 @@ type BodyContentProps = {
   liveReviewCount?: number;
   menteesHelpedCount: number;
   requestFeedback: string | null;
+  requestFeedbackVariant?: "error" | "warning" | "info" | "success";
   canRequestMentorship: boolean;
   isViewedMentor: boolean;
   availability: AvailabilitySlot[];
@@ -130,6 +132,7 @@ function renderBodyContent({
   liveReviewCount,
   menteesHelpedCount,
   requestFeedback,
+  requestFeedbackVariant = "info",
   canRequestMentorship,
   isViewedMentor,
   availability,
@@ -154,12 +157,7 @@ function renderBodyContent({
   if (error) {
     return (
       <View className="flex-1 items-center justify-center px-4">
-        <View className="bg-white border border-gray-200 rounded-2xl p-5 w-full">
-          <Text className="text-gray-900 font-bold text-base mb-2">
-            Unable to open profile
-          </Text>
-          <Text className="text-gray-500">{error}</Text>
-        </View>
+        <ErrorBanner title="Unable to open profile" message={error} />
       </View>
     );
   }
@@ -232,7 +230,12 @@ function renderBodyContent({
         )}
 
         {!!requestFeedback && (
-          <Text className="text-sm text-gray-600 mb-4">{requestFeedback}</Text>
+          <View className="mb-4">
+            <ErrorBanner
+              message={requestFeedback}
+              variant={requestFeedbackVariant}
+            />
+          </View>
         )}
 
         {isViewedMentor && (
@@ -316,6 +319,9 @@ export default function MentorProfileScreen() {
   const ratingQuery = useProfileRatingQuery(username ?? "");
 
   const [requestFeedback, setRequestFeedback] = useState<string | null>(null);
+  const [requestFeedbackVariant, setRequestFeedbackVariant] = useState<
+    "error" | "warning" | "info" | "success"
+  >("info");
   const [selectedSlot, setSelectedSlot] = useState<SelectedSlot | null>(null);
   const [coverLetter, setCoverLetter] = useState("");
   const [skillsModalConfig, setSkillsModalConfig] = useState<{
@@ -470,11 +476,13 @@ export default function MentorProfileScreen() {
     slotId?: string;
   }) => {
     if (!canRequestMentorship) {
+      setRequestFeedbackVariant("warning");
       setRequestFeedback("Enable mentee mode in Settings to send requests.");
       return;
     }
 
     if (!payload.slotId) {
+      setRequestFeedbackVariant("error");
       setRequestFeedback(
         "Selected slot could not be resolved. Please refresh and try again.",
       );
@@ -497,6 +505,7 @@ export default function MentorProfileScreen() {
     }
 
     setRequestFeedback(null);
+    setRequestFeedbackVariant("info");
     try {
       await createRequestMutation.mutateAsync({
         mentor_username: username,
@@ -510,6 +519,7 @@ export default function MentorProfileScreen() {
 
       setProfile((prev) => prev);
 
+      setRequestFeedbackVariant("success");
       setRequestFeedback("Request sent successfully.");
       Alert.alert(
         "Request Sent",
@@ -519,6 +529,7 @@ export default function MentorProfileScreen() {
       setCoverLetter("");
       availabilitySlotsQuery.refetch();
     } catch (mutationError) {
+      setRequestFeedbackVariant("error");
       setRequestFeedback(
         mutationError instanceof Error
           ? mutationError.message
@@ -533,6 +544,7 @@ export default function MentorProfileScreen() {
     }
 
     setRequestFeedback(null);
+    setRequestFeedbackVariant("info");
     try {
       await bookSlotMutation.mutateAsync({
         mentorUsername: username,
@@ -542,6 +554,7 @@ export default function MentorProfileScreen() {
       setProfile((prev) => prev);
 
       setSelectedSlot(null);
+      setRequestFeedbackVariant("success");
       setRequestFeedback("Session booked successfully.");
       Alert.alert(
         "Session Booked",
@@ -549,6 +562,7 @@ export default function MentorProfileScreen() {
       );
       availabilitySlotsQuery.refetch();
     } catch (mutationError) {
+      setRequestFeedbackVariant("error");
       setRequestFeedback(
         mutationError instanceof Error
           ? mutationError.message
@@ -580,6 +594,7 @@ export default function MentorProfileScreen() {
     }
 
     if (coverLetter.trim().length < 10) {
+      setRequestFeedbackVariant("warning");
       setRequestFeedback(
         "Please provide at least 10 characters about what you want to discuss.",
       );
@@ -602,6 +617,7 @@ export default function MentorProfileScreen() {
     liveReviewCount: ratingQuery.data?.review_count,
     menteesHelpedCount,
     requestFeedback,
+    requestFeedbackVariant,
     canRequestMentorship,
     isViewedMentor,
     availability,

--- a/mobile/app/(tabs)/user/[username].tsx
+++ b/mobile/app/(tabs)/user/[username].tsx
@@ -3,7 +3,6 @@ import { useLocalSearchParams, useRouter } from "expo-router";
 import React, { useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
-  Alert,
   KeyboardAvoidingView,
   Platform,
   ScrollView,
@@ -21,6 +20,7 @@ import {
 import { ProfileHeader } from "@/components/profile/ProfileHeader";
 import { SkillsCloud } from "@/components/profile/SkillsCloud";
 import { ViewAllSkillsModal } from "@/components/profile/ViewAllSkillsModal";
+import { ConfirmationSheet } from "@/components/ui/ConfirmationSheet";
 import { ErrorBanner } from "@/components/ui/ErrorBanner";
 import { API_BASE_URL } from "@/constants/api";
 import { useAuthStore } from "@/lib/auth/store";
@@ -324,6 +324,7 @@ export default function MentorProfileScreen() {
   >("info");
   const [selectedSlot, setSelectedSlot] = useState<SelectedSlot | null>(null);
   const [coverLetter, setCoverLetter] = useState("");
+  const [showBookingConfirmation, setShowBookingConfirmation] = useState(false);
   const [skillsModalConfig, setSkillsModalConfig] = useState<{
     visible: boolean;
     title: string;
@@ -521,10 +522,6 @@ export default function MentorProfileScreen() {
 
       setRequestFeedbackVariant("success");
       setRequestFeedback("Request sent successfully.");
-      Alert.alert(
-        "Request Sent",
-        "Your mentorship request was sent successfully.",
-      );
       setSelectedSlot(null);
       setCoverLetter("");
       availabilitySlotsQuery.refetch();
@@ -556,10 +553,6 @@ export default function MentorProfileScreen() {
       setSelectedSlot(null);
       setRequestFeedbackVariant("success");
       setRequestFeedback("Session booked successfully.");
-      Alert.alert(
-        "Session Booked",
-        "Your session has been booked successfully.",
-      );
       availabilitySlotsQuery.refetch();
     } catch (mutationError) {
       setRequestFeedbackVariant("error");
@@ -577,19 +570,7 @@ export default function MentorProfileScreen() {
     }
 
     if (hasExistingMentorConnection) {
-      Alert.alert(
-        "Confirm Session Booking",
-        `Book this session on ${selectedSlot.day} at ${selectedSlot.label}?`,
-        [
-          { text: "Cancel", style: "cancel" },
-          {
-            text: "Confirm",
-            onPress: () => {
-              void handleBookConnectedSession(selectedSlot);
-            },
-          },
-        ],
-      );
+      setShowBookingConfirmation(true);
       return;
     }
 
@@ -674,6 +655,26 @@ export default function MentorProfileScreen() {
         onClose={() =>
           setSkillsModalConfig((prev) => ({ ...prev, visible: false }))
         }
+      />
+
+      <ConfirmationSheet
+        visible={showBookingConfirmation}
+        title="Book this session?"
+        message={
+          selectedSlot
+            ? `Book this session on ${selectedSlot.day} at ${selectedSlot.label}?`
+            : "Confirm this booking?"
+        }
+        confirmLabel="Confirm"
+        cancelLabel="Cancel"
+        onCancel={() => setShowBookingConfirmation(false)}
+        onConfirm={() => {
+          const slot = selectedSlot;
+          setShowBookingConfirmation(false);
+          if (slot) {
+            void handleBookConnectedSession(slot);
+          }
+        }}
       />
     </View>
   );

--- a/mobile/app/login.tsx
+++ b/mobile/app/login.tsx
@@ -14,6 +14,7 @@ import { router, type Href } from "expo-router";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 
+import { ErrorBanner } from "@/components/ui/ErrorBanner";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { Colors } from "@/constants/theme";
 import { useLoginMutation } from "@/lib/queries/auth";
@@ -109,11 +110,7 @@ export default function LoginScreen() {
           <View className="gap-5">
             {/* Error Message */}
             {(loginMutation.error || localError) && (
-              <View className="p-3 rounded-lg bg-error/10 dark:bg-error-dark/10 border border-error dark:border-error-dark">
-                <Text className="text-sm font-medium text-error dark:text-error-dark">
-                  {localError || loginMutation.error?.message}
-                </Text>
-              </View>
+              <ErrorBanner message={localError || loginMutation.error?.message || ""} />
             )}
 
             {/* Email / Username */}
@@ -184,9 +181,6 @@ export default function LoginScreen() {
                   accessibilityLabel="Password"
                   onSubmitEditing={handleLogin}
                 />
-                {/* Pressable avoids the stuck-opacity bug that TouchableOpacity
-                    (which wraps children in Animated.View) causes when secureTextEntry
-                    toggles rebuild the TextInput and interrupt the fade animation. */}
                 <Pressable
                   onPress={() => setShowPassword((prev) => !prev)}
                   style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}

--- a/mobile/app/register.tsx
+++ b/mobile/app/register.tsx
@@ -15,6 +15,7 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { RegistrationProfileSetupSheet } from "@/components/profile/RegistrationProfileSetupSheet";
+import { ErrorBanner } from "@/components/ui/ErrorBanner";
 import { Colors } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { useAuthStore } from "@/lib/auth/store";
@@ -505,11 +506,7 @@ export default function RegisterScreen() {
 
             {/* CTA + Log In link */}
             <View className="gap-5 pt-4">
-              {submitError ? (
-                <Text className="text-xs text-red-500 text-center">
-                  {submitError}
-                </Text>
-              ) : null}
+              {submitError ? <ErrorBanner message={submitError} /> : null}
               <TouchableOpacity
                 className="w-full h-16 rounded-xl items-center justify-center flex-row gap-3 bg-primary dark:bg-primary-dim"
                 activeOpacity={0.88}

--- a/mobile/app/register.tsx
+++ b/mobile/app/register.tsx
@@ -24,7 +24,6 @@ import {
   registerFn,
   updateProfileFn,
   updateUsageModeFn,
-  type AuthResponse,
 } from "@/lib/queries/authQueries";
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -43,6 +42,12 @@ function validatePassword(value: string): string {
     return "Password must contain at least one uppercase letter.";
   if (!/\d/.test(value)) return "Password must contain at least one number.";
   return "";
+}
+
+function buildUsernamePreview(email: string): string {
+  const localPart = email.trim().toLowerCase().split("@")[0] ?? "";
+  const sanitized = localPart.replace(/[^a-z0-9._-]/g, "");
+  return sanitized || "assigned during registration";
 }
 
 function getRegistrationValidationErrors(params: {
@@ -92,12 +97,6 @@ export default function RegisterScreen() {
   const [termsError, setTermsError] = useState("");
   const [submitError, setSubmitError] = useState("");
   const [profileSetupVisible, setProfileSetupVisible] = useState(false);
-  const [pendingUser, setPendingUser] = useState<{
-    accessToken: string;
-    refreshToken: string;
-    username: string;
-    user: AuthResponse["user"];
-  } | null>(null);
 
   const {
     data: skillsData,
@@ -113,36 +112,38 @@ export default function RegisterScreen() {
 
   // ── Mutations ──────────────────────────────────────────────────────────────
 
-  const completeProfileSetup = useMutation({
+  const completeRegistration = useMutation({
     mutationFn: async (params: {
       displayName: string;
       bio: string;
       selectedSkills: string[];
     }) => {
-      if (!pendingUser) {
-        throw new Error("Registration session not found. Please try again.");
-      }
+      const registration = await registerFn({
+        email: email.trim(),
+        password,
+        confirm_password: confirmPassword,
+      });
 
       await updateUsageModeFn({
         app_usage_mode: role.toUpperCase() as "MENTOR" | "MENTEE",
-        accessToken: pendingUser.accessToken,
+        accessToken: registration.access_token,
       });
 
       const finalizedUser = {
-        ...pendingUser.user,
+        ...registration.user,
         app_usage_mode: role.toUpperCase() as "MENTOR" | "MENTEE",
       };
 
       await updateProfileFn({
-        accessToken: pendingUser.accessToken,
+        accessToken: registration.access_token,
         display_name: params.displayName,
         bio: params.bio.trim() || undefined,
         skills: params.selectedSkills,
       });
 
       await setAuthenticated(finalizedUser, {
-        access_token: pendingUser.accessToken,
-        refresh_token: pendingUser.refreshToken,
+        access_token: registration.access_token,
+        refresh_token: registration.refresh_token,
       });
     },
     onSuccess: () => {
@@ -153,27 +154,7 @@ export default function RegisterScreen() {
     },
   });
 
-  const register = useMutation({
-    mutationFn: registerFn,
-    onSuccess: async (data: AuthResponse) => {
-      setPendingUser({
-        accessToken: data.access_token,
-        refreshToken: data.refresh_token,
-        username: data.user.username,
-        user: data.user,
-      });
-      setProfileSetupVisible(true);
-
-      if (!skillsData?.length) {
-        void refetchSkills();
-      }
-    },
-    onError: (error: Error) => {
-      setSubmitError(error.message);
-    },
-  });
-
-  const isPending = register.isPending || completeProfileSetup.isPending;
+  const isPending = completeRegistration.isPending;
 
   // ── Handlers ───────────────────────────────────────────────────────────────
 
@@ -212,11 +193,11 @@ export default function RegisterScreen() {
     const hasErrors = Boolean(eErr || pErr || cpErr || tErr);
     if (hasErrors) return;
 
-    register.mutate({
-      email: email.trim(),
-      password,
-      confirm_password: confirmPassword,
-    });
+    setProfileSetupVisible(true);
+
+    if (!skillsData?.length) {
+      void refetchSkills();
+    }
   };
 
   return (
@@ -517,7 +498,7 @@ export default function RegisterScreen() {
                 onPress={handleSubmit}
               >
                 <Text className="text-white font-bold text-lg">
-                  {isPending ? "Creating account…" : "Complete Registration"}
+                  {isPending ? "Creating account…" : "Continue"}
                 </Text>
                 {!isPending && (
                   <Ionicons
@@ -552,16 +533,16 @@ export default function RegisterScreen() {
         role={role}
         skills={skillNames}
         isLoadingSkills={isLoadingSkills}
-        isSubmitting={completeProfileSetup.isPending}
+        isSubmitting={completeRegistration.isPending}
         submitError={submitError}
-        username={pendingUser?.username ?? ""}
+        username={buildUsernamePreview(email)}
         onClose={() => {
           setProfileSetupVisible(false);
-          setPendingUser(null);
+          setSubmitError("");
         }}
         onSubmit={(values) => {
           setSubmitError("");
-          completeProfileSetup.mutate(values);
+          completeRegistration.mutate(values);
         }}
       />
     </SafeAreaView>

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -1,4 +1,5 @@
 import { SettingItem } from "@/components/settings/SettingItem";
+import { ConfirmationSheet } from "@/components/ui/ConfirmationSheet";
 import { ErrorBanner } from "@/components/ui/ErrorBanner";
 import { Colors } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
@@ -66,48 +67,19 @@ export default function SettingsScreen() {
     notifUpdates: false,
   });
   const [actionError, setActionError] = useState<string | null>(null);
+  const [showLogoutConfirmation, setShowLogoutConfirmation] = useState(false);
+  const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
 
   const togglePref = (key: keyof typeof prefs) => {
     setPrefs((prev) => ({ ...prev, [key]: !prev[key] }));
   };
 
   const handleLogout = () => {
-    Alert.alert("Log Out", "Are you sure you want to log out?", [
-      { text: "Cancel", style: "cancel" },
-      {
-        text: "Log Out",
-        style: "destructive",
-        onPress: async () => {
-          try {
-            setActionError(null);
-            await logoutMutation.mutateAsync();
-            router.replace("/login");
-          } catch (error) {
-            console.error("Logout failed:", error);
-            setActionError(
-              error instanceof Error
-                ? error.message
-                : "Failed to log out. Please try again.",
-            );
-          }
-        },
-      },
-    ]);
+    setShowLogoutConfirmation(true);
   };
 
   const handleAccountDeletion = () => {
-    Alert.alert(
-      "Delete Account",
-      "Are you sure you want to permanently delete your account? This action cannot be undone.",
-      [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Delete",
-          style: "destructive",
-          onPress: () => console.log("Account deleted"),
-        },
-      ],
-    );
+    setShowDeleteConfirmation(true);
   };
 
   return (
@@ -265,6 +237,47 @@ export default function SettingsScreen() {
           Version 1.0.0 (MVP)
         </Text>
       </ScrollView>
+
+      <ConfirmationSheet
+        visible={showLogoutConfirmation}
+        title="Log out?"
+        message="You will need to sign in again to access your dashboard."
+        confirmLabel="Log Out"
+        cancelLabel="Stay Logged In"
+        variant="destructive"
+        isConfirming={logoutMutation.isPending}
+        onCancel={() => setShowLogoutConfirmation(false)}
+        onConfirm={async () => {
+          try {
+            setActionError(null);
+            await logoutMutation.mutateAsync();
+            setShowLogoutConfirmation(false);
+            router.replace("/login");
+          } catch (error) {
+            console.error("Logout failed:", error);
+            setShowLogoutConfirmation(false);
+            setActionError(
+              error instanceof Error
+                ? error.message
+                : "Failed to log out. Please try again.",
+            );
+          }
+        }}
+      />
+
+      <ConfirmationSheet
+        visible={showDeleteConfirmation}
+        title="Delete account?"
+        message="This action cannot be undone. Your account deletion flow is not implemented yet."
+        confirmLabel="Delete"
+        cancelLabel="Keep Account"
+        variant="destructive"
+        onCancel={() => setShowDeleteConfirmation(false)}
+        onConfirm={() => {
+          setShowDeleteConfirmation(false);
+          Alert.alert("Not Available", "Account deletion is not implemented yet.");
+        }}
+      />
     </View>
   );
 }

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -1,4 +1,5 @@
 import { SettingItem } from "@/components/settings/SettingItem";
+import { ErrorBanner } from "@/components/ui/ErrorBanner";
 import { Colors } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { useAuthStore } from "@/lib/auth/store";
@@ -64,6 +65,7 @@ export default function SettingsScreen() {
     notifReminders: true,
     notifUpdates: false,
   });
+  const [actionError, setActionError] = useState<string | null>(null);
 
   const togglePref = (key: keyof typeof prefs) => {
     setPrefs((prev) => ({ ...prev, [key]: !prev[key] }));
@@ -77,11 +79,16 @@ export default function SettingsScreen() {
         style: "destructive",
         onPress: async () => {
           try {
+            setActionError(null);
             await logoutMutation.mutateAsync();
             router.replace("/login");
           } catch (error) {
             console.error("Logout failed:", error);
-            Alert.alert("Error", "Failed to log out. Please try again.");
+            setActionError(
+              error instanceof Error
+                ? error.message
+                : "Failed to log out. Please try again.",
+            );
           }
         },
       },
@@ -132,6 +139,12 @@ export default function SettingsScreen() {
         showsVerticalScrollIndicator={false}
         contentContainerStyle={{ paddingBottom: 60 }}
       >
+        {actionError ? (
+          <View className="px-4 pt-4">
+            <ErrorBanner message={actionError} />
+          </View>
+        ) : null}
+
         {/* Section: Account Role */}
         <Text className="text-xs font-bold text-on-surface-muted dark:text-on-surface-muted-dark uppercase tracking-wider ml-4 mt-6 mb-2">
           Account Role

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -1,6 +1,7 @@
 import { SettingItem } from "@/components/settings/SettingItem";
 import { ConfirmationSheet } from "@/components/ui/ConfirmationSheet";
 import { ErrorBanner } from "@/components/ui/ErrorBanner";
+import { SuccessCard } from "@/components/ui/SuccessCard";
 import { Colors } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { useAuthStore } from "@/lib/auth/store";
@@ -9,7 +10,7 @@ import { useLogoutMutation } from "@/lib/queries/auth";
 import { Ionicons } from "@expo/vector-icons";
 import { Stack, useRouter } from "expo-router";
 import React, { useState } from "react";
-import { Alert, ScrollView, Text, TouchableOpacity, View } from "react-native";
+import { ScrollView, Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 export default function SettingsScreen() {
@@ -67,6 +68,8 @@ export default function SettingsScreen() {
     notifUpdates: false,
   });
   const [actionError, setActionError] = useState<string | null>(null);
+  const [infoMessage, setInfoMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [showLogoutConfirmation, setShowLogoutConfirmation] = useState(false);
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
 
@@ -117,6 +120,18 @@ export default function SettingsScreen() {
           </View>
         ) : null}
 
+        {infoMessage ? (
+          <View className="px-4 pt-4">
+            <ErrorBanner message={infoMessage} variant="info" />
+          </View>
+        ) : null}
+
+        {successMessage ? (
+          <View className="px-4 pt-4">
+            <SuccessCard message={successMessage} />
+          </View>
+        ) : null}
+
         {/* Section: Account Role */}
         <Text className="text-xs font-bold text-on-surface-muted dark:text-on-surface-muted-dark uppercase tracking-wider ml-4 mt-6 mb-2">
           Account Role
@@ -126,7 +141,7 @@ export default function SettingsScreen() {
             icon="person-circle-outline"
             label="Role"
             value={roleModeLabel}
-            onPress={() => Alert.alert("Role Policy", roleModeDescription)}
+            onPress={() => setInfoMessage(roleModeDescription)}
           />
         </View>
 
@@ -250,6 +265,7 @@ export default function SettingsScreen() {
         onConfirm={async () => {
           try {
             setActionError(null);
+            setSuccessMessage(null);
             await logoutMutation.mutateAsync();
             setShowLogoutConfirmation(false);
             router.replace("/login");
@@ -275,7 +291,7 @@ export default function SettingsScreen() {
         onCancel={() => setShowDeleteConfirmation(false)}
         onConfirm={() => {
           setShowDeleteConfirmation(false);
-          Alert.alert("Not Available", "Account deletion is not implemented yet.");
+          setInfoMessage("Account deletion is not implemented yet.");
         }}
       />
     </View>

--- a/mobile/components/connections/ConnectionActionsSheet.tsx
+++ b/mobile/components/connections/ConnectionActionsSheet.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { ActivityIndicator, Modal, Pressable, Text, TouchableOpacity, View } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 
+import { ConfirmationSheet } from "@/components/ui/ConfirmationSheet";
+
 interface ConnectionActionsSheetProps {
   visible: boolean;
   name: string;
@@ -23,83 +25,113 @@ export function ConnectionActionsSheet({
   hasReviewed = false,
   isCheckingReview = false,
 }: Readonly<ConnectionActionsSheetProps>) {
+  const [showRemoveConfirmation, setShowRemoveConfirmation] =
+    React.useState(false);
+
+  React.useEffect(() => {
+    if (!visible) {
+      setShowRemoveConfirmation(false);
+    }
+  }, [visible]);
+
   return (
-    <Modal animationType="fade" transparent visible={visible} onRequestClose={onClose}>
-      <View className="flex-1 justify-end">
-        <Pressable className="absolute inset-0 bg-black/40" onPress={onClose} />
+    <>
+      <Modal
+        animationType="fade"
+        transparent
+        visible={visible && !showRemoveConfirmation}
+        onRequestClose={onClose}
+      >
+        <View className="flex-1 justify-end">
+          <Pressable className="absolute inset-0 bg-black/40" onPress={onClose} />
 
-        <View className="bg-surface dark:bg-surface-dark rounded-t-3xl px-5 pt-3 pb-8 border-t border-divider/20">
-          {/* Drag Indicator */}
-          <View className="items-center pb-3">
-            <View className="w-12 h-1.5 rounded-full bg-gray-300 dark:bg-gray-600" />
-          </View>
+          <View className="bg-surface dark:bg-surface-dark rounded-t-3xl px-5 pt-3 pb-8 border-t border-divider/20">
+            {/* Drag Indicator */}
+            <View className="items-center pb-3">
+              <View className="w-12 h-1.5 rounded-full bg-gray-300 dark:bg-gray-600" />
+            </View>
 
-          {/* Header */}
-          <Text className="text-xs font-bold uppercase tracking-wider text-on-surface-muted mb-1">
-            Manage Connection
-          </Text>
-          <Text className="text-[22px] font-extrabold text-on-surface dark:text-white mb-5">
-            {name}
-          </Text>
-
-          {/* VIEW PROFILE BUTTON (Matches Secondary Button) */}
-          <TouchableOpacity
-            activeOpacity={0.85}
-            onPress={onViewProfile}
-            className="flex-row items-center justify-center gap-2 px-4 py-3.5 rounded-lg bg-gray-100 dark:bg-gray-800 mb-3"
-          >
-            <Ionicons name="person-outline" size={18} color="#374151" />
-            <Text className="text-base font-semibold text-gray-700 dark:text-gray-300">
-              View Profile
+            {/* Header */}
+            <Text className="text-xs font-bold uppercase tracking-wider text-on-surface-muted mb-1">
+              Manage Connection
             </Text>
-          </TouchableOpacity>
+            <Text className="text-[22px] font-extrabold text-on-surface dark:text-white mb-5">
+              {name}
+            </Text>
 
-          {/* LEAVE REVIEW BUTTON (Matches Primary Button) */}
-          {onLeaveReview && (
+            {/* VIEW PROFILE BUTTON (Matches Secondary Button) */}
             <TouchableOpacity
-              activeOpacity={hasReviewed ? 1 : 0.85}
-              onPress={hasReviewed ? undefined : onLeaveReview}
-              className={`flex-row items-center justify-center gap-2 px-4 py-3.5 rounded-lg mb-3 ${
-                hasReviewed ? "bg-gray-100 dark:bg-gray-800" : "bg-primary"
-              }`}
+              activeOpacity={0.85}
+              onPress={onViewProfile}
+              className="flex-row items-center justify-center gap-2 px-4 py-3.5 rounded-lg bg-gray-100 dark:bg-gray-800 mb-3"
             >
-              {isCheckingReview ? (
-                <ActivityIndicator size="small" color={hasReviewed ? "#9ca3af" : "#ffffff"} />
-              ) : (
-                <Ionicons
-                  name={hasReviewed ? "checkmark-circle" : "star"}
-                  size={18}
-                  color={hasReviewed ? "#9ca3af" : "#ffffff"}
-                />
-              )}
-              <Text
-                className={`text-base font-semibold ${
-                  hasReviewed ? "text-gray-400 dark:text-gray-500" : "text-white"
-                }`}
-              >
-                {isCheckingReview ? "Checking..." : hasReviewed ? "Reviewed" : "Leave Review"}
+              <Ionicons name="person-outline" size={18} color="#374151" />
+              <Text className="text-base font-semibold text-gray-700 dark:text-gray-300">
+                View Profile
               </Text>
             </TouchableOpacity>
-          )}
 
-          {/* REMOVE CONNECTION BUTTON (Destructive) */}
-          <TouchableOpacity
-            activeOpacity={0.85}
-            onPress={onRemoveConnection}
-            className="flex-row items-center justify-center gap-2 px-4 py-3.5 rounded-lg bg-red-50 dark:bg-red-900/30 border border-red-100 dark:border-red-900/50"
-          >
-            <Ionicons name="trash-outline" size={18} color="#b91c1c" />
-            <Text className="text-base font-semibold text-red-700 dark:text-red-400">
-              Remove Connection
-            </Text>
-          </TouchableOpacity>
+            {/* LEAVE REVIEW BUTTON (Matches Primary Button) */}
+            {onLeaveReview && (
+              <TouchableOpacity
+                activeOpacity={hasReviewed ? 1 : 0.85}
+                onPress={hasReviewed ? undefined : onLeaveReview}
+                className={`flex-row items-center justify-center gap-2 px-4 py-3.5 rounded-lg mb-3 ${
+                  hasReviewed ? "bg-gray-100 dark:bg-gray-800" : "bg-primary"
+                }`}
+              >
+                {isCheckingReview ? (
+                  <ActivityIndicator size="small" color={hasReviewed ? "#9ca3af" : "#ffffff"} />
+                ) : (
+                  <Ionicons
+                    name={hasReviewed ? "checkmark-circle" : "star"}
+                    size={18}
+                    color={hasReviewed ? "#9ca3af" : "#ffffff"}
+                  />
+                )}
+                <Text
+                  className={`text-base font-semibold ${
+                    hasReviewed ? "text-gray-400 dark:text-gray-500" : "text-white"
+                  }`}
+                >
+                  {isCheckingReview ? "Checking..." : hasReviewed ? "Reviewed" : "Leave Review"}
+                </Text>
+              </TouchableOpacity>
+            )}
 
-          {/* CLOSE BUTTON */}
-          <TouchableOpacity activeOpacity={0.8} onPress={onClose} className="items-center justify-center py-4 mt-3">
-            <Text className="text-on-surface-soft dark:text-gray-400 font-bold">Close</Text>
-          </TouchableOpacity>
+            {/* REMOVE CONNECTION BUTTON (Destructive) */}
+            <TouchableOpacity
+              activeOpacity={0.85}
+              onPress={() => setShowRemoveConfirmation(true)}
+              className="flex-row items-center justify-center gap-2 px-4 py-3.5 rounded-lg bg-red-50 dark:bg-red-900/30 border border-red-100 dark:border-red-900/50"
+            >
+              <Ionicons name="trash-outline" size={18} color="#b91c1c" />
+              <Text className="text-base font-semibold text-red-700 dark:text-red-400">
+                Remove Connection
+              </Text>
+            </TouchableOpacity>
+
+            {/* CLOSE BUTTON */}
+            <TouchableOpacity activeOpacity={0.8} onPress={onClose} className="items-center justify-center py-4 mt-3">
+              <Text className="text-on-surface-soft dark:text-gray-400 font-bold">Close</Text>
+            </TouchableOpacity>
+          </View>
         </View>
-      </View>
-    </Modal>
+      </Modal>
+
+      <ConfirmationSheet
+        visible={visible && showRemoveConfirmation}
+        title={`Remove ${name}?`}
+        message="This will end the active mentorship connection."
+        confirmLabel="Remove"
+        cancelLabel="Keep Connection"
+        variant="destructive"
+        onCancel={() => setShowRemoveConfirmation(false)}
+        onConfirm={() => {
+          setShowRemoveConfirmation(false);
+          onRemoveConnection();
+        }}
+      />
+    </>
   );
 }

--- a/mobile/components/connections/FeedbackBottomSheet.tsx
+++ b/mobile/components/connections/FeedbackBottomSheet.tsx
@@ -18,7 +18,6 @@ interface FeedbackBottomSheetProps {
   onClose: () => void;
   onSubmit: (rating: number, text?: string) => Promise<void>;
   otherUserName: string;
-  yourRole: "Mentor" | "Mentee";
   isSubmitting?: boolean;
 }
 
@@ -27,7 +26,6 @@ export function FeedbackBottomSheet({
   onClose,
   onSubmit,
   otherUserName,
-  yourRole,
   isSubmitting = false,
 }: Readonly<FeedbackBottomSheetProps>): React.ReactNode {
   const [rating, setRating] = useState<number>(0);
@@ -118,27 +116,6 @@ export function FeedbackBottomSheet({
             }}
             showsVerticalScrollIndicator={false}
           >
-            {/* Role Badge */}
-            <View className="flex-row items-center gap-2 mb-6">
-              <View
-                className={`px-3 py-1 rounded-full ${
-                  yourRole === "Mentor"
-                    ? "bg-indigo-100 dark:bg-indigo-900"
-                    : "bg-emerald-100 dark:bg-emerald-900"
-                }`}
-              >
-                <Text
-                  className={`text-xs font-bold uppercase tracking-wider ${
-                    yourRole === "Mentor"
-                      ? "text-indigo-700 dark:text-indigo-200"
-                      : "text-emerald-700 dark:text-emerald-200"
-                  }`}
-                >
-                  As {yourRole}
-                </Text>
-              </View>
-            </View>
-
             {/* Star Rating */}
             <View className="mb-2">
               <Text className="text-gray-600 dark:text-gray-300 text-sm font-medium mb-2">

--- a/mobile/components/connections/FeedbackBottomSheet.tsx
+++ b/mobile/components/connections/FeedbackBottomSheet.tsx
@@ -11,6 +11,8 @@ import {
   View,
 } from "react-native";
 
+import { ErrorBanner } from "@/components/ui/ErrorBanner";
+
 interface FeedbackBottomSheetProps {
   visible: boolean;
   onClose: () => void;
@@ -179,10 +181,8 @@ export function FeedbackBottomSheet({
 
             {/* Error Message */}
             {error ? (
-              <View className="bg-red-50 dark:bg-red-900 border border-red-200 dark:border-red-700 rounded-xl p-3 mb-6">
-                <Text className="text-red-600 dark:text-red-200 text-sm font-medium">
-                  {error}
-                </Text>
+              <View className="mb-6">
+                <ErrorBanner message={error} />
               </View>
             ) : null}
           </ScrollView>

--- a/mobile/components/dashboard/SessionDetailsModal.tsx
+++ b/mobile/components/dashboard/SessionDetailsModal.tsx
@@ -15,7 +15,6 @@ interface SessionDetailsModalProps {
   onClose: () => void;
   onReschedule?: () => void;
   onCancelSession?: () => void;
-  onLeaveFeedback?: () => void;
   isCancelling?: boolean;
   session: {
     id?: string;
@@ -34,7 +33,6 @@ export function SessionDetailsModal({
   onClose,
   onReschedule,
   onCancelSession,
-  onLeaveFeedback,
   isCancelling = false,
   session,
 }: Readonly<SessionDetailsModalProps>) {
@@ -48,24 +46,6 @@ export function SessionDetailsModal({
     statusTextClass = "text-green-600";
   } else if (session.status === "Pending") {
     statusTextClass = "text-amber-600";
-  }
-
-  // 1. Primary Action: completed sessions show feedback CTA.
-  let primaryAction: React.ReactNode = null;
-  if (session.status === "Completed") {
-    primaryAction = (
-      <TouchableOpacity
-        className="bg-indigo-600 py-4 rounded-xl items-center mb-3 shadow-sm"
-        onPress={() => {
-          onClose();
-          if (onLeaveFeedback) {
-            setTimeout(() => onLeaveFeedback(), 300);
-          }
-        }}
-      >
-        <Text className="text-white font-bold text-lg">Leave Feedback</Text>
-      </TouchableOpacity>
-    );
   }
 
   return (
@@ -118,13 +98,9 @@ export function SessionDetailsModal({
             </View>
           </View>
 
-          {/* Dynamic Primary Action Button */}
-          {primaryAction}
-
-          {/* 2. Secondary Actions: Hidden completely if session has started or is completed */}
+          {/* Secondary actions are hidden once a session starts or completes. */}
           {!session.isSessionStarted && session.status !== "Completed" && (
             <View className="flex-row justify-between gap-3 mb-2 mt-2">
-              
               {/* RESCHEDULE BUTTON: Only for Mentees */}
               {session.myRole === "Mentee" && (
                 <TouchableOpacity

--- a/mobile/components/dashboard/SessionDetailsModal.tsx
+++ b/mobile/components/dashboard/SessionDetailsModal.tsx
@@ -8,7 +8,6 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
-import { Ionicons } from "@expo/vector-icons";
 
 interface SessionDetailsModalProps {
   visible: boolean;
@@ -25,8 +24,6 @@ interface SessionDetailsModalProps {
     status: string;
     topic?: string;
     myRole?: string;
-    location?: string;
-    meetingUrl?: string;
     isSessionStarted?: boolean;
   } | null;
 }
@@ -63,26 +60,6 @@ export function SessionDetailsModal({
         }}
       >
         <Text className="text-white font-bold text-lg">Leave Feedback</Text>
-      </TouchableOpacity>
-    );
-  } else if (session.location) {
-    primaryAction = (
-      <TouchableOpacity
-        className="bg-blue-600 py-4 rounded-xl items-center mb-3 shadow-sm flex-row justify-center gap-2"
-        onPress={() => console.log(`TODO: Open Maps for ${session.location}`)}
-      >
-        <Ionicons name="location" size={20} color="white" />
-        <Text className="text-white font-bold text-lg">Get Directions</Text>
-      </TouchableOpacity>
-    );
-  } else if (session.meetingUrl) {
-    primaryAction = (
-      <TouchableOpacity
-        className="bg-blue-600 py-4 rounded-xl items-center mb-3 shadow-sm flex-row justify-center gap-2"
-        onPress={() => console.log(`TODO: Open Link ${session.meetingUrl}`)}
-      >
-        <Ionicons name="videocam" size={20} color="white" />
-        <Text className="text-white font-bold text-lg">Join Video Call</Text>
       </TouchableOpacity>
     );
   }
@@ -126,18 +103,6 @@ export function SessionDetailsModal({
               <Text className="text-gray-500 font-medium">Start Time</Text>
               <Text className="text-gray-900 font-semibold">
                 {session.time}
-              </Text>
-            </View>
-
-            <View className="flex-row justify-between mb-3">
-              <Text className="text-gray-500 font-medium">
-                {session.location ? "Location" : "Platform"}
-              </Text>
-              <Text
-                className="text-gray-900 font-semibold text-right flex-1 ml-4"
-                numberOfLines={1}
-              >
-                {session.location || "Video Call"}
               </Text>
             </View>
 

--- a/mobile/components/dashboard/SessionDetailsModal.tsx
+++ b/mobile/components/dashboard/SessionDetailsModal.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import {
   ActivityIndicator,
-  Alert,
   Modal,
   Pressable,
   Text,
   TouchableOpacity,
   View,
 } from "react-native";
+
+import { ConfirmationSheet } from "@/components/ui/ConfirmationSheet";
 
 interface SessionDetailsModalProps {
   visible: boolean;
@@ -37,6 +38,9 @@ export function SessionDetailsModal({
   isCancelling = false,
   session,
 }: Readonly<SessionDetailsModalProps>) {
+  const [showCancelConfirmation, setShowCancelConfirmation] =
+    React.useState(false);
+
   if (!session) return null;
 
   let statusTextClass = "text-gray-600";
@@ -143,24 +147,7 @@ export function SessionDetailsModal({
               <TouchableOpacity
                 className="flex-1 bg-white py-3 rounded-xl items-center border border-gray-300"
                 disabled={isCancelling}
-                onPress={() => {
-                  Alert.alert(
-                    "Cancel Session",
-                    "Are you sure you want to cancel this session?",
-                    [
-                      { text: "Keep Session", style: "cancel" },
-                      {
-                        text: "Cancel Session",
-                        style: "destructive",
-                        onPress: () => {
-                          if (onCancelSession) {
-                            onCancelSession();
-                          }
-                        },
-                      },
-                    ],
-                  );
-                }}
+                onPress={() => setShowCancelConfirmation(true)}
               >
                 {isCancelling ? (
                   <ActivityIndicator size="small" color="#dc2626" />
@@ -174,6 +161,21 @@ export function SessionDetailsModal({
           )}
         </Pressable>
       </Pressable>
+
+      <ConfirmationSheet
+        visible={showCancelConfirmation}
+        title="Cancel session?"
+        message="This will cancel the scheduled mentorship session for both participants."
+        confirmLabel="Cancel Session"
+        cancelLabel="Keep Session"
+        variant="destructive"
+        isConfirming={isCancelling}
+        onCancel={() => setShowCancelConfirmation(false)}
+        onConfirm={() => {
+          setShowCancelConfirmation(false);
+          onCancelSession?.();
+        }}
+      />
     </Modal>
   );
 }

--- a/mobile/components/profile/BookingModal.tsx
+++ b/mobile/components/profile/BookingModal.tsx
@@ -14,6 +14,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 
+import { ConfirmationSheet } from "@/components/ui/ConfirmationSheet";
 import { ErrorBanner } from "@/components/ui/ErrorBanner";
 import { Offering } from "./MentorshipOfferings";
 import type { AvailabilitySlot } from "./AvailabilityPreview";
@@ -143,6 +144,7 @@ export function BookingModal({
   const [selectedSlot, setSelectedSlot] = useState<string | null>(null);
   const [coverLetter, setCoverLetter] = useState("");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [showDiscardConfirmation, setShowDiscardConfirmation] = useState(false);
   const [isCustomTime, setIsCustomTime] = useState(false);
   const [customStartTime, setCustomStartTime] = useState(DEFAULT_START_TIME);
   const [customEndTime, setCustomEndTime] = useState(DEFAULT_END_TIME);
@@ -207,14 +209,7 @@ export function BookingModal({
       return;
     }
 
-    Alert.alert(
-      "Discard Request?",
-      "You have unsaved changes. Are you sure you want to discard this and go back?",
-      [
-        { text: "Keep Editing", style: "cancel" },
-        { text: "Discard", style: "destructive", onPress: onClose },
-      ],
-    );
+    setShowDiscardConfirmation(true);
   };
 
   const getProposedTime = (): string | null => {
@@ -608,6 +603,20 @@ export function BookingModal({
           </TouchableOpacity>
         </View>
       </View>
+
+      <ConfirmationSheet
+        visible={showDiscardConfirmation}
+        title="Discard request?"
+        message="You have unsaved changes. If you leave now, your current selection and message will be lost."
+        confirmLabel="Discard"
+        cancelLabel="Keep Editing"
+        variant="destructive"
+        onCancel={() => setShowDiscardConfirmation(false)}
+        onConfirm={() => {
+          setShowDiscardConfirmation(false);
+          onClose();
+        }}
+      />
     </Modal>
   );
 }

--- a/mobile/components/profile/BookingModal.tsx
+++ b/mobile/components/profile/BookingModal.tsx
@@ -14,6 +14,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 
+import { ErrorBanner } from "@/components/ui/ErrorBanner";
 import { Offering } from "./MentorshipOfferings";
 import type { AvailabilitySlot } from "./AvailabilityPreview";
 
@@ -141,6 +142,7 @@ export function BookingModal({
   );
   const [selectedSlot, setSelectedSlot] = useState<string | null>(null);
   const [coverLetter, setCoverLetter] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isCustomTime, setIsCustomTime] = useState(false);
   const [customStartTime, setCustomStartTime] = useState(DEFAULT_START_TIME);
   const [customEndTime, setCustomEndTime] = useState(DEFAULT_END_TIME);
@@ -154,6 +156,7 @@ export function BookingModal({
     setSelectedDateObj(null);
     setSelectedSlot(null);
     setCoverLetter("");
+    setErrorMessage(null);
     setIsCustomTime(false);
     setCustomStartTime(DEFAULT_START_TIME);
     setCustomEndTime(DEFAULT_END_TIME);
@@ -248,8 +251,7 @@ export function BookingModal({
 
   const submit = async () => {
     if (isFirstBooking && coverLetter.trim().length < 10) {
-      Alert.alert(
-        "Cover Letter too short",
+      setErrorMessage(
         "Please provide a bit more detail about what you want to discuss.",
       );
       return;
@@ -264,6 +266,7 @@ export function BookingModal({
 
     if (onSubmit) {
       try {
+        setErrorMessage(null);
         await onSubmit({
           date: selectedDateObj.date,
           rawDate: selectedDateObj.rawDate,
@@ -274,8 +277,7 @@ export function BookingModal({
         onClose();
       } catch (error) {
         setIsLoading(false);
-        Alert.alert(
-          "Booking Failed",
+        setErrorMessage(
           error instanceof Error ? error.message : "Please try again.",
         );
       }
@@ -297,7 +299,7 @@ export function BookingModal({
   const handlePrimaryAction = async () => {
     const validationError = validateSelection();
     if (validationError) {
-      Alert.alert("Missing Information", validationError);
+      setErrorMessage(validationError);
       return;
     }
 
@@ -307,8 +309,7 @@ export function BookingModal({
         selectedDateObj.rawDate === existingSession.date &&
         finalTime === existingSession.time
       ) {
-        Alert.alert(
-          "No Change Detected",
+        setErrorMessage(
           "You selected the exact same date and time as your current session. Please select a new slot to reschedule.",
         );
         return;
@@ -382,6 +383,12 @@ export function BookingModal({
             className="flex-1 px-6"
             keyboardShouldPersistTaps="handled"
           >
+            {errorMessage ? (
+              <View className="mt-4">
+                <ErrorBanner message={errorMessage} />
+              </View>
+            ) : null}
+
             <View className="bg-indigo-50 border border-indigo-100 rounded-2xl p-5 mb-8 mt-4">
               <View className="flex-row items-center mb-3">
                 <View className="w-10 h-10 bg-white rounded-full items-center justify-center shadow-sm mr-3">
@@ -430,6 +437,7 @@ export function BookingModal({
                           onPress={() => {
                             setSelectedDateObj(dateObj);
                             setSelectedSlot(null);
+                            setErrorMessage(null);
                           }}
                           className={
                             isSelected
@@ -475,6 +483,7 @@ export function BookingModal({
                               onPress={() => {
                                 setSelectedSlot(slot);
                                 setIsCustomTime(false);
+                                setErrorMessage(null);
                               }}
                               className={
                                 isSelected
@@ -506,6 +515,7 @@ export function BookingModal({
                       onPress={() => {
                         setIsCustomTime(true);
                         setSelectedSlot(null);
+                        setErrorMessage(null);
                       }}
                       className={
                         isCustomTime

--- a/mobile/components/profile/BookingModal.tsx
+++ b/mobile/components/profile/BookingModal.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
-  Alert,
   KeyboardAvoidingView,
   Modal,
   Platform,
@@ -16,6 +15,7 @@ import { Ionicons } from "@expo/vector-icons";
 
 import { ConfirmationSheet } from "@/components/ui/ConfirmationSheet";
 import { ErrorBanner } from "@/components/ui/ErrorBanner";
+import { SuccessCard } from "@/components/ui/SuccessCard";
 import { Offering } from "./MentorshipOfferings";
 import type { AvailabilitySlot } from "./AvailabilityPreview";
 
@@ -144,6 +144,7 @@ export function BookingModal({
   const [selectedSlot, setSelectedSlot] = useState<string | null>(null);
   const [coverLetter, setCoverLetter] = useState("");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [showDiscardConfirmation, setShowDiscardConfirmation] = useState(false);
   const [isCustomTime, setIsCustomTime] = useState(false);
   const [customStartTime, setCustomStartTime] = useState(DEFAULT_START_TIME);
@@ -159,6 +160,7 @@ export function BookingModal({
     setSelectedSlot(null);
     setCoverLetter("");
     setErrorMessage(null);
+    setSuccessMessage(null);
     setIsCustomTime(false);
     setCustomStartTime(DEFAULT_START_TIME);
     setCustomEndTime(DEFAULT_END_TIME);
@@ -262,6 +264,7 @@ export function BookingModal({
     if (onSubmit) {
       try {
         setErrorMessage(null);
+        setSuccessMessage(null);
         await onSubmit({
           date: selectedDateObj.date,
           rawDate: selectedDateObj.rawDate,
@@ -281,12 +284,10 @@ export function BookingModal({
 
     setTimeout(() => {
       setIsLoading(false);
-      Alert.alert(
-        isFirstBooking ? "Request Sent!" : "Booking Confirmed!",
+      setSuccessMessage(
         isFirstBooking
           ? `Your request for ${offering.title} on ${selectedDateObj.date} at ${finalTime} has been sent.`
           : `Your booking for ${offering.title} on ${selectedDateObj.date} at ${finalTime} is confirmed.`,
-        [{ text: "Great", onPress: onClose }],
       );
     }, 1500);
   };
@@ -381,6 +382,12 @@ export function BookingModal({
             {errorMessage ? (
               <View className="mt-4">
                 <ErrorBanner message={errorMessage} />
+              </View>
+            ) : null}
+
+            {successMessage ? (
+              <View className="mt-4">
+                <SuccessCard message={successMessage} />
               </View>
             ) : null}
 

--- a/mobile/components/profile/EditAvailabilityModal.tsx
+++ b/mobile/components/profile/EditAvailabilityModal.tsx
@@ -11,6 +11,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 
+import { ErrorBanner } from "@/components/ui/ErrorBanner";
 import {
   useCreateAvailabilitySlotMutation,
   useDeleteAvailabilitySlotMutation,
@@ -108,12 +109,14 @@ export function EditAvailabilityModal({
   const [weekOffset, setWeekOffset] = useState(0);
   const [selectedDayIndex, setSelectedDayIndex] = useState(0);
   const [togglingKey, setTogglingKey] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   useEffect(() => {
     if (visible) {
       setWeekOffset(0);
       setSelectedDayIndex(0);
       setTogglingKey(null);
+      setActionError(null);
     }
   }, [visible]);
 
@@ -180,6 +183,7 @@ export function EditAvailabilityModal({
     setTogglingKey(key);
 
     try {
+      setActionError(null);
       for (const requestId of pendingRequestIds) {
         await respondToRequestMutation.mutateAsync({
           requestId,
@@ -190,8 +194,7 @@ export function EditAvailabilityModal({
       await deleteSlotMutation.mutateAsync(slotId);
       onChanged?.();
     } catch (error) {
-      Alert.alert(
-        "Update Failed",
+      setActionError(
         error instanceof Error
           ? error.message
           : "Could not update availability slot.",
@@ -263,6 +266,7 @@ export function EditAvailabilityModal({
     setTogglingKey(key);
 
     try {
+      setActionError(null);
       await createSlotMutation.mutateAsync({
         date: selectedDateString,
         startTime: `${String(hour).padStart(2, "0")}:00:00`,
@@ -271,8 +275,7 @@ export function EditAvailabilityModal({
 
       onChanged?.();
     } catch (error) {
-      Alert.alert(
-        "Update Failed",
+      setActionError(
         error instanceof Error
           ? error.message
           : "Could not update availability slot.",
@@ -315,6 +318,12 @@ export function EditAvailabilityModal({
         </View>
 
         <View className="px-6 pt-4">
+          {actionError ? (
+            <View className="mb-4">
+              <ErrorBanner message={actionError} />
+            </View>
+          ) : null}
+
           <View className="flex-row items-center justify-between">
             <TouchableOpacity
               className="w-8 h-8 rounded-full items-center justify-center bg-gray-100"

--- a/mobile/components/profile/EditAvailabilityModal.tsx
+++ b/mobile/components/profile/EditAvailabilityModal.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
-  Alert,
   Modal,
   ScrollView,
   Text,
@@ -11,6 +10,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 
+import { ConfirmationSheet } from "@/components/ui/ConfirmationSheet";
 import { ErrorBanner } from "@/components/ui/ErrorBanner";
 import {
   useCreateAvailabilitySlotMutation,
@@ -110,6 +110,12 @@ export function EditAvailabilityModal({
   const [selectedDayIndex, setSelectedDayIndex] = useState(0);
   const [togglingKey, setTogglingKey] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [pendingDeactivation, setPendingDeactivation] = useState<{
+    key: string;
+    slotId: string;
+    pendingRequestIds: string[];
+    count: number;
+  } | null>(null);
 
   useEffect(() => {
     if (visible) {
@@ -117,6 +123,7 @@ export function EditAvailabilityModal({
       setSelectedDayIndex(0);
       setTogglingKey(null);
       setActionError(null);
+      setPendingDeactivation(null);
     }
   }, [visible]);
 
@@ -213,10 +220,7 @@ export function EditAvailabilityModal({
     }
 
     if (isPastHourSlot(selectedDate, hour)) {
-      Alert.alert(
-        "Past Slot",
-        "Past availability slots cannot be modified.",
-      );
+      setActionError("Past availability slots cannot be modified.");
       return;
     }
 
@@ -230,32 +234,19 @@ export function EditAvailabilityModal({
       );
 
       if (existing.is_booked || acceptedRequests.length > 0) {
-        Alert.alert(
-          "Cannot Make Slot Unavailable",
-          `This slot has ${acceptedRequests.length} planned session(s). TODO: Cancelling accepted sessions from availability editing requires a backend endpoint that is not available yet.`,
+        setActionError(
+          `This slot has ${acceptedRequests.length} planned session(s). Cancelling accepted sessions from availability editing is not supported by the current backend.`,
         );
         return;
       }
 
       if (pendingRequests.length > 0) {
-        Alert.alert(
-          "Confirm Make Unavailable",
-          `This will decline ${pendingRequests.length} pending request(s) for this slot and then make it unavailable.`,
-          [
-            { text: "Keep Slot", style: "cancel" },
-            {
-              text: "Make Unavailable",
-              style: "destructive",
-              onPress: () => {
-                void deactivateSlot(
-                  key,
-                  existing.id,
-                  pendingRequests.map((request) => request.id),
-                );
-              },
-            },
-          ],
-        );
+        setPendingDeactivation({
+          key,
+          slotId: existing.id,
+          pendingRequestIds: pendingRequests.map((request) => request.id),
+          count: pendingRequests.length,
+        });
         return;
       }
 
@@ -515,6 +506,33 @@ export function EditAvailabilityModal({
           </View>
         </ScrollView>
       </View>
+
+      <ConfirmationSheet
+        visible={pendingDeactivation !== null}
+        title="Make slot unavailable?"
+        message={
+          pendingDeactivation
+            ? `This will decline ${pendingDeactivation.count} pending request${
+                pendingDeactivation.count > 1 ? "s" : ""
+              } for this slot and then make it unavailable.`
+            : ""
+        }
+        confirmLabel="Make Unavailable"
+        cancelLabel="Keep Slot"
+        variant="destructive"
+        onCancel={() => setPendingDeactivation(null)}
+        onConfirm={() => {
+          const payload = pendingDeactivation;
+          setPendingDeactivation(null);
+          if (payload) {
+            void deactivateSlot(
+              payload.key,
+              payload.slotId,
+              payload.pendingRequestIds,
+            );
+          }
+        }}
+      />
     </Modal>
   );
 }

--- a/mobile/components/profile/ManageOfferingsModal.tsx
+++ b/mobile/components/profile/ManageOfferingsModal.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
 import { 
   View, Text, Modal, TouchableOpacity, ScrollView, 
-  KeyboardAvoidingView, Platform, TextInput, Alert 
+  KeyboardAvoidingView, Platform, TextInput
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
+import { ErrorBanner } from '@/components/ui/ErrorBanner';
 import { Offering } from './MentorshipOfferings';
 
 interface ManageOfferingsModalProps {
@@ -37,12 +38,14 @@ export function ManageOfferingsModal({
   const [selectedDuration, setSelectedDuration] = useState('60 min');
   const [selectedLevel, setSelectedLevel] = useState('All Levels');
   const [selectedIcon, setSelectedIcon] = useState<keyof typeof Ionicons.glyphMap>('bulb-outline');
+  const [formError, setFormError] = useState('');
 
   const handleAdd = () => {
     if (!title.trim()) {
-      Alert.alert('Missing Title', 'Please give your package a title.');
+      setFormError('Please give your package a title.');
       return;
     }
+    setFormError('');
     const newOffering: Offering = {
       id: Date.now().toString(), 
       title: title.trim(),
@@ -91,10 +94,18 @@ export function ManageOfferingsModal({
             {/* 1. QUICK COMPOSER SECTION */}
             <View className="bg-white px-6 pt-6 pb-8 border-b border-gray-100 mb-2">
               <Text className="text-xs font-bold text-gray-500 uppercase tracking-wider mb-4">Create New</Text>
+              {formError ? (
+                <View className="mb-4">
+                  <ErrorBanner message={formError} />
+                </View>
+              ) : null}
               
               <TextInput
                 value={title}
-                onChangeText={setTitle}
+                onChangeText={(value) => {
+                  setTitle(value);
+                  if (formError) setFormError('');
+                }}
                 placeholder="Offering Title (e.g., React Review)"
                 className="bg-gray-50 border border-gray-200 rounded-xl px-4 py-3.5 text-base text-gray-900 font-bold mb-3"
               />

--- a/mobile/components/profile/RegistrationProfileSetupSheet.tsx
+++ b/mobile/components/profile/RegistrationProfileSetupSheet.tsx
@@ -12,6 +12,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { useColorScheme } from "@/hooks/use-color-scheme";
+import { ErrorBanner } from "@/components/ui/ErrorBanner";
 import { Colors } from "@/constants/theme";
 
 type Role = "mentor" | "mentee";
@@ -45,6 +46,14 @@ function buildDisplayNameSuggestion(username: string): string {
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ");
+}
+
+function formatUsername(username: string): string {
+  if (!username) {
+    return "Assigned during registration";
+  }
+
+  return username.startsWith("@") ? username : `@${username}`;
 }
 
 export function RegistrationProfileSetupSheet({
@@ -214,14 +223,25 @@ export function RegistrationProfileSetupSheet({
           keyboardShouldPersistTaps="handled"
         >
           {submitError ? (
-            <View className="mb-4 rounded-xl border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-950/30">
-              <Text className="text-sm font-medium text-red-600 dark:text-red-300">
-                {submitError}
-              </Text>
+            <View className="mb-4">
+              <ErrorBanner message={submitError} />
             </View>
           ) : null}
 
           <View className="gap-5">
+            <View className="rounded-2xl border border-divider dark:border-divider-dark bg-surface-card dark:bg-surface-card-dark px-4 py-4">
+              <Text className="text-xs font-bold tracking-widest uppercase text-on-surface-soft dark:text-on-surface-soft-dark">
+                Username
+              </Text>
+              <Text className="mt-2 text-lg font-semibold text-on-surface dark:text-on-surface-dark">
+                {formatUsername(username)}
+              </Text>
+              <Text className="mt-1 text-sm leading-5 text-on-surface-soft dark:text-on-surface-soft-dark">
+                Your username is generated during registration. It is shown here
+                for reference and cannot be edited in the current backend flow.
+              </Text>
+            </View>
+
             <View className="gap-1.5">
               <Text className="text-xs font-bold tracking-widest uppercase ml-1 text-on-surface-soft dark:text-on-surface-soft-dark">
                 Display Name

--- a/mobile/components/profile/RegistrationProfileSetupSheet.tsx
+++ b/mobile/components/profile/RegistrationProfileSetupSheet.tsx
@@ -236,10 +236,6 @@ export function RegistrationProfileSetupSheet({
               <Text className="mt-2 text-lg font-semibold text-on-surface dark:text-on-surface-dark">
                 {formatUsername(username)}
               </Text>
-              <Text className="mt-1 text-sm leading-5 text-on-surface-soft dark:text-on-surface-soft-dark">
-                Your username is generated during registration. It is shown here
-                for reference and cannot be edited in the current backend flow.
-              </Text>
             </View>
 
             <View className="gap-1.5">

--- a/mobile/components/ui/ConfirmationSheet.tsx
+++ b/mobile/components/ui/ConfirmationSheet.tsx
@@ -1,0 +1,109 @@
+import { Ionicons } from "@expo/vector-icons";
+import React from "react";
+import {
+  ActivityIndicator,
+  Modal,
+  Pressable,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+interface ConfirmationSheetProps {
+  visible: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: "default" | "destructive";
+  isConfirming?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmationSheet({
+  visible,
+  title,
+  message,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  variant = "default",
+  isConfirming = false,
+  onConfirm,
+  onCancel,
+}: Readonly<ConfirmationSheetProps>) {
+  const isDestructive = variant === "destructive";
+
+  return (
+    <Modal
+      animationType="fade"
+      transparent
+      visible={visible}
+      onRequestClose={onCancel}
+    >
+      <Pressable className="flex-1 bg-black/40 justify-end" onPress={onCancel}>
+        <Pressable
+          onPress={(event) => event.stopPropagation()}
+          className="bg-surface dark:bg-surface-dark w-full rounded-t-3xl px-6 pt-4 pb-8 shadow-2xl"
+        >
+          <View className="items-center pb-4">
+            <View className="w-12 h-1.5 rounded-full bg-gray-300 dark:bg-gray-600" />
+          </View>
+
+          <View className="items-center mb-5">
+            <View
+              className={`h-14 w-14 rounded-full items-center justify-center ${
+                isDestructive
+                  ? "bg-red-50 dark:bg-red-950/40"
+                  : "bg-surface-active dark:bg-surface-active-dark"
+              }`}
+            >
+              <Ionicons
+                name={isDestructive ? "warning" : "help-circle"}
+                size={28}
+                color={isDestructive ? "#dc2626" : "#4a7c6f"}
+              />
+            </View>
+          </View>
+
+          <Text className="text-2xl font-extrabold text-center text-on-surface dark:text-on-surface-dark">
+            {title}
+          </Text>
+          <Text className="mt-3 text-base leading-6 text-center text-on-surface-soft dark:text-on-surface-soft-dark">
+            {message}
+          </Text>
+
+          <View className="mt-8 gap-3">
+            <TouchableOpacity
+              activeOpacity={0.9}
+              onPress={onConfirm}
+              disabled={isConfirming}
+              className={`py-4 rounded-xl items-center justify-center ${
+                isDestructive ? "bg-red-600" : "bg-primary dark:bg-primary-dim"
+              }`}
+            >
+              {isConfirming ? (
+                <ActivityIndicator size="small" color="#ffffff" />
+              ) : (
+                <Text className="text-white font-bold text-base">
+                  {confirmLabel}
+                </Text>
+              )}
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              activeOpacity={0.85}
+              onPress={onCancel}
+              disabled={isConfirming}
+              className="py-4 rounded-xl items-center justify-center border border-divider dark:border-divider-dark bg-surface-card dark:bg-surface-card-dark"
+            >
+              <Text className="font-semibold text-on-surface dark:text-on-surface-dark">
+                {cancelLabel}
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}

--- a/mobile/components/ui/ErrorBanner.tsx
+++ b/mobile/components/ui/ErrorBanner.tsx
@@ -1,0 +1,32 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Text, View } from "react-native";
+
+interface ErrorBannerProps {
+  message: string;
+  title?: string;
+}
+
+export function ErrorBanner({
+  message,
+  title = "Something went wrong",
+}: Readonly<ErrorBannerProps>) {
+  if (!message.trim()) {
+    return null;
+  }
+
+  return (
+    <View className="w-full flex-row items-start gap-3 rounded-2xl border border-error/20 bg-error-container px-4 py-3 dark:border-red-900/60 dark:bg-red-950/30">
+      <View className="mt-0.5 h-8 w-8 items-center justify-center rounded-full bg-white/70 dark:bg-red-950/40">
+        <Ionicons name="alert-circle" size={18} color="#ba1a1a" />
+      </View>
+      <View className="flex-1">
+        <Text className="text-sm font-semibold text-error dark:text-red-200">
+          {title}
+        </Text>
+        <Text className="mt-1 text-sm leading-5 text-error dark:text-red-200">
+          {message}
+        </Text>
+      </View>
+    </View>
+  );
+}

--- a/mobile/components/ui/ErrorBanner.tsx
+++ b/mobile/components/ui/ErrorBanner.tsx
@@ -4,26 +4,73 @@ import { Text, View } from "react-native";
 interface ErrorBannerProps {
   message: string;
   title?: string;
+  variant?: "error" | "warning" | "info" | "success";
 }
+
+const VARIANT_STYLES = {
+  error: {
+    title: "Something went wrong",
+    icon: "alert-circle",
+    container:
+      "border-error/20 bg-error-container dark:border-red-900/60 dark:bg-red-950/30",
+    iconWrap: "bg-white/70 dark:bg-red-950/40",
+    iconColor: "#ba1a1a",
+    text: "text-error dark:text-red-200",
+  },
+  warning: {
+    title: "Please check this",
+    icon: "warning",
+    container:
+      "border-amber-200 bg-amber-50 dark:border-amber-900/60 dark:bg-amber-950/30",
+    iconWrap: "bg-white/70 dark:bg-amber-950/40",
+    iconColor: "#b45309",
+    text: "text-amber-800 dark:text-amber-200",
+  },
+  info: {
+    title: "Heads up",
+    icon: "information-circle",
+    container:
+      "border-sky-200 bg-sky-50 dark:border-sky-900/60 dark:bg-sky-950/30",
+    iconWrap: "bg-white/70 dark:bg-sky-950/40",
+    iconColor: "#0369a1",
+    text: "text-sky-800 dark:text-sky-200",
+  },
+  success: {
+    title: "Done",
+    icon: "checkmark-circle",
+    container:
+      "border-emerald-200 bg-emerald-50 dark:border-emerald-900/60 dark:bg-emerald-950/30",
+    iconWrap: "bg-white/70 dark:bg-emerald-950/40",
+    iconColor: "#047857",
+    text: "text-emerald-800 dark:text-emerald-200",
+  },
+} as const;
 
 export function ErrorBanner({
   message,
-  title = "Something went wrong",
+  title,
+  variant = "error",
 }: Readonly<ErrorBannerProps>) {
   if (!message.trim()) {
     return null;
   }
 
+  const styles = VARIANT_STYLES[variant];
+
   return (
-    <View className="w-full flex-row items-start gap-3 rounded-2xl border border-error/20 bg-error-container px-4 py-3 dark:border-red-900/60 dark:bg-red-950/30">
-      <View className="mt-0.5 h-8 w-8 items-center justify-center rounded-full bg-white/70 dark:bg-red-950/40">
-        <Ionicons name="alert-circle" size={18} color="#ba1a1a" />
+    <View
+      className={`w-full flex-row items-start gap-3 rounded-2xl border px-4 py-3 ${styles.container}`}
+    >
+      <View
+        className={`mt-0.5 h-8 w-8 items-center justify-center rounded-full ${styles.iconWrap}`}
+      >
+        <Ionicons name={styles.icon} size={18} color={styles.iconColor} />
       </View>
       <View className="flex-1">
-        <Text className="text-sm font-semibold text-error dark:text-red-200">
-          {title}
+        <Text className={`text-sm font-semibold ${styles.text}`}>
+          {title ?? styles.title}
         </Text>
-        <Text className="mt-1 text-sm leading-5 text-error dark:text-red-200">
+        <Text className={`mt-1 text-sm leading-5 ${styles.text}`}>
           {message}
         </Text>
       </View>

--- a/mobile/components/ui/SuccessCard.tsx
+++ b/mobile/components/ui/SuccessCard.tsx
@@ -1,0 +1,13 @@
+import { ErrorBanner } from "@/components/ui/ErrorBanner";
+
+interface SuccessCardProps {
+  message: string;
+  title?: string;
+}
+
+export function SuccessCard({
+  message,
+  title = "Success",
+}: Readonly<SuccessCardProps>) {
+  return <ErrorBanner message={message} title={title} variant="success" />;
+}


### PR DESCRIPTION
## Related Issue

Closes mobile side of #373 

## Description

This PR improves the professionalism and consistency of the mobile UX around backend-driven states and removes a few mobile behaviors that were not supported by the backend contract.

The main changes are:
- standardized backend error handling with themed in-app error banners across major mobile screens and sheets
- replaced native confirmation alerts with a shared themed confirmation sheet and added a shared success surface for in-app status feedback
- deferred account creation until registration onboarding is completed, reducing the risk of creating incomplete accounts when the flow is interrupted
- updated onboarding to show username as read-only preview context instead of editable data, since username is not writable through the current backend API
- removed unsupported meeting type / platform UI from session details
- removed a legacy session-based feedback path so feedback remains correctly tied to mentor/mentee connections
- added and updated tests to reflect the new UI behavior and interaction model

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or configuration

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code

## Notes

Backend contract checks informed a few mobile decisions in this PR:
- username is still assigned by backend registration flow and is not editable through the current mobile-accessible profile update API
- availability slot payloads do not expose a pending status, so availability preview remains limited to states supported by the current backend response