### PR TITLE
test: increased branch coverage and resolve some sonarqube and pylance issues

### DIFF
--- a/web/src/components/dashboard/ExpertiseEditModal.tsx
+++ b/web/src/components/dashboard/ExpertiseEditModal.tsx
@@ -1,5 +1,5 @@
 // web/src/components/dashboard/ExpertiseEditModal.tsx
-import { useState } from 'react'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -11,15 +11,24 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
-import { Badge } from '@/components/ui/badge'
 import { X } from 'lucide-react'
-import { MOCK_DISCOVER_SKILLS } from '@/lib/mocks/loggedInHome' // Mock data for existing skills. Replace with actual data from backend in the future.
+import { useState } from 'react'
 
-export function ExpertiseEditModal() {
+interface ExpertiseSkill {
+  id: string
+  name: string
+  category: string
+  description: string
+}
+
+interface ExpertiseEditModalProps {
+  initialSkills?: ExpertiseSkill[]
+}
+
+export function ExpertiseEditModal({ initialSkills = [] }: Readonly<ExpertiseEditModalProps>) {
   const [isOpen, setIsOpen] = useState(false)
-  
-  // Local state initialized with our mock data
-  const [skills, setSkills] = useState(MOCK_DISCOVER_SKILLS)
+
+  const [skills, setSkills] = useState<ExpertiseSkill[]>(initialSkills)
   const [newSkillText, setNewSkillText] = useState('')
 
   const handleRemoveSkill = (idToRemove: string) => {

--- a/web/src/components/dashboard/MentorAvailabilityModal.tsx
+++ b/web/src/components/dashboard/MentorAvailabilityModal.tsx
@@ -12,7 +12,6 @@ import {
 } from '@/components/ui/dialog'
 import { Label } from '@/components/ui/label'
 import { Input } from '@/components/ui/input'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Plus, Clock } from 'lucide-react'
 
 export function MentorAvailabilityModal() {

--- a/web/src/components/dashboard/SessionManagementModal.tsx
+++ b/web/src/components/dashboard/SessionManagementModal.tsx
@@ -1,5 +1,5 @@
 // web/src/components/dashboard/SessionManagementModal.tsx
-import { useState } from 'react'
+import { Body, Muted } from '@/components/Typography'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -11,20 +11,38 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
-import { Body, Muted } from '@/components/Typography'
-import { Link2, CalendarDays, Clock, XCircle, Calendar } from 'lucide-react'
-import type { MockMeetingSession } from '@/lib/mocks/loggedInHome'
-
-interface SessionManagementModalProps {
-  session: MockMeetingSession
+import { Calendar, CalendarDays, Clock, Link2, XCircle } from 'lucide-react'
+import { useState } from 'react'
+interface SessionParticipant {
+  id: string
+  username: string
+  fullName: string
+  avatarUrl?: string
+  role: 'mentor' | 'mentee'
 }
 
-export function SessionManagementModal({ session }: SessionManagementModalProps) {
+interface SessionManagementData {
+  id: string
+  title: string
+  description: string
+  startAt: string
+  endAt: string
+  type: 'video' | 'in-person'
+  status: 'upcoming' | 'completed' | 'cancelled'
+  host: SessionParticipant
+  attendee: SessionParticipant
+}
+
+interface SessionManagementModalProps {
+  session: SessionManagementData
+}
+
+export function SessionManagementModal({ session }: Readonly<SessionManagementModalProps>) {
   const [isOpen, setIsOpen] = useState(false)
   const [meetingLink, setMeetingLink] = useState('')
   const [isSaved, setIsSaved] = useState(false)
 
-  const handleSaveLink = (e: React.FormEvent) => {
+  const handleSaveLink = (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault()
     if (!meetingLink.trim()) return
     // FUTURE: Trigger TanStack Query mutation to update the session's meeting link on the backend

--- a/web/src/components/dashboard/__tests__/ExpertiseEditModal.test.tsx
+++ b/web/src/components/dashboard/__tests__/ExpertiseEditModal.test.tsx
@@ -9,16 +9,15 @@ vi.mock('lucide-react', () => ({
   XIcon: () => <span data-testid="icon-close" />,
 }))
 
-// Mock the mock data so our test is predictable and doesn't rely on external files
-vi.mock('@/lib/mocks/loggedInHome', () => ({
-  MOCK_DISCOVER_SKILLS: [
-    { id: '1', name: 'Test Driven Development', category: 'Software', description: 'TDD skills' },
-  ]
-}))
-
 describe('ExpertiseEditModal', () => {
   it('renders the trigger button, opens the modal, and displays current skills', () => {
-    render(<ExpertiseEditModal />)
+    render(
+      <ExpertiseEditModal
+        initialSkills={[
+          { id: '1', name: 'Test Driven Development', category: 'Software', description: 'TDD skills' },
+        ]}
+      />,
+    )
     
     // 1. Verify the button is on the dashboard
     const triggerButton = screen.getByRole('button', { name: /Edit Skills/i })

--- a/web/src/components/layout/UnauthorizedFooter.tsx
+++ b/web/src/components/layout/UnauthorizedFooter.tsx
@@ -1,4 +1,3 @@
-import { useLocation } from '@tanstack/react-router'
 import { Muted } from '@/components/Typography'
 import {NavLink} from '@/components/NavLink'
 

--- a/web/src/components/layout/__test__/AuthorizedHeader.test.tsx
+++ b/web/src/components/layout/__test__/AuthorizedHeader.test.tsx
@@ -8,7 +8,7 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-router')>()
   return {
     ...actual,
-    Link: ({ children, to, className }: any) => <a href={to} className={className}>{children}</a>,
+    Link: ({ children, to, className }: Record<string, unknown>) => <a href={to as string} className={className as string}>{children as React.ReactNode}</a>,
     useNavigate: () => vi.fn(),
     useLocation: () => ({ pathname: '/dashboard' }),
   }

--- a/web/src/components/profile/AvailabilityCalendar.tsx
+++ b/web/src/components/profile/AvailabilityCalendar.tsx
@@ -1,8 +1,8 @@
 import { meQueryOptions } from "#/lib/queries/AuthQueries.ts"
 import {
+    useCancelSession,
     useMyMatches,
-    useSendMentorshipRequest,
-    useCancelSession
+    useSendMentorshipRequest
 } from '#/lib/queries/MentorshipQueries.ts'
 import {
     useAvailabilitySlots,
@@ -20,7 +20,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { CalendarDays, ChevronLeft, ChevronRight, Loader2, X } from 'lucide-react'
 import { useState } from 'react'
 import { createPortal } from 'react-dom'
-import {toast} from "sonner";
+import { toast } from "sonner"
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------

--- a/web/src/components/profile/__tests__/ProfilePageView.test.tsx
+++ b/web/src/components/profile/__tests__/ProfilePageView.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockUseAvailabilitySlots } = vi.hoisted(() => ({
+  mockUseAvailabilitySlots: vi.fn(),
+}))
+
+vi.mock('#/lib/queries/ProfileTimeSlotQueries.ts', () => ({
+  useAvailabilitySlots: (username: string, isMentor: boolean) =>
+    mockUseAvailabilitySlots(username, isMentor),
+}))
+
+vi.mock('#/components/profile/AvailabilityCalendar.tsx', () => ({
+  AvailabilityCalendar: ({ username }: { username: string }) => (
+    <div data-testid="availability-calendar">Calendar for {username}</div>
+  ),
+}))
+
+vi.mock('#/components/profile/EditProfileModal.tsx', () => ({
+  EditProfileModal: ({ mode }: { mode: 'MENTOR' | 'MENTEE' }) => (
+    <div data-testid="edit-profile-modal">Edit modal in {mode} mode</div>
+  ),
+}))
+
+import { ProfilePageView } from '../ProfilePageView'
+
+describe('ProfilePageView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseAvailabilitySlots.mockReturnValue({
+      data: [
+        { id: 'slot-1', is_booked: false },
+        { id: 'slot-2', is_booked: false },
+        { id: 'slot-3', is_booked: true },
+      ],
+    })
+  })
+
+  it('hides private mentor fields from non-owners', () => {
+    render(
+      <ProfilePageView
+        profile={{
+          isMentor: true,
+          username: 'mentor-hidden',
+          full_name: 'Hidden Mentor',
+          bio: 'Private bio',
+          hidden: true,
+          picture_url: '',
+          title: 'Senior Mentor',
+          skills: ['React'],
+          rating: 4.8,
+          total_mentee_count: 15,
+        }}
+        isOwner={false}
+        isAuthenticatedViewer={true}
+      />,
+    )
+
+    expect(screen.getByText(/Bio is hidden by the user/i)).toBeInTheDocument()
+    expect(screen.getByText(/Title is hidden by the user/i)).toBeInTheDocument()
+    expect(screen.getByText(/Rating is hidden by the user/i)).toBeInTheDocument()
+    expect(screen.getByText(/Mentee count is hidden by the user/i)).toBeInTheDocument()
+    expect(screen.queryByTestId('availability-calendar')).not.toBeInTheDocument()
+    expect(mockUseAvailabilitySlots).toHaveBeenCalledWith('mentor-hidden', true)
+  })
+
+  it('shows mentor snapshot/calendar and opens edit modal for owner', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ProfilePageView
+        profile={{
+          isMentor: true,
+          username: 'mentor-public',
+          full_name: 'Public Mentor',
+          bio: 'I help with systems design.',
+          hidden: false,
+          picture_url: '',
+          title: 'Principal Engineer',
+          skills: ['Systems Design', 'TypeScript'],
+          rating: 4.6,
+          total_mentee_count: 22,
+        }}
+        isOwner={true}
+        isAuthenticatedViewer={true}
+      />,
+    )
+
+    expect(screen.getByText('Open Slots')).toBeInTheDocument()
+    expect(screen.getByTestId('availability-calendar')).toHaveTextContent('Calendar for mentor-public')
+
+    await user.click(screen.getByRole('button', { name: /Edit profile/i }))
+
+    expect(screen.getByTestId('edit-profile-modal')).toHaveTextContent('Edit modal in MENTOR mode')
+  })
+})

--- a/web/src/lib/queries/__tests__/AuthQueries.test.ts
+++ b/web/src/lib/queries/__tests__/AuthQueries.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { queryClientClearMock, queryClientSetDataMock, navigateMock } = vi.hoisted(() => ({
+  queryClientClearMock: vi.fn(),
+  queryClientSetDataMock: vi.fn(),
+  navigateMock: vi.fn(),
+}))
+
+vi.mock('#/router.tsx', () => ({
+  queryClient: {
+    clear: queryClientClearMock,
+    setQueryData: queryClientSetDataMock,
+  },
+  router: {
+    navigate: navigateMock,
+  },
+}))
+
+import {
+    getStoredUser,
+    handleAuthSuccess,
+    loginFn,
+    logout,
+    meQueryOptions,
+    registerFn,
+    updateAppUsageModeFn,
+} from '../AuthQueries'
+
+function jsonResponse(data: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(data), {
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  })
+}
+
+describe('AuthQueries', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn<typeof globalThis, 'fetch'>>
+
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  it('returns null from me query when there is no access token', async () => {
+    const result = await meQueryOptions.queryFn!({} as never)
+
+    expect(result).toBeNull()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('refreshes expired access token and retries me query', async () => {
+    localStorage.setItem('access_token', 'expired-token')
+    localStorage.setItem('refresh_token', 'refresh-token')
+
+    const me = {
+      id: 'user-1',
+      username: 'alex',
+      email: 'alex@example.com',
+      role: 'USER',
+      auth_provider: 'LOCAL',
+      app_usage_mode: 'MENTOR',
+      is_active: true,
+      created_at: '2026-04-10T09:00:00Z',
+    }
+
+    fetchSpy
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(jsonResponse({ access: 'fresh-token' }, { status: 200 }))
+      .mockResolvedValueOnce(jsonResponse(me, { status: 200 }))
+
+    const result = await meQueryOptions.queryFn!({} as never)
+
+    expect(result).toEqual(me)
+    expect(localStorage.getItem('access_token')).toBe('fresh-token')
+
+    const retryUrl = new URL(fetchSpy.mock.calls[2][0] as string, globalThis.location.origin)
+    expect(retryUrl.pathname).toBe('/api/auth/me/')
+    expect(fetchSpy.mock.calls[2][1]).toEqual(
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer fresh-token' },
+      }),
+    )
+  })
+
+  it('clears auth state and redirects to login when token refresh fails', async () => {
+    localStorage.setItem('access_token', 'expired-token')
+    localStorage.setItem('refresh_token', 'invalid-refresh')
+    localStorage.setItem('id', 'user-1')
+
+    fetchSpy
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+
+    const result = await meQueryOptions.queryFn!({} as never)
+
+    expect(result).toBeNull()
+    expect(localStorage.getItem('access_token')).toBeNull()
+    expect(localStorage.getItem('refresh_token')).toBeNull()
+    expect(localStorage.getItem('id')).toBeNull()
+    expect(queryClientClearMock).toHaveBeenCalled()
+    expect(navigateMock).toHaveBeenCalledWith({ to: '/login' })
+  })
+
+  it('returns null when access token is expired and no refresh token exists', async () => {
+    localStorage.setItem('access_token', 'expired-token')
+
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 401 }))
+
+    await expect(meQueryOptions.queryFn!({} as never)).resolves.toBeNull()
+    expect(queryClientClearMock).not.toHaveBeenCalled()
+    expect(navigateMock).not.toHaveBeenCalled()
+  })
+
+  it('returns null when retrying me query fails after successful refresh', async () => {
+    localStorage.setItem('access_token', 'expired-token')
+    localStorage.setItem('refresh_token', 'refresh-token')
+
+    fetchSpy
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(jsonResponse({ access: 'fresh-token' }, { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 500 }))
+
+    await expect(meQueryOptions.queryFn!({} as never)).resolves.toBeNull()
+    expect(localStorage.getItem('access_token')).toBe('fresh-token')
+  })
+
+  it('returns stored user id when access token exists', () => {
+    localStorage.setItem('access_token', 'token-1')
+    localStorage.setItem('id', 'user-123')
+
+    expect(getStoredUser()).toEqual({ id: 'user-123' })
+  })
+
+  it('returns an empty user object when token exists but id is missing', () => {
+    localStorage.setItem('access_token', 'token-1')
+
+    expect(getStoredUser()).toEqual({})
+  })
+
+  it('stores tokens and hydrates me cache on auth success', () => {
+    const data = {
+      access_token: 'token-1',
+      refresh_token: 'refresh-1',
+      user: {
+        id: 'user-1',
+        username: 'alex',
+        email: 'alex@example.com',
+        role: 'USER',
+        auth_provider: 'LOCAL',
+        app_usage_mode: 'MENTEE' as const,
+        is_active: true,
+        created_at: '2026-04-10T09:00:00Z',
+      },
+    }
+
+    handleAuthSuccess(data)
+
+    expect(localStorage.getItem('access_token')).toBe('token-1')
+    expect(localStorage.getItem('refresh_token')).toBe('refresh-1')
+    expect(localStorage.getItem('id')).toBe('user-1')
+    expect(queryClientSetDataMock).toHaveBeenCalledWith(['me'], data.user)
+  })
+
+  it('throws meaningful errors for failed login and register calls', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 400 }))
+
+    await expect(
+      loginFn({ email: 'alex@example.com', password: 'bad-password' }),
+    ).rejects.toThrow('Invalid credentials')
+
+    await expect(
+      registerFn({
+        email: 'alex@example.com',
+        password: 'short',
+        confirm_password: 'short',
+      }),
+    ).rejects.toThrow('Registration failed')
+  })
+
+  it('returns payload for successful login and register calls', async () => {
+    const authPayload = {
+      access_token: 'token-1',
+      refresh_token: 'refresh-1',
+      user: {
+        id: 'user-1',
+        username: 'alex',
+        email: 'alex@example.com',
+        role: 'USER',
+        auth_provider: 'LOCAL',
+        app_usage_mode: 'MENTEE' as const,
+        is_active: true,
+        created_at: '2026-04-10T09:00:00Z',
+      },
+    }
+
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse(authPayload, { status: 200 }))
+      .mockResolvedValueOnce(jsonResponse(authPayload, { status: 200 }))
+
+    await expect(loginFn({ email: 'alex@example.com', password: 'pass123456' })).resolves.toEqual(authPayload)
+    await expect(
+      registerFn({
+        email: 'alex@example.com',
+        password: 'pass123456',
+        confirm_password: 'pass123456',
+      }),
+    ).resolves.toEqual(authPayload)
+  })
+
+  it('logs out locally even when logout endpoint request fails', async () => {
+    localStorage.setItem('access_token', 'token-1')
+    localStorage.setItem('refresh_token', 'refresh-1')
+    localStorage.setItem('id', 'user-1')
+
+    fetchSpy.mockRejectedValueOnce(new Error('network down'))
+
+    await logout()
+
+    expect(localStorage.getItem('access_token')).toBeNull()
+    expect(localStorage.getItem('refresh_token')).toBeNull()
+    expect(localStorage.getItem('id')).toBeNull()
+    expect(queryClientClearMock).toHaveBeenCalled()
+    expect(navigateMock).toHaveBeenCalledWith({ to: '/login' })
+  })
+
+  it('logs out without calling backend when refresh token is missing', async () => {
+    localStorage.setItem('access_token', 'token-1')
+
+    await logout()
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(queryClientClearMock).toHaveBeenCalled()
+    expect(navigateMock).toHaveBeenCalledWith({ to: '/login' })
+  })
+
+  it('updates app usage mode and throws when update fails', async () => {
+    localStorage.setItem('access_token', 'token-1')
+
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse({ app_usage_mode: 'MENTOR' }, { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 500 }))
+
+    await expect(
+      updateAppUsageModeFn({ app_usage_mode: 'MENTOR' }),
+    ).resolves.toEqual({ app_usage_mode: 'MENTOR' })
+
+    await expect(
+      updateAppUsageModeFn({ app_usage_mode: 'MENTEE' }),
+    ).rejects.toThrow('Failed to update usage mode')
+  })
+})

--- a/web/src/lib/queries/__tests__/DiscoverQueries.test.ts
+++ b/web/src/lib/queries/__tests__/DiscoverQueries.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  fetchAllSkills,
+  fetchMentors,
+  fetchPopularMentors,
+  fetchRecentlyAddedMentors,
+} from '../DiscoverQueries'
+
+function jsonResponse(data: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(data), {
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  })
+}
+
+describe('DiscoverQueries fetchers', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn<typeof globalThis, 'fetch'>>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  it('builds mentor search URL with query, paging, and skill filters', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ count: 1, page: 2, pageSize: 6, results: [{ id: 'mentor-1' }] }, { status: 200 }),
+    )
+
+    const response = await fetchMentors({
+      q: 'react',
+      page: 2,
+      pageSize: 6,
+      skills: ['TypeScript', 'System Design'],
+    })
+
+    expect(response.results).toEqual([{ id: 'mentor-1' }])
+
+    const calledUrl = new URL(fetchSpy.mock.calls[0][0] as string, globalThis.location.origin)
+    expect(calledUrl.pathname).toBe('/api/profiles/')
+    expect(calledUrl.searchParams.get('q')).toBe('react')
+    expect(calledUrl.searchParams.get('page')).toBe('2')
+    expect(calledUrl.searchParams.get('pageSize')).toBe('6')
+    expect(calledUrl.searchParams.getAll('skill')).toEqual(['TypeScript', 'System Design'])
+  })
+
+  it('throws on mentor search API failure', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 500 }))
+
+    await expect(
+      fetchMentors({ page: 1, pageSize: 6 }),
+    ).rejects.toThrow('Failed to fetch mentors')
+  })
+
+  it('throws on skills API failure', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 500 }))
+
+    await expect(fetchAllSkills()).rejects.toThrow('Failed to fetch skills')
+  })
+
+  it('returns popular and recent mentors lists from API results payload', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(jsonResponse({ results: [{ id: 'popular-1' }] }, { status: 200 }))
+      .mockResolvedValueOnce(jsonResponse({ results: [{ id: 'recent-1' }] }, { status: 200 }))
+
+    await expect(fetchPopularMentors(4)).resolves.toEqual([{ id: 'popular-1' }])
+    await expect(fetchRecentlyAddedMentors(4)).resolves.toEqual([{ id: 'recent-1' }])
+  })
+
+  it('throws when popular or recent mentor APIs fail', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(new Response(null, { status: 500 }))
+      .mockResolvedValueOnce(new Response(null, { status: 500 }))
+
+    await expect(fetchPopularMentors()).rejects.toThrow('Failed to fetch popular mentors')
+    await expect(fetchRecentlyAddedMentors()).rejects.toThrow('Failed to fetch recently added mentors')
+  })
+})

--- a/web/src/lib/queries/__tests__/MentorshipQueries.test.ts
+++ b/web/src/lib/queries/__tests__/MentorshipQueries.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  meetingSessionsQueryOptions,
+  myMatchesQueryOptions,
+  myRequestsQueryOptions,
+} from '../MentorshipQueries'
+
+function jsonResponse(data: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(data), {
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  })
+}
+
+describe('MentorshipQueries query options', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn<typeof globalThis, 'fetch'>>
+
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  it('requests my matches with bearer auth when token exists', async () => {
+    localStorage.setItem('access_token', 'token-1')
+
+    fetchSpy.mockResolvedValueOnce(jsonResponse([{ id: 'match-1' }], { status: 200 }))
+
+    const data = await myMatchesQueryOptions.queryFn!({} as never)
+
+    expect(data).toEqual([{ id: 'match-1' }])
+
+    const matchesUrl = new URL(fetchSpy.mock.calls[0][0] as string, globalThis.location.origin)
+    expect(matchesUrl.pathname).toBe('/api/mentorship/matches/me/')
+    expect(fetchSpy.mock.calls[0][1]).toEqual(
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer token-1' },
+      }),
+    )
+  })
+
+  it('requests my matches with empty headers when no token exists', async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse([{ id: 'match-2' }], { status: 200 }))
+
+    await myMatchesQueryOptions.queryFn!({} as never)
+
+    expect(fetchSpy.mock.calls[0][1]).toEqual(
+      expect.objectContaining({
+        headers: {},
+      }),
+    )
+  })
+
+  it('throws when fetching my requests fails', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 500 }))
+
+    await expect(myRequestsQueryOptions.queryFn!({} as never)).rejects.toThrow('Failed to fetch requests')
+  })
+
+  it('requests my requests with bearer auth when token exists', async () => {
+    localStorage.setItem('access_token', 'token-1')
+    fetchSpy.mockResolvedValueOnce(jsonResponse([{ id: 'req-1' }], { status: 200 }))
+
+    await myRequestsQueryOptions.queryFn!({} as never)
+
+    const requestsUrl = new URL(fetchSpy.mock.calls[0][0] as string, globalThis.location.origin)
+    expect(requestsUrl.pathname).toBe('/api/mentorship/requests/me/')
+    expect(fetchSpy.mock.calls[0][1]).toEqual(
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer token-1' },
+      }),
+    )
+  })
+
+  it('builds meeting sessions URL including role and status filters', async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse([{ session_id: 's-1' }], { status: 200 }))
+
+    const result = await meetingSessionsQueryOptions({ role: 'mentor', status: 'upcoming' }).queryFn!({} as never)
+
+    expect(result).toEqual([{ session_id: 's-1' }])
+
+    const sessionsUrl = new URL(fetchSpy.mock.calls[0][0] as string, globalThis.location.origin)
+    expect(sessionsUrl.pathname).toBe('/api/mentorship/meeting-sessions/me/')
+    expect(sessionsUrl.searchParams.get('role')).toBe('mentor')
+    expect(sessionsUrl.searchParams.get('status')).toBe('upcoming')
+    expect(fetchSpy.mock.calls[0][1]).toEqual(
+      expect.objectContaining({
+        headers: {},
+      }),
+    )
+  })
+
+  it('omits role query parameter when role is all', async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse([{ session_id: 's-2' }], { status: 200 }))
+
+    await meetingSessionsQueryOptions({ role: 'all', status: 'past' }).queryFn!({} as never)
+
+    const allRoleUrl = new URL(fetchSpy.mock.calls[0][0] as string, globalThis.location.origin)
+    expect(allRoleUrl.pathname).toBe('/api/mentorship/meeting-sessions/me/')
+    expect(allRoleUrl.searchParams.get('status')).toBe('past')
+    expect(allRoleUrl.searchParams.has('role')).toBe(false)
+    expect(fetchSpy.mock.calls[0][1]).toEqual(expect.any(Object))
+  })
+
+  it('omits all filters when no role or status is provided', async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse([{ session_id: 's-3' }], { status: 200 }))
+
+    await meetingSessionsQueryOptions().queryFn!({} as never)
+
+    const unfilteredUrl = new URL(fetchSpy.mock.calls[0][0] as string, globalThis.location.origin)
+    expect(unfilteredUrl.pathname).toBe('/api/mentorship/meeting-sessions/me/')
+    expect(unfilteredUrl.search).toBe('')
+  })
+
+  it('throws when meeting sessions API fails', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 500 }))
+
+    await expect(
+      meetingSessionsQueryOptions({ role: 'mentee', status: 'upcoming' }).queryFn!({} as never),
+    ).rejects.toThrow('Failed to fetch meeting sessions')
+  })
+})

--- a/web/src/routes/_authorized/__tests__/connections.test.tsx
+++ b/web/src/routes/_authorized/__tests__/connections.test.tsx
@@ -1,26 +1,26 @@
-import { render, screen } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../../routeTree.gen', () => ({}))
 vi.mock('../../../router', () => ({}))
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
-  const actual = await importOriginal<any>()
+  const actual = await importOriginal<Record<string, unknown>>()
   return {
     ...actual,
     createFileRoute: () => () => ({
       update: vi.fn().mockReturnThis(),
     }),
-    Link: ({ children, to, params, className }: any) => (
-        <a href={`${to}/${params?.username ?? ''}`} className={className}>{children}</a>
+    Link: ({ children, to, params, className }: Record<string, unknown>) => (
+        <a href={`${to as string}/${(params as Record<string, string>)?.username ?? ''}`} className={className as string}>{children as React.ReactNode}</a>
     ),
     useNavigate: () => vi.fn(),
   }
 })
 
 vi.mock('lucide-react', async (importOriginal) => {
-  const actual = await importOriginal<any>()
+  const actual = await importOriginal<Record<string, unknown>>()
   return {
     ...actual,
     Loader2: () => <div data-testid="icon-loader" />,
@@ -59,7 +59,7 @@ const MOCK_MATCHES = [
   {
     id: 'match-2',
     mentor: {
-      id: 'mentor-1',
+      id: 'mentor-1b',
       username: 'john_mentor',
       display_name: 'John Smith',
       picture_url: '',

--- a/web/src/routes/_authorized/__tests__/dashboard.test.tsx
+++ b/web/src/routes/_authorized/__tests__/dashboard.test.tsx
@@ -1,276 +1,441 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockNavigate } = vi.hoisted(() => ({
-  mockNavigate: vi.fn(),
+const {
+  mockUseMyRequests,
+  mockUseMeetingSessions,
+  mockMutate,
+  toastSuccessMock,
+  toastWarningMock,
+  toastErrorMock,
+} = vi.hoisted(() => ({
+  mockUseMyRequests: vi.fn(),
+  mockUseMeetingSessions: vi.fn(),
+  mockMutate: vi.fn(),
+  toastSuccessMock: vi.fn(),
+  toastWarningMock: vi.fn(),
+  toastErrorMock: vi.fn(),
 }))
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
-  const actual = await importOriginal<any>()
+  const actual = await importOriginal<Record<string, unknown>>()
   return {
     ...actual,
-    createFileRoute: () => () => ({}),
-    useNavigate: () => mockNavigate,
+    createFileRoute: () => () => ({
+      update: vi.fn().mockReturnThis(),
+    }),
+    Link: ({ children, to, params, className }: Record<string, unknown>) => (
+      <a href={`${to as string}/${(params as Record<string, string>)?.username ?? ''}`} className={className as string}>
+        {children as React.ReactNode}
+      </a>
+    ),
   }
 })
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: toastSuccessMock,
+    warning: toastWarningMock,
+    error: toastErrorMock,
+  },
+}))
 
 vi.mock('lucide-react', async (importOriginal) => {
-  const actual = await importOriginal<any>()
+  const actual = await importOriginal<Record<string, unknown>>()
   return {
     ...actual,
-    Search: () => <div data-testid="icon-search" />,
-    SlidersHorizontal: () => <div data-testid="icon-sliders" />,
-    X: () => <div data-testid="icon-x" />,
+    ArrowRight: () => <span data-testid="icon-arrow-right" />,
+    CalendarDays: () => <span data-testid="icon-calendar-days" />,
+    Check: () => <span data-testid="icon-check" />,
+    CheckCircle2: () => <span data-testid="icon-check-circle" />,
+    Clock: () => <span data-testid="icon-clock" />,
+    Loader2: () => <span data-testid="icon-loader" />,
+    XCircle: () => <span data-testid="icon-x-circle" />,
+    X: () => <span data-testid="icon-x" />,
   }
 })
 
-const MOCK_SKILLS = [
-  { id: 1, name: 'Python' },
-  { id: 2, name: 'Kubernetes' },
-  { id: 3, name: 'Go' },
-  { id: 4, name: 'React' },
-]
+vi.mock('#/lib/queries/MentorshipQueries.ts', () => ({
+  useMyRequests: () => mockUseMyRequests(),
+  useMeetingSessions: (params: Record<string, unknown>) => mockUseMeetingSessions(params),
+  useRespondToRequest: () => ({
+    mutate: mockMutate,
+    isPending: false,
+  }),
+}))
 
-const makeMentor = (n: number) => ({
-  id: `id-${n}`,
-  username: `mentor${n}`,
-  full_name: `Mentor ${n}`,
-  bio: `Bio of mentor ${n}`,
-  hidden: false,
-  picture_url: null,
-  title: `Engineer ${n}`,
-  location: null,
-  show_initials_only: false,
-  skills: n % 2 === 0 ? ['Python'] : ['Kubernetes'],
-  rating: 4.5,
-  total_mentee_count: n,
-})
+vi.mock('#/lib/queries/AuthQueries.ts', () => ({
+  meQueryOptions: {
+    queryKey: ['me'],
+    queryFn: async () => null,
+    staleTime: Infinity,
+  },
+}))
 
-const MOCK_MENTORS = Array.from({ length: 8 }, (_, i) => makeMentor(i + 1))
+import { DashboardHome } from '../dashboard'
 
-vi.mock('@/lib/queries/DiscoverQueries.ts', async (importOriginal) => {
-  const actual = await importOriginal<any>()
-  return {
-    ...actual,
-    mentorSearchInfiniteQueryOptions: (params: any) => ({
-      queryKey: ['mentors', 'search', params],
-      queryFn: async ({ pageParam = 1 }: { pageParam: number }) => {
-        const pageSize = params.pageSize ?? 6
-        let results = [...MOCK_MENTORS]
-
-        if (params.q) {
-          const q = params.q.toLowerCase()
-          results = results.filter(
-              (m) =>
-                  m.full_name.toLowerCase().includes(q) ||
-                  m.bio.toLowerCase().includes(q) ||
-                  m.skills.some((e: string) => e.toLowerCase().includes(q)),
-          )
-        }
-
-        if (params.skills?.length) {
-          results = results.filter((m) =>
-              m.skills.some((e: string) => params.skills.includes(e)),
-          )
-        }
-
-        const start = (pageParam - 1) * pageSize
-        return {
-          count: results.length,
-          page: pageParam,
-          pageSize,
-          results: results.slice(start, start + pageSize),
-        }
-      },
-      initialPageParam: 1,
-      getNextPageParam: (lastPage: any) => {
-        const fetched = lastPage.page * lastPage.pageSize
-        return fetched < lastPage.count ? lastPage.page + 1 : undefined
-      },
-    }),
-    allSkillsQueryOptions: {
-      queryKey: ['profiles', 'skills'],
-      queryFn: async () => MOCK_SKILLS,
-    },
-  }
-})
-
-import { DiscoverPage } from '../discover'
-
-function renderDiscover() {
+function renderDashboard(appUsageMode: 'MENTOR' | 'MENTEE', username: string) {
   const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
   })
+
+  queryClient.setQueryData(['me'], {
+    id: 'user-1',
+    username,
+    email: `${username}@example.com`,
+    role: 'USER',
+    auth_provider: 'LOCAL',
+    app_usage_mode: appUsageMode,
+    is_active: true,
+    created_at: '2026-04-01T10:00:00Z',
+  })
+
   return render(
-      <QueryClientProvider client={queryClient}>
-        <DiscoverPage />
-      </QueryClientProvider>,
+    <QueryClientProvider client={queryClient}>
+      <DashboardHome />
+    </QueryClientProvider>,
   )
 }
 
-describe('DiscoverPage', () => {
-  beforeEach(() => vi.clearAllMocks())
-
-  it('renders the hero heading', () => {
-    renderDiscover()
-    expect(screen.getByRole('heading', { name: /Discover the/i })).toBeInTheDocument()
-  })
-
-  it('renders the search bar', () => {
-    renderDiscover()
-    expect(screen.getByPlaceholderText(/Search profiles, skills, or projects/i)).toBeInTheDocument()
-  })
-
-  it('renders the filter button', () => {
-    renderDiscover()
-    expect(screen.getByRole('button', { name: /Filter by skill/i })).toBeInTheDocument()
-  })
-
-  it('renders at least one ProfileCard on initial load', async () => {
-    renderDiscover()
-    await waitFor(() => {
-      expect(screen.getAllByRole('button', { name: /View Profile/i }).length).toBeGreaterThan(0)
+describe('DashboardHome', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockMutate.mockImplementation((_payload, callbacks) => {
+      callbacks?.onSuccess?.()
     })
   })
 
-  it('shows at most PAGE_SIZE (6) cards on initial load', async () => {
-    renderDiscover()
-    await waitFor(() => {
-      expect(screen.getAllByRole('button', { name: /View Profile/i }).length).toBeLessThanOrEqual(6)
-    })
-  })
+  it('shows mentee-specific content and only displays pending sent requests for current user', () => {
+    mockUseMeetingSessions.mockImplementation(({ role }: { role: 'mentor' | 'mentee' }) => ({
+      data:
+        role === 'mentee'
+          ? [
+              {
+                session_id: 'session-1',
+                mentor: {
+                  username: 'mentor-rita',
+                  display_name: 'Rita Mentor',
+                  picture_url: '',
+                  title: 'Data Scientist',
+                },
+                scheduled_start_at: '2026-04-28T14:00:00Z',
+                scheduled_end_at: '2026-04-28T15:00:00Z',
+                display_status: 'SCHEDULED',
+              },
+            ]
+          : [],
+      isLoading: false,
+    }))
 
-  it('shows the empty state when no profiles match the search query', async () => {
-    renderDiscover()
-    fireEvent.change(screen.getByPlaceholderText(/Search profiles, skills, or projects/i), {
-      target: { value: 'xyznonexistent' },
-    })
-    await waitFor(() => {
-      expect(screen.getByText(/No mentors found matching/i)).toBeInTheDocument()
-    })
-  })
-
-  it('filters profiles by skill name via search', async () => {
-    renderDiscover()
-    fireEvent.change(screen.getByPlaceholderText(/Search profiles, skills, or projects/i), {
-      target: { value: 'Kubernetes' },
-    })
-    await waitFor(() => {
-      expect(screen.getByText('Mentor 1')).toBeInTheDocument()
-      expect(screen.queryByText('Mentor 2')).not.toBeInTheDocument()
-    })
-  })
-
-  it('restores profiles when search query is cleared', async () => {
-    renderDiscover()
-    const input = screen.getByPlaceholderText(/Search profiles, skills, or projects/i)
-    fireEvent.change(input, { target: { value: 'Kubernetes' } })
-    await waitFor(() => expect(screen.getByText('Mentor 1')).toBeInTheDocument())
-    fireEvent.change(input, { target: { value: '' } })
-    await waitFor(() => {
-      expect(screen.getAllByRole('button', { name: /View Profile/i }).length).toBeGreaterThan(1)
-    })
-  })
-
-  it('opens the skill filter panel when the filter button is clicked', async () => {
-    renderDiscover()
-    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument())
-    fireEvent.click(screen.getByRole('button', { name: /Filter by skill/i }))
-    expect(screen.getByText(/Filter by Skill/i)).toBeInTheDocument()
-  })
-
-  it('closes the filter panel when clicked outside', async () => {
-    renderDiscover()
-    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument())
-    fireEvent.click(screen.getByRole('button', { name: /Filter by skill/i }))
-    fireEvent.mouseDown(document.body)
-    expect(screen.queryByText(/Filter by Skill/i)).not.toBeInTheDocument()
-  })
-
-  it('filters profiles when a skill chip is selected', async () => {
-    renderDiscover()
-    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument())
-    fireEvent.click(screen.getByRole('button', { name: /Filter by skill/i }))
-    fireEvent.click(await screen.findByRole('button', { name: /^Python$/i }))
-    await waitFor(() => {
-      expect(screen.getByText('Mentor 2')).toBeInTheDocument()
-      expect(screen.queryByText('Mentor 1')).not.toBeInTheDocument()
-    })
-  })
-
-  it('shows the active filter count badge on the filter button', async () => {
-    renderDiscover()
-    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument())
-    fireEvent.click(screen.getByRole('button', { name: /Filter by skill/i }))
-    fireEvent.click(await screen.findByRole('button', { name: /^Go$/i }))
-    expect(screen.getByText('1')).toBeInTheDocument()
-  })
-
-  it('clears skill filters when "Clear all" is clicked', async () => {
-    renderDiscover()
-    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument())
-    fireEvent.click(screen.getByRole('button', { name: /Filter by skill/i }))
-    fireEvent.click(await screen.findByRole('button', { name: /^Go$/i }))
-    fireEvent.click(screen.getByRole('button', { name: /Clear all/i }))
-    expect(screen.queryByText('1')).not.toBeInTheDocument()
-  })
-
-  it('shows the Load More button when there are more profiles than PAGE_SIZE', async () => {
-    renderDiscover()
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /Load More/i })).toBeInTheDocument()
-    })
-  })
-
-  it('appends more profiles when Load More is clicked', async () => {
-    renderDiscover()
-    await waitFor(() => screen.getAllByRole('button', { name: /View Profile/i }))
-    const before = screen.getAllByRole('button', { name: /View Profile/i }).length
-
-    fireEvent.click(screen.getByRole('button', { name: /Load More/i }))
-
-    await waitFor(() => {
-      const after = screen.getAllByRole('button', { name: /View Profile/i }).length
-      expect(after).toBeGreaterThan(before)
-    })
-  })
-
-  it('hides Load More when all profiles are loaded', async () => {
-    renderDiscover()
-    await waitFor(() => screen.getByRole('button', { name: /Load More/i }))
-    fireEvent.click(screen.getByRole('button', { name: /Load More/i }))
-    await waitFor(() => {
-      expect(screen.queryByRole('button', { name: /Load More/i })).not.toBeInTheDocument()
-    })
-  })
-
-  it('resets to first page when search query changes', async () => {
-    renderDiscover()
-    await waitFor(() => screen.getByRole('button', { name: /Load More/i }))
-    fireEvent.click(screen.getByRole('button', { name: /Load More/i }))
-    await waitFor(() => {
-      expect(screen.getAllByRole('button', { name: /View Profile/i }).length).toBeGreaterThan(6)
+    mockUseMyRequests.mockReturnValue({
+      isLoading: false,
+      data: [
+        {
+          id: 'req-1',
+          mentor: {
+            username: 'mentor-rita',
+            display_name: 'Rita Mentor',
+            picture_url: '',
+            title: 'Data Scientist',
+          },
+          mentee: {
+            username: 'mentee-sam',
+            display_name: 'Sam Mentee',
+            picture_url: '',
+            title: '',
+          },
+          status: 'PENDING',
+          slot_date: '2026-04-28',
+          slot_start_time: '14:00:00',
+          slot_end_time: '15:00:00',
+          cover_letter: 'Would love to learn with you.',
+        },
+        {
+          id: 'req-2',
+          mentor: {
+            username: 'mentor-other',
+            display_name: 'Other Mentor',
+            picture_url: '',
+            title: 'Engineer',
+          },
+          mentee: {
+            username: 'different-user',
+            display_name: 'Different User',
+            picture_url: '',
+            title: '',
+          },
+          status: 'PENDING',
+          slot_date: '2026-04-29',
+          slot_start_time: '10:00:00',
+          slot_end_time: '11:00:00',
+          cover_letter: '',
+        },
+        {
+          id: 'req-3',
+          mentor: {
+            username: 'mentor-accepted',
+            display_name: 'Accepted Mentor',
+            picture_url: '',
+            title: 'Teacher',
+          },
+          mentee: {
+            username: 'mentee-sam',
+            display_name: 'Sam Mentee',
+            picture_url: '',
+            title: '',
+          },
+          status: 'ACCEPTED',
+          slot_date: '2026-04-29',
+          slot_start_time: '10:00:00',
+          slot_end_time: '11:00:00',
+          cover_letter: '',
+        },
+      ],
     })
 
-    fireEvent.change(screen.getByPlaceholderText(/Search profiles, skills, or projects/i), {
-      target: { value: 'Kubernetes' },
-    })
+    renderDashboard('MENTEE', 'mentee-sam')
 
-    await waitFor(() => {
-      expect(screen.getAllByRole('button', { name: /View Profile/i }).length).toBeLessThanOrEqual(6)
-    })
+    expect(screen.getByRole('heading', { name: /Mentee Dashboard/i })).toBeInTheDocument()
+    expect(screen.getByText(/Track your learning goals/i)).toBeInTheDocument()
+    expect(screen.getByText('Session with Rita Mentor')).toBeInTheDocument()
+    expect(screen.getByText('To: Rita Mentor')).toBeInTheDocument()
+    expect(screen.queryByText('To: Other Mentor')).not.toBeInTheDocument()
+    expect(screen.queryByText('To: Accepted Mentor')).not.toBeInTheDocument()
   })
 
-  it('navigates to the profile page when View Profile is clicked', async () => {
-    renderDiscover()
-    await waitFor(() => screen.getAllByRole('button', { name: /View Profile/i }))
-    fireEvent.click(screen.getAllByRole('button', { name: /View Profile/i })[0])
-    expect(mockNavigate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          to: '/profiles/$username',
-          params: expect.objectContaining({ username: expect.any(String) }),
-        }),
+  it('accepts a mentor request and transitions request badge state', async () => {
+    const user = userEvent.setup()
+
+    mockUseMeetingSessions.mockImplementation(() => ({ data: [], isLoading: false }))
+    mockUseMyRequests.mockReturnValue({
+      isLoading: false,
+      data: [
+        {
+          id: 'req-mentor-1',
+          mentor: {
+            username: 'mentor-rita',
+            display_name: 'Rita Mentor',
+            picture_url: '',
+            title: 'Data Scientist',
+          },
+          mentee: {
+            username: 'mentee-kai',
+            display_name: 'Kai Learner',
+            picture_url: '',
+            title: '',
+          },
+          status: 'PENDING',
+          slot_date: '2026-05-02',
+          slot_start_time: '13:00:00',
+          slot_end_time: '14:00:00',
+          cover_letter: 'Looking forward to learning Python.',
+        },
+      ],
+    })
+
+    renderDashboard('MENTOR', 'mentor-rita')
+
+    await user.click(screen.getByRole('button', { name: /Accept/i }))
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      { requestId: 'req-mentor-1', action: 'accept' },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }),
     )
+
+    await waitFor(() => {
+      expect(screen.getByText('ACCEPTED')).toBeInTheDocument()
+    })
+
+    expect(toastSuccessMock).toHaveBeenCalledWith('Request accepted',
+      expect.objectContaining({
+        description: expect.stringMatching(/session is confirmed/i),
+      }),
+    )
+    expect(toastWarningMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a mentor request and shows warning toast with REJECTED status', async () => {
+    const user = userEvent.setup()
+
+    mockMutate.mockImplementation((_payload, callbacks) => {
+      callbacks?.onSuccess?.()
+    })
+
+    mockUseMeetingSessions.mockReturnValue({ data: [], isLoading: false })
+    mockUseMyRequests.mockReturnValue({
+      isLoading: false,
+      data: [
+        {
+          id: 'req-mentor-2',
+          mentor: {
+            username: 'mentor-rita',
+            display_name: 'Rita Mentor',
+            picture_url: '',
+            title: 'Data Scientist',
+          },
+          mentee: {
+            username: 'mentee-lina',
+            display_name: 'Lina Learner',
+            picture_url: '',
+            title: '',
+          },
+          status: 'PENDING',
+          slot_date: '2026-05-03',
+          slot_start_time: '13:00:00',
+          slot_end_time: '14:00:00',
+          cover_letter: '',
+        },
+      ],
+    })
+
+    renderDashboard('MENTOR', 'mentor-rita')
+
+    await user.click(screen.getByRole('button', { name: /Decline/i }))
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      { requestId: 'req-mentor-2', action: 'reject' },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('REJECTED')).toBeInTheDocument()
+    })
+
+    expect(toastWarningMock).toHaveBeenCalledWith(
+      'Request declined',
+      expect.objectContaining({
+        description: expect.stringMatching(/mentee has been notified/i),
+      }),
+    )
+  })
+
+  it('shows an error toast when request response fails', async () => {
+    const user = userEvent.setup()
+
+    mockMutate.mockImplementation((_payload, callbacks) => {
+      callbacks?.onError?.({ message: 'Server is unavailable' })
+    })
+
+    mockUseMeetingSessions.mockReturnValue({ data: [], isLoading: false })
+    mockUseMyRequests.mockReturnValue({
+      isLoading: false,
+      data: [
+        {
+          id: 'req-mentor-3',
+          mentor: {
+            username: 'mentor-rita',
+            display_name: 'Rita Mentor',
+            picture_url: '',
+            title: 'Data Scientist',
+          },
+          mentee: {
+            username: 'mentee-kaan',
+            display_name: 'Kaan Learner',
+            picture_url: '',
+            title: '',
+          },
+          status: 'PENDING',
+          slot_date: '2026-05-04',
+          slot_start_time: '15:00:00',
+          slot_end_time: '16:00:00',
+          cover_letter: 'Please help me with OOP.',
+        },
+      ],
+    })
+
+    renderDashboard('MENTOR', 'mentor-rita')
+
+    await user.click(screen.getByRole('button', { name: /Accept/i }))
+
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      'Failed to respond',
+      expect.objectContaining({
+        description: 'Server is unavailable',
+      }),
+    )
+  })
+
+  it('shows the "View all requests" button when more than three pending requests exist', () => {
+    mockUseMeetingSessions.mockReturnValue({ data: [], isLoading: false })
+    mockUseMyRequests.mockReturnValue({
+      isLoading: false,
+      data: [
+        {
+          id: 'req-1',
+          mentor: { username: 'mentor-rita', display_name: 'Rita Mentor', picture_url: '', title: 'Data Scientist' },
+          mentee: { username: 'mentee-1', display_name: 'A', picture_url: '', title: '' },
+          status: 'PENDING',
+          slot_date: '2026-05-01',
+          slot_start_time: '09:00:00',
+          slot_end_time: '10:00:00',
+          cover_letter: '',
+        },
+        {
+          id: 'req-2',
+          mentor: { username: 'mentor-rita', display_name: 'Rita Mentor', picture_url: '', title: 'Data Scientist' },
+          mentee: { username: 'mentee-2', display_name: 'B', picture_url: '', title: '' },
+          status: 'PENDING',
+          slot_date: '2026-05-02',
+          slot_start_time: '09:00:00',
+          slot_end_time: '10:00:00',
+          cover_letter: '',
+        },
+        {
+          id: 'req-3',
+          mentor: { username: 'mentor-rita', display_name: 'Rita Mentor', picture_url: '', title: 'Data Scientist' },
+          mentee: { username: 'mentee-3', display_name: 'C', picture_url: '', title: '' },
+          status: 'PENDING',
+          slot_date: '2026-05-03',
+          slot_start_time: '09:00:00',
+          slot_end_time: '10:00:00',
+          cover_letter: '',
+        },
+        {
+          id: 'req-4',
+          mentor: { username: 'mentor-rita', display_name: 'Rita Mentor', picture_url: '', title: 'Data Scientist' },
+          mentee: { username: 'mentee-4', display_name: 'D', picture_url: '', title: '' },
+          status: 'PENDING',
+          slot_date: '2026-05-04',
+          slot_start_time: '09:00:00',
+          slot_end_time: '10:00:00',
+          cover_letter: '',
+        },
+      ],
+    })
+
+    renderDashboard('MENTOR', 'mentor-rita')
+
+    expect(screen.getByRole('button', { name: /View all 4 requests/i })).toBeInTheDocument()
+  })
+
+  it('renders loading indicators while mentor dashboard queries are in flight', () => {
+    mockUseMeetingSessions.mockReturnValue({ data: [], isLoading: true })
+    mockUseMyRequests.mockReturnValue({ data: [], isLoading: true })
+
+    renderDashboard('MENTOR', 'mentor-rita')
+
+    expect(screen.getAllByTestId('icon-loader').length).toBeGreaterThan(0)
+  })
+
+  it('renders empty states when mentor has no sessions and no requests', () => {
+    mockUseMeetingSessions.mockReturnValue({ data: [], isLoading: false })
+    mockUseMyRequests.mockReturnValue({ data: [], isLoading: false })
+
+    renderDashboard('MENTOR', 'mentor-rita')
+
+    expect(screen.getAllByText(/No upcoming sessions in the next 7 days/i).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/No pending requests right now/i).length).toBeGreaterThan(0)
   })
 })

--- a/web/src/routes/_authorized/__tests__/discover.test.tsx
+++ b/web/src/routes/_authorized/__tests__/discover.test.tsx
@@ -5,12 +5,40 @@ import {infiniteQueryOptions, QueryClient, QueryClientProvider, queryOptions} fr
 
 // ── Hoist mocks ──────────────────────────────────────────────────────────────
 
-const { mockNavigate } = vi.hoisted(() => ({
+const { mockNavigate, mockMentorSearchLogic } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
+  mockMentorSearchLogic: (mentors: any[], params: any, page = 1) => {
+    const pageSize = params.pageSize ?? 6
+    let results = [...mentors]
+
+    if (params.q) {
+      const q = params.q.toLowerCase()
+      results = results.filter((m) => {
+        const nameMatch = m.full_name.toLowerCase().includes(q)
+        const bioMatch = m.bio.toLowerCase().includes(q)
+        const skillMatch = m.skills.some((s: string) => s.toLowerCase().includes(q))
+        return nameMatch || bioMatch || skillMatch
+      })
+    }
+
+    if (params.skills?.length) {
+      results = results.filter((m: any) =>
+        m.skills.some((s: string) => params.skills.includes(s)),
+      )
+    }
+
+    const start = (page - 1) * pageSize
+    return {
+      count: results.length,
+      page,
+      pageSize,
+      results: results.slice(start, start + pageSize),
+    }
+  },
 }))
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
-  const actual = await importOriginal<any>()
+  const actual = await importOriginal<Record<string, unknown>>()
   return {
     ...actual,
     createFileRoute: () => () => ({}),
@@ -19,7 +47,7 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
 })
 
 vi.mock('lucide-react', async (importOriginal) => {
-  const actual = await importOriginal<any>()
+  const actual = await importOriginal<Record<string, unknown>>()
   return {
     ...actual,
     Search: () => <div data-testid="icon-search" />,
@@ -56,43 +84,15 @@ const makeMentor = (n: number) => ({
 const MOCK_MENTORS = Array.from({ length: 8 }, (_, i) => makeMentor(i + 1))
 
 vi.mock('@/lib/queries/DiscoverQueries.ts', async (importOriginal) => {
-  const actual = await importOriginal<any>()
+  const actual = await importOriginal<Record<string, unknown>>()
   return {
     ...actual,
-    mentorSearchInfiniteQueryOptions: (params: any) =>
+    mentorSearchInfiniteQueryOptions: (params: { pageSize?: number; q?: string; skills?: string[] }) =>
         infiniteQueryOptions({
           queryKey: ['mentors', 'search', params],
-          queryFn: async ({ pageParam }) => {
-            const page = (pageParam as number) ?? 1
-            const pageSize = params.pageSize ?? 6
-            let results = [...MOCK_MENTORS]
-
-            if (params.q) {
-              const q = params.q.toLowerCase()
-              results = results.filter(
-                  (m) =>
-                      m.full_name.toLowerCase().includes(q) ||
-                      m.bio.toLowerCase().includes(q) ||
-                      m.skills.some((e: string) => e.toLowerCase().includes(q)),
-              )
-            }
-
-            if (params.skills?.length) {
-              results = results.filter((m) =>
-                  m.skills.some((e: string) => params.skills.includes(e)),
-              )
-            }
-
-            const start = (page - 1) * pageSize
-            return {
-              count: results.length,
-              page,
-              pageSize,
-              results: results.slice(start, start + pageSize),
-            }
-          },
+          queryFn: async ({ pageParam }) => mockMentorSearchLogic(MOCK_MENTORS, params, pageParam),
           initialPageParam: 1,
-          getNextPageParam: (lastPage: any) => {
+          getNextPageParam: (lastPage: { page: number; pageSize: number; count: number }) => {
             const fetched = lastPage.page * lastPage.pageSize
             return fetched < lastPage.count ? lastPage.page + 1 : undefined
           },

--- a/web/src/routes/_authorized/__tests__/messages.test.tsx
+++ b/web/src/routes/_authorized/__tests__/messages.test.tsx
@@ -1,0 +1,102 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MessagesPage } from '../messages'
+
+globalThis.HTMLElement.prototype.scrollIntoView = vi.fn()
+
+const { mockUseConversations, mockUseMessages, mockUseSendMessage } = vi.hoisted(() => ({
+  mockUseConversations: vi.fn(),
+  mockUseMessages: vi.fn(),
+  mockUseSendMessage: vi.fn(),
+}))
+
+vi.mock('#/lib/queries/MessagingQueries.ts', () => ({
+  useConversations: () => mockUseConversations(),
+  useMessages: (id: string) => mockUseMessages(id),
+  useSendMessage: (id: string) => mockUseSendMessage(id),
+}))
+
+vi.mock('#/lib/queries/AuthQueries.ts', () => ({
+  meQueryOptions: { queryKey: ['me'], queryFn: () => ({ username: 'testuser' }) },
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => () => ({}),
+}))
+
+const MOCK_CONVERSATIONS = [
+  {
+    id: 'conv-1',
+    mentor: { username: 'testuser', display_name: 'Test Mentor', picture_url: '' },
+    mentee: { username: 'otheruser', display_name: 'Other Mentee', picture_url: '' },
+  }
+]
+
+const MOCK_MESSAGES = [
+  {
+    id: 'msg-1',
+    body: 'Hello world',
+    sender: { username: 'otheruser', display_name: 'Other Mentee', picture_url: '' },
+    created_at: '2026-04-20T10:00:00Z',
+  }
+]
+
+function renderWithQueryClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  queryClient.setQueryData(['me'], { username: 'testuser' })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      {ui}
+    </QueryClientProvider>
+  )
+}
+
+describe('MessagesPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseConversations.mockReturnValue({ data: MOCK_CONVERSATIONS, isLoading: false })
+    mockUseMessages.mockReturnValue({ data: MOCK_MESSAGES, isLoading: false })
+    mockUseSendMessage.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+  })
+
+  it('renders the conversation list', () => {
+    renderWithQueryClient(<MessagesPage />)
+    expect(screen.getByText('Messages')).toBeInTheDocument()
+    expect(screen.getByText('Other Mentee')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no conversation is selected', () => {
+    renderWithQueryClient(<MessagesPage />)
+    expect(screen.getByText(/Select a conversation to start messaging/i)).toBeInTheDocument()
+  })
+
+  it('renders messages when a conversation is selected', () => {
+    renderWithQueryClient(<MessagesPage />)
+    
+    const conversation = screen.getByText('Other Mentee')
+    fireEvent.click(conversation)
+    
+    expect(screen.getByText('Hello world')).toBeInTheDocument()
+  })
+
+  it('can send a message', () => {
+    const mockMutate = vi.fn()
+    mockUseSendMessage.mockReturnValue({ mutateAsync: mockMutate, isPending: false })
+    
+    renderWithQueryClient(<MessagesPage />)
+    
+    // Select conversation
+    fireEvent.click(screen.getByText('Other Mentee'))
+    
+    const input = screen.getByPlaceholderText(/Type a message/i)
+    fireEvent.change(input, { target: { value: 'New message' } })
+    
+    const sendButton = screen.getByRole('button', { name: /send message/i })
+    fireEvent.click(sendButton)
+    
+    expect(mockMutate).toHaveBeenCalledWith('New message')
+  })
+})

--- a/web/src/routes/_authorized/__tests__/route.guard.test.tsx
+++ b/web/src/routes/_authorized/__tests__/route.guard.test.tsx
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getStoredUserMock, ensureQueryDataMock } = vi.hoisted(() => ({
+  getStoredUserMock: vi.fn(),
+  ensureQueryDataMock: vi.fn(),
+}))
+
+vi.mock('@/components/layout/AuthorizedHeader', () => ({
+  AuthorizedHeader: () => <div data-testid="authorized-header" />,
+}))
+
+vi.mock('#/components/ui/sonner.tsx', () => ({
+  Toaster: () => null,
+}))
+
+vi.mock('#/lib/queries/AuthQueries.ts', () => ({
+  getStoredUser: getStoredUserMock,
+  meQueryOptions: { queryKey: ['me'] },
+}))
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    createFileRoute: () => (options: Record<string, unknown>) => options,
+    redirect: (options: { to: string }) => ({ ...options, __redirect: true }),
+    Outlet: () => <div data-testid="outlet" />,
+  }
+})
+
+import { Route } from '../route'
+
+describe('Authorized route guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('redirects to login when there is no stored user', () => {
+    getStoredUserMock.mockReturnValue(null)
+
+    let thrown: unknown
+    try {
+      ;(Route as unknown as { beforeLoad: () => void }).beforeLoad()
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toEqual({ to: '/login', __redirect: true })
+  })
+
+  it('allows navigation when stored user exists', () => {
+    getStoredUserMock.mockReturnValue({ id: 'user-1' })
+
+    expect(() => (Route as unknown as { beforeLoad: () => void }).beforeLoad()).not.toThrow()
+  })
+
+  it('ensures current user query data in loader', async () => {
+    await (Route as unknown as { loader: (args: Record<string, unknown>) => Promise<void> }).loader({
+      context: {
+        queryClient: {
+          ensureQueryData: ensureQueryDataMock,
+        },
+      },
+    })
+
+    expect(ensureQueryDataMock).toHaveBeenCalledWith({ queryKey: ['me'] })
+  })
+})

--- a/web/src/routes/_authorized/__tests__/schedule.test.tsx
+++ b/web/src/routes/_authorized/__tests__/schedule.test.tsx
@@ -3,17 +3,21 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { SchedulePage } from '../schedule'
 
+const { mockUseMeetingSessions } = vi.hoisted(() => ({
+  mockUseMeetingSessions: vi.fn(),
+}))
+
 vi.mock('../../../routeTree.gen', () => ({}))
 vi.mock('../../../router', () => ({}))
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
-  const actual = await importOriginal<any>()
+  const actual = await importOriginal<Record<string, unknown>>()
   return {
     ...actual,
     createFileRoute: () => () => ({
       update: vi.fn().mockReturnThis(),
     }),
-    Link: ({ children, to, className }: any) => (
+    Link: ({ children, to, className }: { children: React.ReactNode, to: string, className?: string }) => (
         <a href={to} className={className}>{children}</a>
     ),
   }
@@ -59,14 +63,14 @@ const MOCK_MENTEE_MEETING_SESSIONS = [
     created_at: '2026-04-01T10:00:00Z',
     updated_at: '2026-04-01T10:00:00Z',
   },
-  {
+    {
     session_id: 'session-2',
     match_id: 'match-2',
     mentor: {
       id: 'mentor-1',
       username: 'john_mentor',
       display_name: 'John Smith',
-      picture_url: '',
+      picture_url: 'https://example.com/pic.jpg',
       title: 'Software Engineer',
     },
     mentee: {
@@ -79,8 +83,8 @@ const MOCK_MENTEE_MEETING_SESSIONS = [
     source_slot_id: 'slot-2',
     scheduled_start_at: '2026-04-28T16:00:00',
     scheduled_end_at: '2026-04-28T17:00:00',
-    status: 'SCHEDULED',
-    display_status: 'SCHEDULED',
+    status: 'COMPLETED',
+    display_status: 'COMPLETED',
     my_role: 'MENTEE',
     allowed_actions: [],
     canceled_by_role: null,
@@ -106,8 +110,8 @@ const MOCK_MENTOR_MEETING_SESSIONS = [
       id: 'mentee-1',
       username: 'mentee_user',
       display_name: 'Alice Mentee',
-      picture_url: '',
-      title: '',
+      picture_url: 'https://example.com/mentee.jpg',
+      title: 'Graduate Student',
     },
     source_slot_id: 'slot-3',
     scheduled_start_at: '2026-04-24T10:00:00',
@@ -141,8 +145,8 @@ const MOCK_MENTOR_MEETING_SESSIONS = [
     source_slot_id: 'slot-4',
     scheduled_start_at: '2026-04-28T14:00:00',
     scheduled_end_at: '2026-04-28T15:00:00',
-    status: 'SCHEDULED',
-    display_status: 'SCHEDULED',
+    status: 'COMPLETED',
+    display_status: 'COMPLETED',
     my_role: 'MENTOR',
     allowed_actions: [],
     canceled_by_role: null,
@@ -153,10 +157,7 @@ const MOCK_MENTOR_MEETING_SESSIONS = [
 ]
 
 vi.mock('#/lib/queries/MentorshipQueries.ts', () => ({
-  useMeetingSessions: (params?: { role?: 'mentor' | 'mentee' | 'all' }) => ({
-    data: params?.role === 'mentor' ? MOCK_MENTOR_MEETING_SESSIONS : MOCK_MENTEE_MEETING_SESSIONS,
-    isLoading: false,
-  }),
+  useMeetingSessions: (params?: { role?: 'mentor' | 'mentee' | 'all' }) => mockUseMeetingSessions(params),
   useMyRequests: () => ({ data: [], isLoading: false }),
   useRespondToRequest: () => ({ mutate: vi.fn(), isPending: false }),
 }))
@@ -193,6 +194,26 @@ function renderWithUser(appUsageMode: 'MENTOR' | 'MENTEE') {
 describe('SchedulePage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockUseMeetingSessions.mockImplementation((params?: { role?: 'mentor' | 'mentee' | 'all' }) => ({
+      data: params?.role === 'mentor' ? MOCK_MENTOR_MEETING_SESSIONS : MOCK_MENTEE_MEETING_SESSIONS,
+      isLoading: false,
+    }))
+  })
+
+  it('shows a loading indicator while sessions are being fetched', () => {
+    mockUseMeetingSessions.mockReturnValue({ data: [], isLoading: true })
+
+    renderWithUser('MENTEE')
+
+    expect(screen.getByTestId('icon-loader')).toBeInTheDocument()
+  })
+
+  it('shows an empty state when there are no sessions for the selected role', () => {
+    mockUseMeetingSessions.mockReturnValue({ data: [], isLoading: false })
+
+    renderWithUser('MENTEE')
+
+    expect(screen.getByText(/No sessions scheduled for this selection/i)).toBeInTheDocument()
   })
 
   it('renders the Mentee Learning Schedule for mentee', () => {
@@ -220,6 +241,19 @@ describe('SchedulePage', () => {
     expect(screen.getByText('Bob Mentee')).toBeInTheDocument()
   })
 
+  it('renders peer titles and pictures when available', () => {
+    renderWithUser('MENTEE')
+    expect(screen.getAllByText('Software Engineer').length).toBeGreaterThan(0)
+    const img = screen.getByAltText('John Smith')
+    expect(img).toHaveAttribute('src', 'https://example.com/pic.jpg')
+  })
+
+  it('renders status badges correctly', () => {
+    renderWithUser('MENTOR')
+    expect(screen.getAllByText('Upcoming').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Completed').length).toBeGreaterThan(0)
+  })
+
   it('filters sessions when a calendar day is clicked', () => {
     renderWithUser('MENTEE')
 
@@ -232,6 +266,10 @@ describe('SchedulePage', () => {
 
     // Filter header updates
     expect(screen.getByText(/Sessions for 28 April 2026/i)).toBeInTheDocument()
+
+    // Click day 28 again to deselect
+    fireEvent.click(day28)
+    expect(screen.getByText('All Sessions')).toBeInTheDocument()
   })
 
   it('clears filter when Clear Filter is clicked', () => {

--- a/web/src/routes/_authorized/messages.tsx
+++ b/web/src/routes/_authorized/messages.tsx
@@ -231,6 +231,7 @@ function Thread({ conversationId }: { conversationId: string }) {
                 <Button
                     type="submit"
                     size="icon"
+                    aria-label="Send message"
                     disabled={!text.trim() || sendMessage.isPending}
                     className="rounded-xl bg-accent hover:bg-accent/90 text-white shrink-0"
                 >

--- a/web/src/routes/_unauthorized/__tests__/login.test.tsx
+++ b/web/src/routes/_unauthorized/__tests__/login.test.tsx
@@ -1,0 +1,132 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { navigateMock, loginFnMock, handleAuthSuccessMock } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  loginFnMock: vi.fn(),
+  handleAuthSuccessMock: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      update: vi.fn().mockReturnThis(),
+    }),
+    Link: ({ children, to, className }: Record<string, unknown>) => (
+      <a href={to as string} className={className as string}>
+        {children as React.ReactNode}
+      </a>
+    ),
+    useRouter: () => ({ navigate: navigateMock }),
+  }
+})
+
+vi.mock('#/lib/queries/AuthQueries.ts', () => ({
+  loginFn: loginFnMock,
+  handleAuthSuccess: handleAuthSuccessMock,
+}))
+
+import { LoginPage } from '../login'
+
+function renderLoginPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <LoginPage />
+    </QueryClientProvider>,
+  )
+}
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('logs in successfully and redirects to dashboard', async () => {
+    const user = userEvent.setup()
+
+    const authResponse = {
+      access_token: 'access-1',
+      refresh_token: 'refresh-1',
+      user: {
+        id: 'user-1',
+        username: 'mentor.alex',
+        email: 'alex@example.com',
+      },
+    }
+
+    loginFnMock.mockResolvedValue(authResponse)
+
+    renderLoginPage()
+
+    await user.type(screen.getByLabelText(/Email/i), 'alex@example.com')
+    await user.type(screen.getByLabelText(/Password/i), 'pass123456')
+    await user.click(screen.getByRole('button', { name: /Sign in/i }))
+
+    await waitFor(() => {
+      expect(loginFnMock).toHaveBeenCalledWith({
+        email: 'alex@example.com',
+        password: 'pass123456',
+      }, expect.anything())
+    })
+
+    expect(handleAuthSuccessMock).toHaveBeenCalledWith(authResponse)
+    expect(navigateMock).toHaveBeenCalledWith({ to: '/dashboard' })
+  })
+
+  it('shows API error message when sign-in fails', async () => {
+    const user = userEvent.setup()
+
+    loginFnMock.mockRejectedValue(new Error('Invalid credentials'))
+
+    renderLoginPage()
+
+    await user.type(screen.getByLabelText(/Email/i), 'alex@example.com')
+    await user.type(screen.getByLabelText(/Password/i), 'wrong-password')
+    await user.click(screen.getByRole('button', { name: /Sign in/i }))
+
+    expect(await screen.findByText('Invalid credentials')).toBeInTheDocument()
+    expect(handleAuthSuccessMock).not.toHaveBeenCalled()
+    expect(navigateMock).not.toHaveBeenCalled()
+  })
+
+  it('shows a pending state while request is in flight', async () => {
+    const user = userEvent.setup()
+
+    let resolveLogin: ((value: unknown) => void) | undefined
+    loginFnMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveLogin = resolve
+        }),
+    )
+
+    renderLoginPage()
+
+    await user.type(screen.getByLabelText(/Email/i), 'alex@example.com')
+    await user.type(screen.getByLabelText(/Password/i), 'pass123456')
+    await user.click(screen.getByRole('button', { name: /Sign in/i }))
+
+    expect(screen.getByRole('button', { name: /Signing in/i })).toBeDisabled()
+
+    resolveLogin?.({
+      access_token: 'access-1',
+      refresh_token: 'refresh-1',
+      user: { id: 'u1', username: 'alex', email: 'alex@example.com' },
+    })
+
+    await waitFor(() => {
+      expect(handleAuthSuccessMock).toHaveBeenCalled()
+    })
+  })
+})

--- a/web/src/routes/_unauthorized/__tests__/register.test.tsx
+++ b/web/src/routes/_unauthorized/__tests__/register.test.tsx
@@ -1,16 +1,16 @@
 // web/src/routes/_unauthorized/__tests__/register.test.tsx
-import type { ReactNode } from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
 import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-global.ResizeObserver = vi.fn().mockImplementation(() => ({
+globalThis.ResizeObserver = vi.fn().mockImplementation(() => ({
   observe: vi.fn(),
   unobserve: vi.fn(),
   disconnect: vi.fn(),
 }))
 
-global.matchMedia = vi.fn().mockImplementation((query: string) => ({
+globalThis.matchMedia = vi.fn().mockImplementation((query: string) => ({
   matches: false,
   media: query,
   onchange: null,
@@ -33,22 +33,38 @@ vi.mock('#/lib/demoAuth', () => ({
   setDemoAuthRole: vi.fn(),
 }))
 
-vi.mock('#/lib/queries/Authqueries', () => ({
-  registerFn: vi.fn(),
-  handleAuthSuccess: vi.fn(),
+const { mockRegisterFn, mockHandleAuthSuccess, createMutationMock } = vi.hoisted(() => ({
+  mockRegisterFn: vi.fn(),
+  mockHandleAuthSuccess: vi.fn(),
+  createMutationMock: (options: any, result: 'success' | 'error' = 'success', errorMessage = 'Registration failed') => ({
+    mutate: vi.fn(() => {
+      if (result === 'success' && options?.onSuccess) {
+        options.onSuccess({ user: { id: '1' } })
+      } else if (result === 'error' && options?.onError) {
+        options.onError(new Error('API Error'))
+      }
+    }),
+    isPending: false,
+    isError: result === 'error',
+    error: result === 'error' ? { message: errorMessage } : null,
+  })
+}))
+
+vi.mock('#/lib/queries/AuthQueries.ts', () => ({
+  registerFn: mockRegisterFn,
+  handleAuthSuccess: mockHandleAuthSuccess,
   meQueryOptions: { queryKey: ['me'], queryFn: () => null },
+}))
+
+const { mockUseMutation } = vi.hoisted(() => ({
+  mockUseMutation: vi.fn(),
 }))
 
 vi.mock('@tanstack/react-query', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-query')>()
   return {
     ...actual,
-    useMutation: () => ({
-      mutate: vi.fn(),
-      isPending: false,
-      isError: false,
-      error: null,
-    }),
+    useMutation: (options: Record<string, unknown>) => mockUseMutation(options),
   }
 })
 
@@ -65,7 +81,7 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
 })
 
 vi.mock('lucide-react', async (importOriginal) => {
-  const actual = await importOriginal<any>()
+  const actual = await importOriginal<Record<string, unknown>>()
   return {
     ...actual,
     User: () => <span data-testid="icon-user" />,
@@ -81,6 +97,7 @@ describe('RegisterPage Component', () => {
     mockLink.mockImplementation(({ children, to }: { children: ReactNode; to: string }) => (
         <a href={to} data-testid={`link-${to.replace('/', '')}`}>{children}</a>
     ))
+    mockUseMutation.mockImplementation((opts: any) => createMutationMock(opts))
   })
 
   describe('Rendering', () => {
@@ -318,6 +335,54 @@ describe('RegisterPage Component', () => {
 
       expect(screen.getByText(/Terms of Service/i)).toBeInTheDocument()
       expect(screen.getByText(/Privacy Policy/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('Mutation States', () => {
+    it('calls handleAuthSuccess and navigates on success', async () => {
+      const user = userEvent.setup()
+      render(<RegisterPage />)
+
+      await user.type(screen.getByLabelText(/Email/i), 'john@example.com')
+      await user.type(screen.getByLabelText(/^Password$/i), 'password123')
+      await user.type(screen.getByLabelText(/Confirm password/i), 'password123')
+      await user.click(screen.getByRole('checkbox', { name: /Terms of Service/i }))
+      await user.click(screen.getByRole('button', { name: /Create Account/i }))
+
+      expect(mockHandleAuthSuccess).toHaveBeenCalled()
+      expect(mockNavigate).toHaveBeenCalledWith({ to: '/gettingToKnowYou' })
+    })
+
+    it('displays error message on mutation error and calls onError', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      
+      mockUseMutation.mockImplementation((opts: any) => createMutationMock(opts, 'error'))
+
+      const user = userEvent.setup()
+      render(<RegisterPage />)
+      
+      await user.type(screen.getByLabelText(/Email/i), 'john@example.com')
+      await user.type(screen.getByLabelText(/^Password$/i), 'password123')
+      await user.type(screen.getByLabelText(/Confirm password/i), 'password123')
+      await user.click(screen.getByRole('checkbox', { name: /Terms of Service/i }))
+      await user.click(screen.getByRole('button', { name: /Create Account/i }))
+
+      expect(screen.getByText('Registration failed')).toBeInTheDocument()
+      expect(consoleSpy).toHaveBeenCalledWith('Register error:', expect.any(Error))
+      
+      consoleSpy.mockRestore()
+    })
+
+    it('shows loading text when pending', () => {
+      mockUseMutation.mockReturnValue({
+        mutate: vi.fn(),
+        isPending: true,
+        isError: false,
+        error: null,
+      })
+
+      render(<RegisterPage />)
+      expect(screen.getByText('Creating account...')).toBeInTheDocument()
     })
   })
 })

--- a/web/src/routes/_unauthorized/__tests__/route.guard.test.tsx
+++ b/web/src/routes/_unauthorized/__tests__/route.guard.test.tsx
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getStoredUserMock } = vi.hoisted(() => ({
+  getStoredUserMock: vi.fn(),
+}))
+
+vi.mock('#/components/layout/UnauthorizedHeader.tsx', () => ({
+  UnauthorizedHeader: () => <div data-testid="unauthorized-header" />,
+}))
+
+vi.mock('#/components/layout/UnauthorizedFooter.tsx', () => ({
+  UnauthorizedFooter: () => <div data-testid="unauthorized-footer" />,
+}))
+
+vi.mock('#/lib/queries/AuthQueries.ts', () => ({
+  getStoredUser: getStoredUserMock,
+}))
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    createFileRoute: () => (options: Record<string, unknown>) => options,
+    redirect: (options: { to: string }) => ({ ...options, __redirect: true }),
+    Outlet: () => <div data-testid="outlet" />,
+  }
+})
+
+import { Route } from '../route'
+
+describe('Unauthorized route guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('redirects to dashboard when user is already authenticated', () => {
+    getStoredUserMock.mockReturnValue({ id: 'user-1' })
+
+    let thrown: unknown
+    try {
+      ;(Route as unknown as { beforeLoad: () => void }).beforeLoad()
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toEqual({ to: '/dashboard', __redirect: true })
+  })
+
+  it('allows access when no user is stored', () => {
+    getStoredUserMock.mockReturnValue(null)
+
+    expect(() => (Route as unknown as { beforeLoad: () => void }).beforeLoad()).not.toThrow()
+  })
+})

--- a/web/src/routes/_unauthorized/login.tsx
+++ b/web/src/routes/_unauthorized/login.tsx
@@ -1,8 +1,5 @@
-import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
+import { Body, Display, Heading, Muted } from "@/components/Typography"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Search, CalendarDays, TrendingUp } from 'lucide-react'
 import {
     Card,
     CardContent,
@@ -11,12 +8,15 @@ import {
     CardHeader,
     CardTitle,
 } from "@/components/ui/card"
-import { Heading, Muted, Body, Display } from "@/components/Typography"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
+import { CalendarDays, Search, TrendingUp } from 'lucide-react'
 
 // DEMO BYPASS IMPORT - FUTURE: Delete this once real auth is merged
-import {handleAuthSuccess, loginFn} from "#/lib/queries/AuthQueries.ts";
-import {useMutation} from "@tanstack/react-query";
-import {useState} from "react";
+import { handleAuthSuccess, loginFn } from "#/lib/queries/AuthQueries.ts"
+import { useMutation } from "@tanstack/react-query"
+import { useState } from "react"
 
 const FEATURES = [
     { icon: Search,      title: 'Find tutors',    desc: 'Browse verified tutors from your campus' },
@@ -25,10 +25,10 @@ const FEATURES = [
 ]
 
 export const Route = createFileRoute('/_unauthorized/login')({
-    component: RouteComponent,
+    component: LoginPage,
 })
 
-function RouteComponent() {
+export function LoginPage() {
     const router = useRouter()
     const [email, setEmail] = useState('')
     const [password, setPassword] = useState('')
@@ -43,7 +43,7 @@ function RouteComponent() {
         }
     })
 
-    const handleSubmit = (e: React.FormEvent) => {
+    const handleSubmit = (e: React.SyntheticEvent<HTMLFormElement>) => {
         e.preventDefault()
         login.mutate({ email, password })
     }


### PR DESCRIPTION
## Related Issue

Closes #338 

## Description

Increased frontend branch coverage and resolved static analysis issues flagged by SonarQube and Pylance. Key changes:

- **New test files**: Added tests for `AuthQueries`, `DiscoverQueries`, `MentorshipQueries`, `ProfilePageView`, `MessagesPage`, and route guards for both authorized and unauthorized routes.
- **Expanded existing tests**: Significantly expanded `dashboard.test.tsx`, `schedule.test.tsx`, `register.test.tsx`, and `login.test.tsx` to cover more branches.
- **Type safety**: Replaced `any` type assertions with `Record<string, unknown>` or explicit interfaces across test mocks. Fixed unsafe `String()` conversions on fetch spy arguments by using `as string` casts.
- **Reduced nesting**: Extracted deeply nested mock logic into hoisted helpers (`mockMentorSearchLogic`, `createMutationMock`) to stay within 4-level nesting limits.
- **Removed unused code**: Cleaned up unused imports (`Select`, `useLocation`) and props (`username` in `CancelModal`) in production components.
- **Minor production fixes**: Refactored `ExpertiseEditModal`, `SessionManagementModal`, and `login.tsx` to resolve linting warnings.

## Type of Change

- [x] Refactoring (no functional changes)

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code

## Notes

All 114 tests pass and `tsc --noEmit` completes with zero errors.