### PR TITLE
feat: add username patch api endpoint

### DIFF
--- a/backend/profiles/serializers.py
+++ b/backend/profiles/serializers.py
@@ -1,8 +1,10 @@
-"""Serializers for profile self-service API endpoints."""
-
 from datetime import datetime
+from typing import Any, TYPE_CHECKING, cast
 
+from django.contrib.auth import get_user_model
 from django.contrib.gis.geos import Point
+from django.core import validators
+from django.db import transaction
 from django.utils import timezone
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
@@ -10,16 +12,25 @@ from rest_framework import serializers
 
 from .models import AvailabilitySlot, Profile, Skill
 
+if TYPE_CHECKING:
+    from accounts.models import User as UserType
+else:
+    UserType = Any
+
+User = get_user_model()
+
 
 class LocationField(serializers.Field):
     """Serialize a PointField as {latitude, longitude} and accept the same on input."""
 
-    def to_representation(self, value):
+    def to_representation(self, value: Any) -> dict[str, float] | None:
+        """Convert PointField to {latitude, longitude} dictionary."""
         if value is None:
             return None
         return {"latitude": value.y, "longitude": value.x}
 
-    def to_internal_value(self, data):
+    def to_internal_value(self, data: Any) -> Point | None:
+        """Convert {latitude, longitude} dictionary to PointField."""
         if data is None:
             return None
         if isinstance(data, str) and not data.strip():
@@ -130,6 +141,7 @@ class MenteeProfileResponseSerializer(serializers.ModelSerializer):
         model = Profile
         fields = (
             "id",
+            "username",
             "full_name",
             "bio",
             "hidden",
@@ -138,7 +150,8 @@ class MenteeProfileResponseSerializer(serializers.ModelSerializer):
         )
         read_only_fields = fields
 
-    def to_representation(self, instance):
+    def to_representation(self, instance: Profile) -> dict[str, Any]:
+        """Add 'hidden' field to the output representation."""
         ret = super().to_representation(instance)
         # Invert is_visible to get "hidden" semantics
         ret["hidden"] = not instance.is_visible
@@ -160,6 +173,7 @@ class MentorProfileResponseSerializer(serializers.ModelSerializer):
         model = Profile
         fields = (
             "id",
+            "username",
             "full_name",
             "title",
             "bio",
@@ -203,7 +217,28 @@ class ProfileResponseSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
-class ProfileUpdateSerializer(serializers.ModelSerializer):
+class UsernameUpdateMixin:
+    """Shared logic for username validation and cross-model synchronization."""
+
+    def _validate_unique_username(self, value: str, instance: Profile) -> str:
+        """Ensure username is unique across both Profile and User models."""
+        username = value.lower()
+        # Check Profile uniqueness
+        if Profile.objects.filter(username=username).exclude(id=instance.id).exists():
+            raise serializers.ValidationError("This username is already taken.")
+        # Check User uniqueness
+        if User.objects.filter(username=username).exclude(id=instance.user.id).exists():
+            raise serializers.ValidationError("This username is already taken.")
+        return username
+
+    def _sync_user_username(self, user: Any, new_username: str) -> None:
+        """Update the username on the User model if it has changed."""
+        if user.username != new_username:
+            user.username = new_username
+            user.save(update_fields=["username"])
+
+
+class ProfileUpdateSerializer(UsernameUpdateMixin, serializers.ModelSerializer):
     """Partial update serializer for authenticated user's profile."""
 
     location = LocationField(required=False, allow_null=True)
@@ -212,9 +247,21 @@ class ProfileUpdateSerializer(serializers.ModelSerializer):
         required=False,
     )
 
+    username = serializers.CharField(
+        max_length=50,
+        required=False,
+        validators=[
+            validators.RegexValidator(
+                regex=r"^[a-zA-Z0-9_]+$",
+                message="Username can only contain alphanumeric characters and underscores.",
+            )
+        ],
+    )
+
     class Meta:
         model = Profile
         fields = (
+            "username",
             "display_name",
             "bio",
             "picture_url",
@@ -225,12 +272,54 @@ class ProfileUpdateSerializer(serializers.ModelSerializer):
             "skills",
         )
 
-    def validate(self, attrs: dict) -> dict:
+    def validate_username(self, value: str) -> str:
+        """Ensure username is unique across both Profile and User models."""
+        if self.instance is None:
+            return value.lower()
+        return self._validate_unique_username(value, cast(Profile, self.instance))
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         """Validate profile update payload."""
         return attrs
 
-    def update(self, instance: Profile, validated_data: dict) -> Profile:
-        """Apply partial updates."""
+    @transaction.atomic
+    def update(self, instance: Profile, validated_data: dict[str, Any]) -> Profile:
+        """Apply partial updates and sync username to User model if changed."""
+        new_username = validated_data.get("username")
+        if new_username:
+            self._sync_user_username(instance.user, new_username)
+
+        return super().update(instance, validated_data)
+
+
+class ProfileUsernameUpdateSerializer(UsernameUpdateMixin, serializers.ModelSerializer):
+    """Dedicated serializer for updating only the username."""
+
+    username = serializers.CharField(
+        max_length=50,
+        validators=[
+            validators.RegexValidator(
+                regex=r"^[a-zA-Z0-9_]+$",
+                message="Username can only contain alphanumeric characters and underscores.",
+            )
+        ],
+    )
+
+    class Meta:
+        model = Profile
+        fields = ("username",)
+
+    def validate_username(self, value: str) -> str:
+        """Ensure username is unique across both Profile and User models."""
+        if self.instance is None:
+            return value.lower()
+        return self._validate_unique_username(value, cast(Profile, self.instance))
+
+    @transaction.atomic
+    def update(self, instance: Profile, validated_data: dict[str, Any]) -> Profile:
+        """Update username on both Profile and User models."""
+        new_username = validated_data["username"]
+        self._sync_user_username(instance.user, new_username)
         return super().update(instance, validated_data)
 
 
@@ -344,11 +433,13 @@ class PublicMentorProfileSearchResultSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
     def get_full_name(self, obj: Profile) -> str:
+        """Return display name or initials based on 'show_initials_only' setting."""
         if obj.show_initials_only:
             return _get_display_initials(obj.display_name or "")
         return obj.display_name
 
-    def to_representation(self, instance: Profile) -> dict:
+    def to_representation(self, instance: Profile) -> dict[str, Any]:
+        """Add 'hidden' field to the output representation."""
         ret = super().to_representation(instance)
         # Invert is_visible to get "hidden" semantics.
         ret["hidden"] = not instance.is_visible

--- a/backend/profiles/tests.py
+++ b/backend/profiles/tests.py
@@ -434,6 +434,91 @@ class ProfileByUsernameAPIViewTests(TestCase):
         self.assertEqual(response.status_code, 404)
 
 
+class ProfileUsernameUpdateTests(TestCase):
+    """Integration tests for username update endpoints."""
+
+    def setUp(self) -> None:
+        """Create test user, profile, and authenticated client."""
+        self.api_client: Any = APIClient()
+        self.user = User.objects.create_user(
+            email="username-update@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTEE,
+        )
+        # Profile is created by RegisterSerializer logic if called via view,
+        # but here we ensure it exists for the model tests.
+        self.profile = Profile.objects.create(
+            user=self.user,
+            display_name="Username Update User",
+        )
+
+        self.access_token = str(RefreshToken.for_user(self.user).access_token)
+        self.api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.access_token}")
+
+        self.me_url = "/api/profiles/me/"
+        self.username_url = "/api/profiles/me/username/"
+
+    def test_patch_username_via_me_endpoint_success(self) -> None:
+        """User can change username via the general profile me endpoint."""
+        new_username = "new_cool_username"
+        response = self.api_client.patch(
+            self.me_url,
+            {"username": new_username},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.user.refresh_from_db()
+        self.profile.refresh_from_db()
+
+        self.assertEqual(self.user.username, new_username)
+        self.assertEqual(self.profile.username, new_username)
+
+    def test_patch_username_via_dedicated_endpoint_success(self) -> None:
+        """User can change username via the dedicated me/username endpoint."""
+        new_username = "dedicated_username"
+        response = self.api_client.patch(
+            self.username_url,
+            {"username": new_username},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.user.refresh_from_db()
+        self.profile.refresh_from_db()
+
+        self.assertEqual(self.user.username, new_username)
+        self.assertEqual(self.profile.username, new_username)
+
+    def test_patch_username_validation_error_taken(self) -> None:
+        """User cannot change username to one that is already taken."""
+        User.objects.create_user(
+            email="other@example.com",
+            password="SecurePass123",
+            username="taken_username",
+        )
+
+        response = self.api_client.patch(
+            self.username_url,
+            {"username": "taken_username"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("username", response.json())
+
+    def test_patch_username_validation_error_invalid_chars(self) -> None:
+        """User cannot change username to one with invalid characters."""
+        response = self.api_client.patch(
+            self.username_url,
+            {"username": "invalid username!"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("username", response.json())
+
+
 class SkillListAPIViewTests(TestCase):
     """Tests for GET /api/profiles/skills/ endpoint."""
 

--- a/backend/profiles/urls.py
+++ b/backend/profiles/urls.py
@@ -12,6 +12,7 @@ from .views import (
     ProfileByUsernameAPIView,
     ProfileReviewsByUsernameAPIView,
     ProfileMeAPIView,
+    ProfileUsernameUpdateAPIView,
     PublicMentorProfilesSearchListAPIView,
     RecentlyAddedMentorsListAPIView,
     SkillListAPIView,
@@ -20,6 +21,7 @@ from .views import (
 urlpatterns = [
     path("", PublicMentorProfilesSearchListAPIView.as_view(), name="mentor-profiles-search"),
     path("me/", ProfileMeAPIView.as_view(), name="profile-me"),
+    path("me/username/", ProfileUsernameUpdateAPIView.as_view(), name="profile-me-username"),
     path(
         "me/availability-slots/",
         MyAvailabilitySlotListCreateAPIView.as_view(),

--- a/backend/profiles/views.py
+++ b/backend/profiles/views.py
@@ -27,6 +27,7 @@ from .serializers import (
     MentorProfileResponseSerializer,
     ProfileResponseSerializer,
     ProfileUpdateSerializer,
+    ProfileUsernameUpdateSerializer,
     PublicMentorProfileSearchListResponseSerializer,
     PublicMentorProfileSearchResultSerializer,
     SkillSerializer,
@@ -165,6 +166,36 @@ class ProfileMeAPIView(ProfileLookupMixin, APIView):
             return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
 
         serializer = ProfileUpdateSerializer(profile, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        return Response(ProfileResponseSerializer(profile).data, status=status.HTTP_200_OK)
+
+
+class ProfileUsernameUpdateAPIView(ProfileLookupMixin, APIView):
+    """Canonical self-scoped username update endpoint."""
+
+    permission_classes = [IsUser]
+
+    @extend_schema(
+        request=ProfileUsernameUpdateSerializer,
+        responses={
+            200: ProfileResponseSerializer,
+            400: OpenApiResponse(description="Validation error."),
+            401: OpenApiResponse(description="Authentication required."),
+            403: OpenApiResponse(description="Account banned."),
+            404: OpenApiResponse(description="Profile not found."),
+        },
+        description="Update authenticated user's username using `/api/profiles/me/username/`.",
+        tags=["Profiles"],
+    )
+    def patch(self, request: Request) -> Response:
+        """Update authenticated user's username."""
+        profile = self._get_request_profile_or_404(request)
+        if profile is None:
+            return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
+
+        serializer = ProfileUsernameUpdateSerializer(profile, data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
         serializer.save()
 


### PR DESCRIPTION
## Related Issue

Closes #399 

## Description

This PR implements the functionality for users to change their `username`, which is crucial for managing their profile URLs. It also includes significant refactoring to improve code quality and resolve static analysis warnings.

**Key Changes:**
- **New Endpoints**: Added `PATCH /api/profiles/me/username/` for dedicated username updates and integrated the `username` field into the general `PATCH /api/profiles/me/` endpoint.
- **Model Synchronization**: Implemented atomic synchronization between `Profile.username` and `User.username` to maintain data consistency.
- **Validation**: Added unique constraints and regex validation for usernames (alphanumeric and underscores).
- **Code Quality**: Refactored duplicated validation logic into a `UsernameUpdateMixin` and added comprehensive type hints across the `profiles` serializers to resolve Pylance and SonarQube issues.
- **API Visibility**: Updated response serializers to include the `username` field in mentee and mentor profile shapes.
- **Testing**: Added integration tests to verify successful updates and validation error handling.

## Type of Change

- [x] New feature
- [x] Refactoring (no functional changes)

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code

## Notes

The refactoring effort specifically targeted Pylance "Any" type warnings and SonarQube code duplication alerts in the serializer layer. All existing profile functionality remains intact with improved type safety.