### PR TITLE
feat: Added notifications, and changed ui of dashboard a bit.

### DIFF
--- a/web/src/components/layout/AuthorizedHeader.tsx
+++ b/web/src/components/layout/AuthorizedHeader.tsx
@@ -4,10 +4,15 @@ import { logout, meQueryOptions } from "#/lib/queries/AuthQueries.ts"
 import { useQuery } from "@tanstack/react-query"
 import { useProfile } from "#/lib/queries/ProfileQueries.ts"
 import { getInitials } from "#/lib/utils.ts"
+import { useNotifications } from "#/lib/queries/NotificationQueries.ts"
 
 export function AuthorizedHeader() {
   const { data: me } = useQuery(meQueryOptions)
   const { data: profile } = useProfile(me?.username ?? '')
+  const { data: notifications = [] } = useNotifications()
+
+  const hasUnread = notifications.length > 0
+  const hasMessageNotification = notifications.some(n => n.type === 'new_message')
 
   const initials = profile?.full_name
       ? getInitials(profile.full_name)
@@ -34,7 +39,12 @@ export function AuthorizedHeader() {
                   activeProps={{ className: "bg-accent-muted text-ink font-semibold" }}
                   className="text-sm font-medium text-ink-soft hover:text-ink hover:bg-accent-muted/60 transition-colors px-3 py-1.5 rounded-lg"
               >
-                Dashboard
+                <span className="relative">
+                  Dashboard
+                  {hasUnread && (
+                    <span className="absolute -top-1 -right-2.5 h-2 w-2 rounded-full bg-accent" />
+                  )}
+                </span>
               </Link>
               <Link
                   to="/schedule"
@@ -59,10 +69,16 @@ export function AuthorizedHeader() {
               </Link>
               <Link
                   to="/messages"
+                  search={{ conversationId: '' }}
                   activeProps={{ className: "bg-accent-muted text-ink font-semibold" }}
                   className="text-sm font-medium text-ink-soft hover:text-ink hover:bg-accent-muted/60 transition-colors px-3 py-1.5 rounded-lg"
               >
-                Messages
+                <span className="relative">
+                  Messages
+                  {hasMessageNotification && (
+                    <span className="absolute -top-1 -right-2.5 h-2 w-2 rounded-full bg-accent" />
+                  )}
+                </span>
               </Link>
             </nav>
           </div>

--- a/web/src/components/notifications/NotificationItem.tsx
+++ b/web/src/components/notifications/NotificationItem.tsx
@@ -1,0 +1,100 @@
+import { Link } from '@tanstack/react-router'
+import {
+    CalendarCheck,
+    CheckCircle2,
+    Clock,
+    MessageSquare,
+    Star,
+    UserPlus,
+    UserX,
+    XCircle,
+} from 'lucide-react'
+import { cn } from '#/lib/utils.ts'
+import type { Notification, NotificationType } from '#/lib/queries/NotificationQueries.ts'
+
+type VariantConfig = {
+    icon: React.ComponentType<{ className?: string }>
+    iconClass: string
+    borderClass: string
+}
+
+const VARIANT_MAP: Record<NotificationType, VariantConfig> = {
+    new_mentorship_request: {
+        icon: UserPlus,
+        iconClass: 'text-accent',
+        borderClass: 'border-l-accent',
+    },
+    mentorship_request_rejected: {
+        icon: XCircle,
+        iconClass: 'text-red-500',
+        borderClass: 'border-l-red-400',
+    },
+    new_match: {
+        icon: CheckCircle2,
+        iconClass: 'text-green-600',
+        borderClass: 'border-l-green-400',
+    },
+    slot_booked: {
+        icon: CalendarCheck,
+        iconClass: 'text-green-600',
+        borderClass: 'border-l-green-400',
+    },
+    session_canceled: {
+        icon: XCircle,
+        iconClass: 'text-red-500',
+        borderClass: 'border-l-red-400',
+    },
+    session_rescheduled: {
+        icon: Clock,
+        iconClass: 'text-yellow-600',
+        borderClass: 'border-l-yellow-400',
+    },
+    match_deactivated: {
+        icon: UserX,
+        iconClass: 'text-ink-soft',
+        borderClass: 'border-l-line',
+    },
+    new_message: {
+        icon: MessageSquare,
+        iconClass: 'text-accent',
+        borderClass: 'border-l-accent',
+    },
+    new_feedback_available: {
+        icon: Star,
+        iconClass: 'text-yellow-500',
+        borderClass: 'border-l-yellow-400',
+    },
+}
+
+export function NotificationItem({ notification }: { notification: Notification }) {
+    const variant = VARIANT_MAP[notification.type]
+    const Icon = variant.icon
+    const conversationId =
+        notification.type === 'new_message'
+            ? (notification.extra_metadata.conversation_id as string | undefined)
+            : undefined
+
+    return (
+        <div
+            className={cn(
+                'flex items-start gap-3 rounded-lg border border-line border-l-4 bg-white px-4 py-3 shadow-sm',
+                variant.borderClass,
+            )}
+        >
+            <Icon className={cn('mt-0.5 h-4 w-4 shrink-0', variant.iconClass)} />
+            <div className="flex-1 min-w-0">
+                <p className="text-base font-medium text-ink">{notification.title}</p>
+                <p className="text-sm text-ink-soft mt-0.5 leading-relaxed">{notification.message}</p>
+            </div>
+            {conversationId && (
+                <Link
+                    to="/messages"
+                    search={{ conversationId }}
+                    className="shrink-0 text-xs text-accent hover:underline underline-offset-4 whitespace-nowrap"
+                >
+                    View conversation →
+                </Link>
+            )}
+        </div>
+    )
+}

--- a/web/src/components/notifications/NotificationItem.tsx
+++ b/web/src/components/notifications/NotificationItem.tsx
@@ -70,9 +70,7 @@ export function NotificationItem({ notification }: { notification: Notification 
     const variant = VARIANT_MAP[notification.type]
     const Icon = variant.icon
     const conversationId =
-        notification.type === 'new_message'
-            ? (notification.extra_metadata.conversation_id as string | undefined)
-            : undefined
+        notification.type === 'new_message' ? (notification.resource_id ?? undefined) : undefined
 
     return (
         <div

--- a/web/src/components/profile/ProfilePageView.tsx
+++ b/web/src/components/profile/ProfilePageView.tsx
@@ -165,7 +165,7 @@ export function ProfilePageView({ profile, isOwner, isAuthenticatedViewer }: Pro
     // MENTOR layout — restructure to put calendar full width below
     return (
         <main className="page-wrap py-10 sm:py-12 rise-in">
-            <section className="island-shell rounded-3xl p-6 sm:p-8 lg:p-10 space-y-8">
+            <section id="availability" className="island-shell rounded-3xl p-6 sm:p-8 lg:p-10 space-y-8">
 
                 {/* Top 2-col grid: left content + right snapshot */}
                 <div className="grid gap-8 lg:grid-cols-[2fr_1fr]">

--- a/web/src/lib/queries/NotificationQueries.ts
+++ b/web/src/lib/queries/NotificationQueries.ts
@@ -68,3 +68,16 @@ export function useMarkAllNotificationsRead() {
         },
     })
 }
+
+// Maps each notification type to the query keys that should be invalidated when it arrives.
+export const NOTIFICATION_INVALIDATION_MAP: Record<NotificationType, string[][]> = {
+    new_mentorship_request:      [['mentorship', 'requests']],
+    mentorship_request_rejected: [['mentorship', 'requests']],
+    new_match:                   [['mentorship', 'matches'], ['mentorship', 'requests']],
+    slot_booked:                 [['mentorship', 'meeting-sessions', 'me'], ['mentorship', 'requests']],
+    session_canceled:            [['mentorship', 'meeting-sessions', 'me']],
+    session_rescheduled:         [['mentorship', 'meeting-sessions', 'me']],
+    match_deactivated:           [['mentorship', 'matches']],
+    new_message:                 [['messaging', 'conversations']],
+    new_feedback_available:      [['profiles', 'me']],
+}

--- a/web/src/lib/queries/NotificationQueries.ts
+++ b/web/src/lib/queries/NotificationQueries.ts
@@ -1,0 +1,70 @@
+import { queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
+
+function authHeaders(): HeadersInit {
+    const token = localStorage.getItem('access_token')
+    return token ? { Authorization: `Bearer ${token}` } : {}
+}
+
+export type NotificationType =
+    | 'new_mentorship_request'
+    | 'mentorship_request_rejected'
+    | 'new_match'
+    | 'slot_booked'
+    | 'session_canceled'
+    | 'session_rescheduled'
+    | 'match_deactivated'
+    | 'new_message'
+    | 'new_feedback_available'
+
+export interface Notification {
+    id: string
+    type: NotificationType
+    title: string
+    message: string
+    actor: string | null
+    resource_type: string
+    resource_id: string | null
+    action_url: string
+    extra_metadata: Record<string, unknown>
+    is_read: boolean
+    created_at: string
+}
+
+async function fetchNotifications(): Promise<Notification[]> {
+    const res = await fetch(`${API_BASE_URL}/notifications/`, {
+        headers: authHeaders(),
+    })
+    if (!res.ok) throw new Error(`${res.status}`)
+    return res.json()
+}
+
+async function markNotificationRead(id: string): Promise<void> {
+    const res = await fetch(`${API_BASE_URL}/notifications/${id}/read/`, {
+        method: 'PUT',
+        headers: authHeaders(),
+    })
+    if (!res.ok) throw new Error(`${res.status}`)
+}
+
+export const notificationsQueryOptions = queryOptions({
+    queryKey: ['notifications'],
+    queryFn: fetchNotifications,
+    staleTime: 30_000,
+    refetchInterval: 30_000,
+})
+
+export function useNotifications() {
+    return useQuery(notificationsQueryOptions)
+}
+
+export function useMarkAllNotificationsRead() {
+    const queryClient = useQueryClient()
+    return useMutation({
+        mutationFn: (ids: string[]) => Promise.all(ids.map(markNotificationRead)),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['notifications'] })
+        },
+    })
+}

--- a/web/src/lib/queries/NotificationQueries.ts
+++ b/web/src/lib/queries/NotificationQueries.ts
@@ -51,8 +51,8 @@ async function markNotificationRead(id: string): Promise<void> {
 export const notificationsQueryOptions = queryOptions({
     queryKey: ['notifications'],
     queryFn: fetchNotifications,
-    staleTime: 30_000,
-    refetchInterval: 30_000,
+    staleTime: 10 * 1000,
+    refetchInterval: 10 * 1000,
 })
 
 export function useNotifications() {

--- a/web/src/routes/_authorized/__tests__/messages.test.tsx
+++ b/web/src/routes/_authorized/__tests__/messages.test.tsx
@@ -22,7 +22,14 @@ vi.mock('#/lib/queries/AuthQueries.ts', () => ({
 }))
 
 vi.mock('@tanstack/react-router', () => ({
-  createFileRoute: () => () => ({}),
+  createFileRoute: () => () => ({
+    useSearch: () => ({ conversationId: '' }),
+  }),
+}))
+
+vi.mock('#/lib/queries/NotificationQueries.ts', () => ({
+  useNotifications: () => ({ data: [] }),
+  useMarkAllNotificationsRead: () => ({ mutate: vi.fn() }),
 }))
 
 const MOCK_CONVERSATIONS = [

--- a/web/src/routes/_authorized/dashboard.tsx
+++ b/web/src/routes/_authorized/dashboard.tsx
@@ -11,6 +11,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { ArrowRight, Bell, CalendarDays, Check, CheckCircle2, Clock, Loader2, XCircle, X as XIcon } from 'lucide-react'
 import { useState, useEffect, useRef } from "react"
+import type { Notification } from "#/lib/queries/NotificationQueries.ts"
 import {toast} from "sonner";
 
 
@@ -77,18 +78,24 @@ export function DashboardHome() {
   const { data: notifications = [] } = useNotifications()
   const { mutate: markAllRead } = useMarkAllNotificationsRead()
 
-  const pendingIdsRef = useRef<string[]>([])
-  useEffect(() => {
-    pendingIdsRef.current = notifications.filter(n => n.type !== 'new_message').map(n => n.id)
-  }, [notifications])
+  // Accumulate non-message notifications as they arrive via polling.
+  // Each poll only adds genuinely new ones; already-seen IDs are skipped.
+  // Marking as read happens immediately on arrival, separate from visibility.
+  const [visibleNotifications, setVisibleNotifications] = useState<Notification[]>([])
+  const seenIds = useRef<Set<string>>(new Set())
 
   useEffect(() => {
-    return () => {
-      if (pendingIdsRef.current.length > 0) {
-        markAllRead(pendingIdsRef.current)
-      }
-    }
-  }, [markAllRead])
+    if (notifications.length === 0) return
+
+    const incoming = notifications.filter(n => !seenIds.current.has(n.id))
+    if (incoming.length === 0) return
+
+    incoming.forEach(n => seenIds.current.add(n.id))
+    setVisibleNotifications(prev => [...prev, ...incoming])
+
+    const unreadIds = incoming.filter(n => n.type !== 'new_message' && !n.is_read).map(n => n.id)
+    if (unreadIds.length > 0) markAllRead(unreadIds)
+  }, [notifications, markAllRead])
 
   const mode = (data?.app_usage_mode?.toLowerCase() as 'mentor' | 'mentee') ?? 'mentee'
   return (
@@ -109,14 +116,14 @@ export function DashboardHome() {
         )}
       </div>
 
-      {notifications.length > 0 && (
+      {visibleNotifications.length > 0 && (
         <section className="flex flex-col gap-3">
           <Heading as="h3" className="text-xl flex items-center gap-2">
             <Bell className="w-5 h-5 text-accent" />
             Notifications
           </Heading>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-            {notifications.map(n => (
+            {visibleNotifications.map(n => (
               <NotificationItem key={n.id} notification={n} />
             ))}
           </div>

--- a/web/src/routes/_authorized/dashboard.tsx
+++ b/web/src/routes/_authorized/dashboard.tsx
@@ -1,14 +1,16 @@
 // web/src/routes/_authorized/dashboard.tsx
 import { meQueryOptions } from "#/lib/queries/AuthQueries.ts"
 import { useMeetingSessions, useMyRequests, useRespondToRequest } from "#/lib/queries/MentorshipQueries.ts"
+import { useNotifications, useMarkAllNotificationsRead } from "#/lib/queries/NotificationQueries.ts"
 import { getInitials } from "#/lib/utils.ts"
 import { Body, Heading, Muted } from '@/components/Typography'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { NotificationItem } from '@/components/notifications/NotificationItem'
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { ArrowRight, CalendarDays, Check, CheckCircle2, Clock, Loader2, XCircle, X as XIcon } from 'lucide-react'
-import { useState } from "react"
+import { ArrowRight, Bell, CalendarDays, Check, CheckCircle2, Clock, Loader2, XCircle, X as XIcon } from 'lucide-react'
+import { useState, useEffect, useRef } from "react"
 import {toast} from "sonner";
 
 
@@ -71,22 +73,55 @@ function UserAvatar({ name }: Readonly<{ name: string }>) {
 
 export function DashboardHome() {
 
-  const { data, isSuccess } = useQuery(meQueryOptions)
+  const { data } = useQuery(meQueryOptions)
+  const { data: notifications = [] } = useNotifications()
+  const { mutate: markAllRead } = useMarkAllNotificationsRead()
+
+  const pendingIdsRef = useRef<string[]>([])
+  useEffect(() => {
+    pendingIdsRef.current = notifications.filter(n => n.type !== 'new_message').map(n => n.id)
+  }, [notifications])
+
+  useEffect(() => {
+    return () => {
+      if (pendingIdsRef.current.length > 0) {
+        markAllRead(pendingIdsRef.current)
+      }
+    }
+  }, [markAllRead])
 
   const mode = (data?.app_usage_mode?.toLowerCase() as 'mentor' | 'mentee') ?? 'mentee'
   return (
     <div className="page-wrap py-10 rise-in flex flex-col gap-10">
-      {isSuccess && (
-          <p className="text-xs text-green-600">Logged in as: {data?.email}</p>
-      )}
-      <div className="flex flex-col gap-2">
-        <Heading as="h2">{mode === 'mentor' ? 'Mentor Dashboard' : 'Mentee Dashboard'}</Heading>
-        <Body className="text-ink-soft max-w-2xl">
-          {mode === 'mentor' 
-            ? 'Review incoming mentorship requests and manage your upcoming teaching sessions.' 
-            : 'Track your learning goals, view the status of your requests, and prepare for upcoming sessions.'}
-        </Body>
+      <div className="flex items-start justify-between gap-6">
+        <div className="flex flex-col gap-2">
+          <Heading as="h2">{mode === 'mentor' ? 'Mentor Dashboard' : 'Mentee Dashboard'}</Heading>
+          <Body className="text-ink-soft max-w-xl">
+            {mode === 'mentor'
+              ? 'Review incoming mentorship requests and manage your upcoming teaching sessions.'
+              : 'Track your learning goals, view the status of your requests, and prepare for upcoming sessions.'}
+          </Body>
+        </div>
+        {mode === 'mentor' && (
+          <Link to="/profiles/$username" params={{ username: data?.username ?? '' }} hash="availability" className="shrink-0 mt-1">
+            <Button variant="outline" size="sm">+ Add Availability</Button>
+          </Link>
+        )}
       </div>
+
+      {notifications.length > 0 && (
+        <section className="flex flex-col gap-3">
+          <Heading as="h3" className="text-xl flex items-center gap-2">
+            <Bell className="w-5 h-5 text-accent" />
+            Notifications
+          </Heading>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+            {notifications.map(n => (
+              <NotificationItem key={n.id} notification={n} />
+            ))}
+          </div>
+        </section>
+      )}
 
       {mode === 'mentor' ? <MentorDashboardView /> : <MenteeDashboardView />}
     </div>
@@ -121,6 +156,11 @@ function MenteeDashboardView() {
             <Heading as="h3" className="text-xl flex items-center gap-2">
               <CalendarDays className="w-5 h-5 text-accent" />
               Upcoming Sessions
+              {!sessionsLoading && upcomingSessions.length > 0 && (
+                <span className="inline-flex items-center justify-center h-5 min-w-5 px-1 rounded-full bg-accent/15 text-accent text-xs font-bold">
+                  {upcomingSessions.length}
+                </span>
+              )}
             </Heading>
             <div className="flex flex-col gap-4">
               {sessionsLoading && (
@@ -131,7 +171,7 @@ function MenteeDashboardView() {
               {!sessionsLoading && displaySessions.length === 0 && (
                   <Card className="island-shell border-line bg-white shadow-sm">
                     <CardContent className="py-8 text-center">
-                      <Muted>No upcoming sessions in the next 7 days.</Muted>
+                      <Muted>No upcoming sessions yet.</Muted>
                     </CardContent>
                   </Card>
               )}
@@ -197,7 +237,14 @@ function MenteeDashboardView() {
         {/* RIGHT COLUMN: Sent Requests */}
         <div className="flex flex-col gap-8">
           <section className="space-y-5">
-            <Heading as="h3" className="text-xl">Sent Requests</Heading>
+            <Heading as="h3" className="text-xl flex items-center gap-2">
+              Sent Requests
+              {!requestsLoading && sentRequests.length > 0 && (
+                <span className="inline-flex items-center justify-center h-5 min-w-5 px-1 rounded-full bg-accent/15 text-accent text-xs font-bold">
+                  {sentRequests.length}
+                </span>
+              )}
+            </Heading>
             <div className="flex flex-col gap-4">
               {requestsLoading && (
                   <div className="flex justify-center py-8">
@@ -207,8 +254,11 @@ function MenteeDashboardView() {
 
               {!requestsLoading && sentRequests.length === 0 && (
                   <Card className="island-shell border-line bg-white shadow-sm">
-                    <CardContent className="py-8 text-center">
+                    <CardContent className="py-8 text-center flex flex-col items-center gap-3">
                       <Muted>No pending requests right now.</Muted>
+                      <Link to="/discover">
+                        <Button variant="outline" size="sm">Find a Mentor <ArrowRight className="w-3.5 h-3.5 ml-1.5" /></Button>
+                      </Link>
                     </CardContent>
                   </Card>
               )}
@@ -338,6 +388,11 @@ function MentorDashboardView() {
             <Heading as="h3" className="text-xl flex items-center gap-2">
               <CalendarDays className="w-5 h-5 text-accent" />
               Upcoming Sessions
+              {!sessionsLoading && upcomingSessions.length > 0 && (
+                <span className="inline-flex items-center justify-center h-5 min-w-5 px-1 rounded-full bg-accent/15 text-accent text-xs font-bold">
+                  {upcomingSessions.length}
+                </span>
+              )}
             </Heading>
             <div className="flex flex-col gap-4">
               {sessionsLoading && (
@@ -348,8 +403,11 @@ function MentorDashboardView() {
 
               {!sessionsLoading && upcomingSessions.length === 0 && (
                   <Card className="island-shell border-line bg-white shadow-sm">
-                    <CardContent className="py-8 text-center">
+                    <CardContent className="py-8 text-center flex flex-col items-center gap-3">
                       <Muted>No upcoming sessions in the next 7 days.</Muted>
+                      <Link to="/profiles/$username" params={{ username: me?.username ?? '' }} hash="availability">
+                        <Button variant="outline" size="sm">+ Add Availability</Button>
+                      </Link>
                     </CardContent>
                   </Card>
               )}
@@ -417,7 +475,14 @@ function MentorDashboardView() {
         {/* RIGHT COLUMN: Incoming Requests — unchanged */}
         <div className="flex flex-col gap-10">
           <section className="space-y-5">
-            <Heading as="h3" className="text-xl">Incoming Requests</Heading>
+            <Heading as="h3" className="text-xl flex items-center gap-2">
+              Incoming Requests
+              {!requestsLoading && displayRequests.length > 0 && (
+                <span className="inline-flex items-center justify-center h-5 min-w-5 px-1 rounded-full bg-accent/15 text-accent text-xs font-bold">
+                  {pendingRequests.length}
+                </span>
+              )}
+            </Heading>
             <div className="flex flex-col gap-4">
               {requestsLoading && (
                   <div className="flex justify-center py-8">
@@ -431,6 +496,7 @@ function MentorDashboardView() {
                     </CardContent>
                   </Card>
               )}
+
               {displayRequests.map(req => {
                 const responded = respondedIds[req.id]
                 return (

--- a/web/src/routes/_authorized/dashboard.tsx
+++ b/web/src/routes/_authorized/dashboard.tsx
@@ -1,7 +1,7 @@
 // web/src/routes/_authorized/dashboard.tsx
 import { meQueryOptions } from "#/lib/queries/AuthQueries.ts"
 import { useMeetingSessions, useMyRequests, useRespondToRequest } from "#/lib/queries/MentorshipQueries.ts"
-import { useNotifications, useMarkAllNotificationsRead } from "#/lib/queries/NotificationQueries.ts"
+import { useNotifications, useMarkAllNotificationsRead, NOTIFICATION_INVALIDATION_MAP } from "#/lib/queries/NotificationQueries.ts"
 import { getInitials } from "#/lib/utils.ts"
 import { Body, Heading, Muted } from '@/components/Typography'
 import { Button } from '@/components/ui/button'
@@ -77,6 +77,7 @@ export function DashboardHome() {
   const { data } = useQuery(meQueryOptions)
   const { data: notifications = [] } = useNotifications()
   const { mutate: markAllRead } = useMarkAllNotificationsRead()
+  const queryClient = useQueryClient()
 
   // Accumulate non-message notifications as they arrive via polling.
   // Each poll only adds genuinely new ones; already-seen IDs are skipped.
@@ -95,7 +96,15 @@ export function DashboardHome() {
 
     const unreadIds = incoming.filter(n => n.type !== 'new_message' && !n.is_read).map(n => n.id)
     if (unreadIds.length > 0) markAllRead(unreadIds)
-  }, [notifications, markAllRead])
+
+    const keysToInvalidate = new Set<string>()
+    for (const n of incoming) {
+      for (const key of NOTIFICATION_INVALIDATION_MAP[n.type]) {
+        keysToInvalidate.add(JSON.stringify(key))
+      }
+    }
+    keysToInvalidate.forEach(k => queryClient.invalidateQueries({ queryKey: JSON.parse(k) }))
+  }, [notifications, markAllRead, queryClient])
 
   const mode = (data?.app_usage_mode?.toLowerCase() as 'mentor' | 'mentee') ?? 'mentee'
   return (

--- a/web/src/routes/_authorized/messages.tsx
+++ b/web/src/routes/_authorized/messages.tsx
@@ -8,6 +8,7 @@ import {
     useSendMessage,
     type Conversation,
 } from '#/lib/queries/MessagingQueries.ts'
+import { useNotifications, useMarkAllNotificationsRead } from '#/lib/queries/NotificationQueries.ts'
 import { getInitials } from '#/lib/utils.ts'
 import { Button } from '@/components/ui/button'
 import { Loader2, MessageSquare, Send } from 'lucide-react'
@@ -15,6 +16,9 @@ import { cn } from '#/lib/utils.ts'
 
 export const Route = createFileRoute('/_authorized/messages')({
     component: MessagesPage,
+    validateSearch: (search: Record<string, unknown>) => ({
+        conversationId: (search.conversationId as string) ?? '',
+    }),
 })
 
 // ---------------------------------------------------------------------------
@@ -22,7 +26,26 @@ export const Route = createFileRoute('/_authorized/messages')({
 // ---------------------------------------------------------------------------
 
 export function MessagesPage() {
-    const [selectedId, setSelectedId] = useState<string | null>(null)
+    const { conversationId } = Route.useSearch()
+    const [selectedId, setSelectedId] = useState<string | null>(conversationId || null)
+
+    const { data: notifications = [] } = useNotifications()
+    const { mutate: markAllRead } = useMarkAllNotificationsRead()
+
+    const pendingMsgIdsRef = useRef<string[]>([])
+    useEffect(() => {
+        pendingMsgIdsRef.current = notifications
+            .filter(n => n.type === 'new_message')
+            .map(n => n.id)
+    }, [notifications])
+
+    useEffect(() => {
+        return () => {
+            if (pendingMsgIdsRef.current.length > 0) {
+                markAllRead(pendingMsgIdsRef.current)
+            }
+        }
+    }, [markAllRead])
 
     return (
         <div className="p-4 md:p-6 h-[calc(100vh-3.5rem)]">


### PR DESCRIPTION
## Related Issue

Closes #382 
 ### Description

Connects the existing backend notification endpoints to the web frontend. Adds a `NotificationItem` component with type-driven variants, a `NotificationQueries` module with 30s polling, notification display on the dashboard, and unread indicators in the header nav. Also includes several dashboard UI improvements.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or configuration

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code

## Notes

### Notification queries (`lib/queries/NotificationQueries.ts`)
- `useNotifications()` — fetches unread notifications from `GET /api/notifications/`, polls every 30s.
- `useMarkAllNotificationsRead()` — calls `PUT /api/notifications/<id>/read/` for each ID in parallel via `Promise.all`.

### Notification component (`components/notifications/NotificationItem.tsx`)
- Renders a left-bordered card with a type-driven icon and color (9 variants: `new_mentorship_request`, `new_match`, `new_message`, etc.).
- `new_message` notifications include a "View conversation →" link that deep-links to the correct conversation via `/messages?conversationId=<id>`.

### Dashboard (`routes/_authorized/dashboard.tsx`)
- Notifications section rendered above sessions/requests grid in a 2-column responsive layout.
- Non-message notifications are marked as read on dashboard unmount (not mount), so the user sees them while on the page.
- Minor UI improvements: removed leftover debug line, header row CTA (+ Add Availability for mentors), count badges on section headings, better empty states.

### Header (`components/layout/AuthorizedHeader.tsx`)
- Small teal dot on the Dashboard nav link when any unread notifications exist.
- Separate dot on the Messages nav link only for `new_message` type notifications.

### Messages page (`routes/_authorized/messages.tsx`)
- Added `validateSearch: { conversationId }` so notification links can pre-select a conversation.
- `new_message` notifications are marked as read on messages page unmount.