### PR TITLE
fix: fixed cancellation behavior

### DIFF
--- a/backend/mentorship/services.py
+++ b/backend/mentorship/services.py
@@ -143,9 +143,7 @@ def book_match_session(*, mentor_profile: Profile, slot_id: Any, actor: Any) -> 
         try:
             mentee_profile = Profile.objects.get(user=actor)
             active_match = Match.objects.filter(
-                mentor=mentor_profile,
-                mentee=mentee_profile,
-                is_active=True
+                mentor=mentor_profile, mentee=mentee_profile, is_active=True
             ).first()
 
             if active_match:
@@ -168,22 +166,18 @@ def book_match_session(*, mentor_profile: Profile, slot_id: Any, actor: Any) -> 
         return slot
 
 
-def _mark_latest_meeting_session_canceled(*, match: Match, canceled_by: Profile) -> None:
-    """Mark the latest canonical session for the match as canceled."""
-    meeting_session = MeetingSession.objects.filter(match=match).order_by("-created_at").first()
-    if meeting_session is None:
-        return
-
+def _mark_meeting_session_canceled(*, session: MeetingSession, canceled_by: Profile) -> None:
+    """Mark the provided meeting session as canceled and detach its slot link."""
     canceled_by_role = (
         MeetingSession.CanceledByRole.MENTOR
-        if canceled_by == match.mentor
+        if canceled_by == session.match.mentor
         else MeetingSession.CanceledByRole.MENTEE
     )
-    meeting_session.status = MeetingSession.Status.CANCELED
-    meeting_session.source_slot = None
-    meeting_session.canceled_by_role = canceled_by_role
-    meeting_session.cancel_reason = "Session canceled by participant."
-    meeting_session.save(
+    session.status = MeetingSession.Status.CANCELED
+    session.source_slot = None
+    session.canceled_by_role = canceled_by_role
+    session.cancel_reason = "Session canceled by participant."
+    session.save(
         update_fields=[
             "status",
             "source_slot",
@@ -200,21 +194,28 @@ def cancel_match_session(
     actor: Any,
     actor_profile: Profile,
 ) -> MentorshipRequest:
-    """Cancel the currently booked slot for a session and sync canonical session state."""
+    """Cancel the booked slot for the provided session and sync session state."""
     match = session.match
     mentorship_request = match.request
     slot = session.source_slot
 
-    if slot is None or not slot.is_booked:
-        raise NoActiveBookingError("This session has no active booking to cancel.")
+    # Idempotent behavior: repeated cancellation on an already canceled session
+    # should not fail with a client-visible error.
+    if session.status == MeetingSession.Status.CANCELED:
+        mentorship_request.refresh_from_db()
+        return mentorship_request
 
     with transaction.atomic():
-        cancel_availability_booking(
-            profile=match.mentor,
-            slot_id=slot.id,
-            actor=actor,
-        )
-        _mark_latest_meeting_session_canceled(match=match, canceled_by=actor_profile)
+        # If slot booking is still active, cancel it first.
+        # If booking was already released but session remained scheduled/rescheduled,
+        # proceed to cancel the session to repair consistency.
+        if slot is not None and slot.is_booked:
+            cancel_availability_booking(
+                profile=match.mentor,
+                slot_id=slot.id,
+                actor=actor,
+            )
+        _mark_meeting_session_canceled(session=session, canceled_by=actor_profile)
 
     mentorship_request.refresh_from_db()
     return mentorship_request

--- a/backend/mentorship/tests.py
+++ b/backend/mentorship/tests.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 from typing import Any
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
@@ -863,18 +864,97 @@ class CancelSessionAPIViewTests(MentorshipRequestAPIBaseTestCase):
         response = self.anon_client.post(self._cancel_url(session.id))
         self.assertEqual(response.status_code, 401)
 
-    def test_cancel_unbooked_slot_returns_400(self) -> None:
+    def test_cancel_unbooked_slot_marks_session_canceled(self) -> None:
         match, session = self._setup_active_match_with_booking()
         # Free the slot manually
         self.mentor_slot.mark_available()
         response = self.mentee_client.post(self._cancel_url(session.id))
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 200)
+
+        session.refresh_from_db()
+        self.assertEqual(session.status, MeetingSession.Status.CANCELED)
+        self.assertIsNone(session.source_slot)
 
     def test_nonexistent_session_returns_404(self) -> None:
         import uuid
 
         response = self.mentee_client.post(self._cancel_url(uuid.uuid4()))
         self.assertEqual(response.status_code, 404)
+
+    @patch("mentorship.views.Notification.objects.create", side_effect=IntegrityError("boom"))
+    def test_cancel_succeeds_when_notification_create_fails(self, _mock_create) -> None:
+        """Cancellation should not fail if notification persistence raises an error."""
+        match, session = self._setup_active_match_with_booking()
+
+        response = self.mentee_client.post(self._cancel_url(session.id))
+        self.assertEqual(response.status_code, 200)
+
+        session.refresh_from_db()
+        self.assertEqual(session.status, MeetingSession.Status.CANCELED)
+        self.assertIsNone(session.source_slot)
+
+    def test_canceling_older_session_keeps_newer_session_linked(self) -> None:
+        """Canceling one session must not detach source_slot from another newer session."""
+        request_obj = _create_accepted_request(
+            mentor=self.mentor_profile,
+            mentee=self.mentee_profile,
+            slot=self.mentor_slot,
+        )
+        self.mentor_slot.mark_booked(self.mentee_user)
+
+        match = Match.objects.get(request=request_obj)
+        session_a = MeetingSession.objects.get(match=match, source_slot=self.mentor_slot)
+
+        slot_b_start = timezone.now() + timedelta(days=4)
+        slot_b = AvailabilitySlot.objects.create(
+            profile=self.mentor_profile,
+            start_at=slot_b_start,
+            end_at=slot_b_start + timedelta(hours=1),
+        )
+        slot_c_start = timezone.now() + timedelta(days=5)
+        slot_c = AvailabilitySlot.objects.create(
+            profile=self.mentor_profile,
+            start_at=slot_c_start,
+            end_at=slot_c_start + timedelta(hours=1),
+        )
+
+        book_slot_b_response = self.mentee_client.post(
+            f"/api/profiles/{self.mentor_profile.username}/availability-slots/{slot_b.id}/book/"
+        )
+        self.assertEqual(book_slot_b_response.status_code, 200)
+        session_b = MeetingSession.objects.get(match=match, source_slot=slot_b)
+
+        first_cancel_response = self.mentee_client.post(self._cancel_url(session_b.id))
+        self.assertEqual(first_cancel_response.status_code, 200)
+
+        book_slot_c_response = self.mentee_client.post(
+            f"/api/profiles/{self.mentor_profile.username}/availability-slots/{slot_c.id}/book/"
+        )
+        self.assertEqual(book_slot_c_response.status_code, 200)
+        session_c = MeetingSession.objects.get(match=match, source_slot=slot_c)
+
+        second_cancel_response = self.mentee_client.post(self._cancel_url(session_a.id))
+        self.assertEqual(second_cancel_response.status_code, 200)
+
+        session_c.refresh_from_db()
+        self.assertEqual(session_c.status, MeetingSession.Status.SCHEDULED)
+        self.assertEqual(session_c.source_slot, slot_c)
+
+        availability_response = self.mentee_client.get(
+            f"/api/profiles/{self.mentor_profile.username}/availability-slots/"
+        )
+        self.assertEqual(availability_response.status_code, 200)
+        slot_c_payload = next(
+            item for item in availability_response.data if str(item["id"]) == str(slot_c.id)
+        )
+        self.assertTrue(slot_c_payload["is_booked"])
+        self.assertIsNotNone(slot_c_payload["sessionId"])
+        self.assertEqual(slot_c_payload["sessionId"], str(session_c.id))
+
+        third_cancel_response = self.mentee_client.post(self._cancel_url(session_c.id))
+        self.assertEqual(third_cancel_response.status_code, 200)
+        slot_c.refresh_from_db()
+        self.assertFalse(slot_c.is_booked)
 
 
 class RescheduleSessionAPIViewTests(MentorshipRequestAPIBaseTestCase):

--- a/backend/mentorship/views.py
+++ b/backend/mentorship/views.py
@@ -1,5 +1,6 @@
 """Views for mentorship request and match API endpoints."""
 
+import logging
 from typing import Any, cast
 
 from django.db import IntegrityError
@@ -54,12 +55,25 @@ _MENTEE_REQUIRED = {"detail": "You need a MENTEE profile to send mentorship requ
 _MENTOR_REQUIRED = {"detail": "You need a MENTOR profile to access this resource."}
 _NO_PROFILE = {"detail": "Profile not found."}
 _SLOT_BOOKING_FAILED = {"detail": "Selected slot could not be booked while accepting this request."}
+_NO_ACTIVE_BOOKING = {"detail": "This session has no active booking to cancel."}
 _INVALID_MEETING_SESSION_STATUS = {
     "detail": (
         "Invalid status. Use one of: upcoming, past, scheduled, rescheduled, canceled, completed."
     )
 }
 _INVALID_MEETING_SESSION_ROLE = {"detail": "Invalid role. Use one of: mentor, mentee, all."}
+
+logger = logging.getLogger(__name__)
+
+
+def _create_notification_best_effort(**kwargs: Any) -> None:
+    """Persist notifications without breaking the primary request flow on failure."""
+    try:
+        Notification.objects.create(**kwargs)
+    except IntegrityError as exc:
+        logger.warning("Notification persistence skipped due to integrity error: %s", exc)
+    except Exception:
+        logger.exception("Notification persistence failed for mentorship flow.")
 
 
 class MyRequestsListAPIView(APIView):
@@ -209,11 +223,11 @@ class RespondToRequestAPIView(APIView):
         except AvailabilitySlot.DoesNotExist:
             return Response(_NOT_FOUND, status=status.HTTP_404_NOT_FOUND)
 
-        if new_status == MentorshipRequest.Status.ACCEPTED:
-            Notification.objects.create(
+        if mentorship_request.status == MentorshipRequest.Status.ACCEPTED:
+            _create_notification_best_effort(
                 user=mentorship_request.mentee.user,
-                type='new_match',
-                message='Your mentorship request has been accepted.',
+                type="new_match",
+                message="Your mentorship request has been accepted.",
             )
 
         return Response(
@@ -376,29 +390,19 @@ class CancelSessionAPIView(APIView):
                 actor=request.user,
                 actor_profile=profile,
             )
-        except NoActiveBookingError:
-            return Response(
-                {"detail": "This session has no active booking to cancel."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-        except SlotNotBookedError:
-            return Response(
-                {"detail": "This session has no active booking to cancel."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+        except (NoActiveBookingError, SlotNotBookedError):
+            return Response(_NO_ACTIVE_BOOKING, status=status.HTTP_400_BAD_REQUEST)
         except BookingCancelNotAllowedError:
             return Response(_PERMISSION_DENIED, status=status.HTTP_403_FORBIDDEN)
         except AvailabilitySlot.DoesNotExist:
             return Response(_NOT_FOUND, status=status.HTTP_404_NOT_FOUND)
 
-        mentorship_request.refresh_from_db()
-
         # Notify the other participant
         other_user = match.mentor.user if request.user == match.mentee.user else match.mentee.user
-        Notification.objects.create(
+        _create_notification_best_effort(
             user=other_user,
-            type='session_canceled',
-            message='The session has been canceled.',
+            type="session_canceled",
+            message="The session has been canceled.",
         )
 
         return Response(
@@ -488,13 +492,11 @@ class RescheduleSessionAPIView(APIView):
         except AvailabilitySlot.DoesNotExist:
             return Response(_NOT_FOUND, status=status.HTTP_404_NOT_FOUND)
 
-        mentorship_request.refresh_from_db()
-
         # Notify the mentor
-        Notification.objects.create(
+        _create_notification_best_effort(
             user=match.mentor.user,
-            type='session_rescheduled',
-            message='The session has been rescheduled.',
+            type="session_rescheduled",
+            message="The session has been rescheduled.",
         )
 
         return Response(


### PR DESCRIPTION
## Related Issue

Closes #375 

## Description

This PR fixes the meeting cancellation flow so users can cancel multiple sessions safely and consistently.

Main improvements:
- Cancels the exact requested meeting session instead of canceling the latest session in the same match.
- Makes cancellation idempotent so repeated cancel requests do not fail unexpectedly.
- Prevents successful cancel actions from returning 500 due to notification persistence errors.
- Keeps behavior intact while simplifying view-level logic and removing duplicated branches.

Updated areas:
- services.py
- views.py
- tests.py

## Type of Change

- [x] Bug fix
- [x] Refactoring (no functional changes)

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code

## Notes

Tested with:
- docker compose exec backend python manage.py test mentorship.tests.CancelSessionAPIViewTests
- docker compose exec backend python manage.py test mentorship.tests.CancelSessionAPIViewTests mentorship.tests.RescheduleSessionAPIViewTests

Added regression coverage for:
- Multi-session cancellation ordering bug (older session cancel must not detach newer session).
- Cancellation success when notification creation fails.
- Unbooked-slot cancel path now consistently marks session canceled and returns success.