### PR TITLE
feat: added logic to update updated_at upon messaging

### DIFF
--- a/backend/messaging/signals.py
+++ b/backend/messaging/signals.py
@@ -7,7 +7,7 @@ from django.dispatch import receiver
 
 from mentorship.models import Match
 
-from .models import Conversation
+from .models import Conversation, Message
 
 
 @receiver(
@@ -26,3 +26,23 @@ def create_conversation_for_new_match(
         return
 
     Conversation.objects.get_or_create(match=instance)
+
+
+@receiver(
+    post_save,
+    sender=Message,
+    dispatch_uid="messaging.update_conversation_timestamp",
+)
+def update_conversation_timestamp(
+    sender: type[Message],
+    instance: Message,
+    created: bool,
+    **kwargs: Any,
+) -> None:
+    """Update the conversation's updated_at timestamp when a new message is sent."""
+    if not created or kwargs.get("raw", False):
+        return
+
+    # Using save() ensures that auto_now=True fields (updated_at) are refreshed.
+    # We specify update_fields for efficiency.
+    instance.conversation.save(update_fields=["updated_at"])

--- a/backend/messaging/views.py
+++ b/backend/messaging/views.py
@@ -43,9 +43,11 @@ class ConversationListAPIView(APIView):
         except Profile.DoesNotExist:
             return Response([], status=status.HTTP_200_OK)
 
-        conversations = Conversation.objects.filter(
-            Q(match__mentor=profile) | Q(match__mentee=profile)
-        ).select_related("match__mentor", "match__mentee")
+        conversations = (
+            Conversation.objects.filter(Q(match__mentor=profile) | Q(match__mentee=profile))
+            .select_related("match__mentor", "match__mentee")
+            .order_by("-updated_at")
+        )
 
         return Response(
             ConversationSerializer(conversations, many=True).data,
@@ -146,9 +148,12 @@ class ConversationDetailAPIView(APIView):
             body=validated_data.get("body", ""),
             attachment=validated_data.get("attachment"),
         )
-        
-        # Notify the other participant
-        other_profile = conversation.match.mentor if profile == conversation.match.mentee else conversation.match.mentee
+
+        other_profile = (
+            conversation.match.mentor
+            if profile == conversation.match.mentee
+            else conversation.match.mentee
+        )
         Notification.objects.create(
             user=other_profile.user,
             type=NotificationType.NEW_MESSAGE,


### PR DESCRIPTION
## Related Issue

Closes #405 

## Description

This PR implements activity tracking for private conversations. It ensures that whenever a new message is sent, the parent conversation's `updated_at` timestamp is updated. Additionally, the conversation list API now sorts results by this timestamp to prioritize active chats.

Key changes:
- Added `post_save` signal in `backend/messaging/signals.py` to "touch" the conversation when a message is saved.
- Updated `ConversationListAPIView` in `backend/messaging/views.py` to use `.order_by("-updated_at")`.

## Type of Change

- [x] New feature

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [ ] I have written or updated tests where applicable
- [x] I have performed a self-review of my code

## Notes

The implementation uses `instance.conversation.save(update_fields=["updated_at"])` to efficiently update only the timestamp field and trigger the `auto_now` logic.