### PR TITLE
fix: fixed timezone issues by adding middleware

### DIFF
--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -1,0 +1,22 @@
+"""Custom middleware for the core project."""
+
+from typing import Any, Callable
+
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse
+from django.utils import timezone
+
+
+class TimezoneMiddleware:
+    """
+    Middleware to ensure the project's configured timezone is active for every request.
+    This ensures that timezone.localtime() and other localized operations
+    consistently use settings.TIME_ZONE (e.g., Europe/Istanbul).
+    """
+
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]) -> None:
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        timezone.activate(timezone.get_default_timezone())
+        return self.get_response(request)

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -118,6 +118,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "core.middleware.TimezoneMiddleware",
 ]
 
 ROOT_URLCONF = "core.urls"

--- a/backend/core/utils/__init__.py
+++ b/backend/core/utils/__init__.py
@@ -1,0 +1,1 @@
+# Init file for core utils

--- a/backend/core/utils/timezone.py
+++ b/backend/core/utils/timezone.py
@@ -1,0 +1,35 @@
+"""Timezone utility functions for consistent localized datetime handling."""
+
+import zoneinfo
+from datetime import datetime
+from typing import Any
+
+from django.conf import settings
+from django.utils import timezone
+
+
+def get_project_timezone() -> zoneinfo.ZoneInfo:
+    """Return the ZoneInfo object for the configured project timezone."""
+    return zoneinfo.ZoneInfo(settings.TIME_ZONE)
+
+
+def to_local_time(dt: datetime | None) -> datetime | None:
+    """
+    Convert a datetime to the project's local timezone.
+    If dt is naive, it's assumed to be in the project's default timezone first.
+    """
+    if dt is None:
+        return None
+
+    if timezone.is_naive(dt):
+        dt = timezone.make_aware(dt, timezone.get_default_timezone())
+
+    return timezone.localtime(dt, get_project_timezone())
+
+
+def format_local_datetime(dt: datetime | None, fmt: str = "%Y-%m-%d %H:%M:%S") -> str:
+    """Convert to local time and format as string."""
+    local_dt = to_local_time(dt)
+    if local_dt is None:
+        return ""
+    return local_dt.strftime(fmt)

--- a/backend/mentorship/serializers.py
+++ b/backend/mentorship/serializers.py
@@ -1,6 +1,7 @@
 """Serializers for mentorship request and match API endpoints."""
 
 from django.utils import timezone
+from core.utils.timezone import to_local_time
 from rest_framework import serializers
 
 from accounts.models import AppUsageMode
@@ -46,25 +47,25 @@ class MentorshipRequestSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
     def get_slot_date(self, obj: MentorshipRequest) -> str | None:
-        """Return selected slot date in local timezone."""
+        """Return selected slot date in project local timezone."""
         slot_start_at = obj.slot.start_at if obj.slot is not None else obj.initial_session_start_at
         if slot_start_at is None:
             return None
-        return timezone.localtime(slot_start_at).date().isoformat()
+        return to_local_time(slot_start_at).date().isoformat()
 
     def get_slot_start_time(self, obj: MentorshipRequest) -> str | None:
-        """Return selected slot start time in local timezone."""
+        """Return selected slot start time in project local timezone."""
         slot_start_at = obj.slot.start_at if obj.slot is not None else obj.initial_session_start_at
         if slot_start_at is None:
             return None
-        return timezone.localtime(slot_start_at).time().replace(microsecond=0).isoformat()
+        return to_local_time(slot_start_at).time().replace(microsecond=0).isoformat()
 
     def get_slot_end_time(self, obj: MentorshipRequest) -> str | None:
-        """Return selected slot end time in local timezone."""
+        """Return selected slot end time in project local timezone."""
         slot_end_at = obj.slot.end_at if obj.slot is not None else obj.initial_session_end_at
         if slot_end_at is None:
             return None
-        return timezone.localtime(slot_end_at).time().replace(microsecond=0).isoformat()
+        return to_local_time(slot_end_at).time().replace(microsecond=0).isoformat()
 
 
 class MentorshipRequestCreateSerializer(serializers.Serializer):
@@ -190,16 +191,16 @@ class UpcomingMenteeSessionSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
     def get_slot_date(self, obj: AvailabilitySlot) -> str:
-        """Return session date in local timezone."""
-        return timezone.localtime(obj.start_at).date().isoformat()
+        """Return session date in project local timezone."""
+        return to_local_time(obj.start_at).date().isoformat()
 
     def get_slot_start_time(self, obj: AvailabilitySlot) -> str:
-        """Return session start time in local timezone."""
-        return timezone.localtime(obj.start_at).time().replace(microsecond=0).isoformat()
+        """Return session start time in project local timezone."""
+        return to_local_time(obj.start_at).time().replace(microsecond=0).isoformat()
 
     def get_slot_end_time(self, obj: AvailabilitySlot) -> str:
-        """Return session end time in local timezone."""
-        return timezone.localtime(obj.end_at).time().replace(microsecond=0).isoformat()
+        """Return session end time in project local timezone."""
+        return to_local_time(obj.end_at).time().replace(microsecond=0).isoformat()
 
 
 class UpcomingMentorSessionSerializer(serializers.ModelSerializer):
@@ -233,16 +234,16 @@ class UpcomingMentorSessionSerializer(serializers.ModelSerializer):
             return None
 
     def get_slot_date(self, obj: AvailabilitySlot) -> str:
-        """Return session date in local timezone."""
-        return timezone.localtime(obj.start_at).date().isoformat()
+        """Return session date in project local timezone."""
+        return to_local_time(obj.start_at).date().isoformat()
 
     def get_slot_start_time(self, obj: AvailabilitySlot) -> str:
-        """Return session start time in local timezone."""
-        return timezone.localtime(obj.start_at).time().replace(microsecond=0).isoformat()
+        """Return session start time in project local timezone."""
+        return to_local_time(obj.start_at).time().replace(microsecond=0).isoformat()
 
     def get_slot_end_time(self, obj: AvailabilitySlot) -> str:
-        """Return session end time in local timezone."""
-        return timezone.localtime(obj.end_at).time().replace(microsecond=0).isoformat()
+        """Return session end time in project local timezone."""
+        return to_local_time(obj.end_at).time().replace(microsecond=0).isoformat()
 
 
 class MeetingSessionSerializer(serializers.ModelSerializer):
@@ -281,12 +282,12 @@ class MeetingSessionSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
     def get_scheduled_start_at(self, obj: MeetingSession) -> str:
-        """Return session start time in local timezone."""
-        return timezone.localtime(obj.scheduled_start_at_utc).isoformat()
+        """Return session start time in project local timezone."""
+        return to_local_time(obj.scheduled_start_at_utc).isoformat()
 
     def get_scheduled_end_at(self, obj: MeetingSession) -> str:
-        """Return session end time in local timezone."""
-        return timezone.localtime(obj.scheduled_end_at_utc).isoformat()
+        """Return session end time in project local timezone."""
+        return to_local_time(obj.scheduled_end_at_utc).isoformat()
 
     def get_my_role(self, obj: MeetingSession) -> str:
         """Return the authenticated caller role for this session."""

--- a/backend/mentorship/services.py
+++ b/backend/mentorship/services.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.db import IntegrityError, transaction
 from django.db.models import Avg, F
 from django.utils import timezone
+from core.utils.timezone import to_local_time
 
 from notifications.models import Notification, NotificationType
 from profiles.models import AvailabilitySlot, Profile
@@ -251,8 +252,8 @@ def book_match_session(*, mentor_profile: Profile, slot_id: Any, actor: Any) -> 
                     title="Slot Booked",
                     message=(
                         f"{mentee_profile.display_name} booked a slot on "
-                        f"{slot.start_at.strftime('%B %d, %Y at %H:%M')} - "
-                        f"{slot.end_at.strftime('%H:%M')}."
+                        f"{to_local_time(slot.start_at).strftime('%B %d, %Y at %H:%M')} - "
+                        f"{to_local_time(slot.end_at).strftime('%H:%M')}."
                     ),
                     actor=mentee_profile,
                     resource_type="availability_slot",

--- a/backend/profiles/serializers.py
+++ b/backend/profiles/serializers.py
@@ -11,6 +11,7 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from .models import AvailabilitySlot, Profile, Skill
+from core.utils.timezone import get_project_timezone, to_local_time
 
 if TYPE_CHECKING:
     from accounts.models import User as UserType
@@ -88,18 +89,18 @@ class AvailabilitySlotSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(OpenApiTypes.DATE)
     def get_date(self, obj: AvailabilitySlot) -> str:
-        """Return slot date in current timezone."""
-        return timezone.localtime(obj.start_at).date().isoformat()
+        """Return slot date in project timezone."""
+        return to_local_time(obj.start_at).date().isoformat()
 
     @extend_schema_field(OpenApiTypes.TIME)
     def get_startTime(self, obj: AvailabilitySlot) -> str:
-        """Return slot start time in current timezone."""
-        return timezone.localtime(obj.start_at).time().replace(microsecond=0).isoformat()
+        """Return slot start time in project timezone."""
+        return to_local_time(obj.start_at).time().replace(microsecond=0).isoformat()
 
     @extend_schema_field(OpenApiTypes.TIME)
     def get_endTime(self, obj: AvailabilitySlot) -> str:
-        """Return slot end time in current timezone."""
-        return timezone.localtime(obj.end_at).time().replace(microsecond=0).isoformat()
+        """Return slot end time in project timezone."""
+        return to_local_time(obj.end_at).time().replace(microsecond=0).isoformat()
 
     @extend_schema_field(OpenApiTypes.STR)
     def get_bookedBy(self, obj: AvailabilitySlot) -> str | None:
@@ -338,11 +339,11 @@ class AvailabilitySlotWriteSerializer(serializers.Serializer):
 
         if self.instance is not None:
             if slot_date is None:
-                slot_date = timezone.localtime(self.instance.start_at).date()
+                slot_date = to_local_time(self.instance.start_at).date()
             if start_time is None:
-                start_time = timezone.localtime(self.instance.start_at).time()
+                start_time = to_local_time(self.instance.start_at).time()
             if end_time is None:
-                end_time = timezone.localtime(self.instance.end_at).time()
+                end_time = to_local_time(self.instance.end_at).time()
 
         if slot_date is None:
             raise serializers.ValidationError({"date": "Date is required."})
@@ -361,7 +362,7 @@ class AvailabilitySlotWriteSerializer(serializers.Serializer):
                 {"endTime": "endTime must be greater than startTime."}
             )
 
-        timezone_info = timezone.get_current_timezone()
+        timezone_info = get_project_timezone()
         attrs["start_at"] = timezone.make_aware(
             datetime.combine(slot_date, start_time),
             timezone_info,


### PR DESCRIPTION
## Related Issue

Closes #408 

## Description

This PR standardizes timezone handling across the backend to ensure all user-facing timestamps are consistently localized to `Europe/Istanbul` (UTC+3).

Key changes:
- **TimezoneMiddleware**: Ensures the project's timezone is active for every request thread, enabling automatic localization for `DateTimeField` and `timezone.localtime()`.
- **Timezone Utility**: Created `backend/core/utils/timezone.py` as a central helper for robust datetime localization.
- **Serializer Refactor**: Updated `profiles` and `mentorship` serializers to use the unified `to_local_time` helper, fixing the "6:00 vs 9:00" discrepancy.
- **Notification Fix**: Corrected manual string formatting in `mentorship/services.py` to use localized times for notification messages.

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable (270 existing tests verified in Docker)
- [x] I have performed a self-review of my code

## Notes

Verified the fixes by running the test suite in the Dockerized environment (`docker compose exec backend python manage.py test profiles mentorship`). All 270 tests passed.