### PR TITLE
Feat/web patch username

### DIFF
--- a/web/src/components/layout/AuthorizedHeader.tsx
+++ b/web/src/components/layout/AuthorizedHeader.tsx
@@ -11,8 +11,8 @@ export function AuthorizedHeader() {
   const { data: profile } = useProfile(me?.username ?? '')
   const { data: notifications = [] } = useNotifications()
 
-  const hasUnread = notifications.length > 0
-  const hasMessageNotification = notifications.some(n => n.type === 'new_message')
+  const hasUnread = notifications.some(n => !n.is_read && n.type !== 'new_message')
+  const hasMessageNotification = notifications.some(n => n.type === 'new_message' && !n.is_read)
 
   const initials = profile?.full_name
       ? getInitials(profile.full_name)

--- a/web/src/components/profile/__tests__/AvailabilityCalendar.test.tsx
+++ b/web/src/components/profile/__tests__/AvailabilityCalendar.test.tsx
@@ -70,7 +70,7 @@ function nextWeekday(dayOfWeek: number): string {
   return `${y}-${m}-${day}`
 }
 
-const futureDate = nextWeekday(3) // next Wednesday
+const futureDate = '2030-01-09' // Wednesday of the mocked week (2030-01-07 Monday)
 
 function makeSlot(overrides = {}) {
   return {
@@ -103,6 +103,8 @@ function renderCalendar(props = {}) {
 
 describe('AvailabilityCalendar — Pending Slot Display', () => {
   beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2030-01-07T00:00:00Z')) // fixed Monday far in the future
     vi.clearAllMocks()
 
     mockUseMyMatches.mockReturnValue({ data: [] })
@@ -112,6 +114,10 @@ describe('AvailabilityCalendar — Pending Slot Display', () => {
     mockUseBookSlot.mockReturnValue({ mutate: vi.fn(), isPending: false })
     mockUseCreateSlot.mockReturnValue({ mutate: vi.fn(), isPending: false })
     mockUseDeleteSlot.mockReturnValue({ mutate: vi.fn(), isPending: false })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('shows "Requested" label on a slot that has a pending request (mentee view)', () => {

--- a/web/src/lib/queries/NotificationQueries.ts
+++ b/web/src/lib/queries/NotificationQueries.ts
@@ -71,13 +71,13 @@ export function useMarkAllNotificationsRead() {
 
 // Maps each notification type to the query keys that should be invalidated when it arrives.
 export const NOTIFICATION_INVALIDATION_MAP: Record<NotificationType, string[][]> = {
-    new_mentorship_request:      [['mentorship', 'requests']],
-    mentorship_request_rejected: [['mentorship', 'requests']],
+    new_mentorship_request:      [['mentorship', 'requests'], ['availability-slots']],
+    mentorship_request_rejected: [['mentorship', 'requests'], ['availability-slots']],
     new_match:                   [['mentorship', 'matches'], ['mentorship', 'requests']],
-    slot_booked:                 [['mentorship', 'meeting-sessions', 'me'], ['mentorship', 'requests']],
-    session_canceled:            [['mentorship', 'meeting-sessions', 'me']],
-    session_rescheduled:         [['mentorship', 'meeting-sessions', 'me']],
-    match_deactivated:           [['mentorship', 'matches']],
+    slot_booked:                 [['mentorship', 'meeting-sessions', 'me'], ['mentorship', 'requests'], ['availability-slots']],
+    session_canceled:            [['mentorship', 'meeting-sessions', 'me'], ['availability-slots']],
+    session_rescheduled:         [['mentorship', 'meeting-sessions', 'me'], ['availability-slots']],
+    match_deactivated:           [['mentorship', 'matches'], ['mentorship', 'requests']],
     new_message:                 [['messaging', 'conversations']],
     new_feedback_available:      [['profiles', 'me']],
 }

--- a/web/src/lib/queries/ProfileQueries.ts
+++ b/web/src/lib/queries/ProfileQueries.ts
@@ -127,3 +127,22 @@ export function useUpdateProfile() {
         mutationFn: (body: UpdateProfileBody) => patchProfile(body),
     })
 }
+
+async function patchUsername(newUsername: string): Promise<void> {
+    const token = localStorage.getItem('access_token')
+    const res = await fetch(`${API_BASE_URL}/profiles/me/username/`, {
+        method: 'PATCH',
+        headers: {
+            'Content-Type': 'application/json',
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ username: newUsername }),
+    })
+    if (!res.ok) throw new Error('Failed to update username')
+}
+
+export function useUpdateUsername() {
+    return useMutation({
+        mutationFn: (newUsername: string) => patchUsername(newUsername),
+    })
+}

--- a/web/src/routes/_authorized/dashboard.tsx
+++ b/web/src/routes/_authorized/dashboard.tsx
@@ -92,7 +92,8 @@ export function DashboardHome() {
     if (incoming.length === 0) return
 
     incoming.forEach(n => seenIds.current.add(n.id))
-    setVisibleNotifications(prev => [...prev, ...incoming])
+    const toShow = incoming.filter(n => !n.is_read)
+    if (toShow.length > 0) setVisibleNotifications(prev => [...prev, ...toShow])
 
     const unreadIds = incoming.filter(n => n.type !== 'new_message' && !n.is_read).map(n => n.id)
     if (unreadIds.length > 0) markAllRead(unreadIds)

--- a/web/src/routes/_authorized/dashboard.tsx
+++ b/web/src/routes/_authorized/dashboard.tsx
@@ -84,6 +84,7 @@ export function DashboardHome() {
   // Marking as read happens immediately on arrival, separate from visibility.
   const [visibleNotifications, setVisibleNotifications] = useState<Notification[]>([])
   const seenIds = useRef<Set<string>>(new Set())
+  const isFirstRun = useRef(true)
 
   useEffect(() => {
     if (notifications.length === 0) return
@@ -98,8 +99,13 @@ export function DashboardHome() {
     const unreadIds = incoming.filter(n => n.type !== 'new_message' && !n.is_read).map(n => n.id)
     if (unreadIds.length > 0) markAllRead(unreadIds)
 
+    if (isFirstRun.current) {
+      isFirstRun.current = false
+      return
+    }
+
     const keysToInvalidate = new Set<string>()
-    for (const n of incoming) {
+    for (const n of toShow) {
       for (const key of NOTIFICATION_INVALIDATION_MAP[n.type]) {
         keysToInvalidate.add(JSON.stringify(key))
       }

--- a/web/src/routes/_onBoarding/gettingToKnowYou.tsx
+++ b/web/src/routes/_onBoarding/gettingToKnowYou.tsx
@@ -7,7 +7,7 @@ import { meQueryOptions, useUpdateAppUsageMode } from "#/lib/queries/AuthQueries
 import { useOwnProfile, useUpdateProfile, useUpdateUsername } from "#/lib/queries/ProfileQueries.ts"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute, useRouter } from '@tanstack/react-router'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 
 export const Route = createFileRoute('/_onBoarding/gettingToKnowYou')({
     loader: ({ context }) => context.queryClient.ensureQueryData(meQueryOptions),
@@ -136,9 +136,18 @@ function RouteComponent() {
         bio: '',
         learnSkills: [],
         teachSkills: [],
-        username: me?.email?.split('@')[0] ?? '',
+        username: '',
     })
     const [error, setError] = useState<string | null>(null)
+
+    useEffect(() => {
+        if (me?.email) {
+            setAnswers(prev => ({
+                ...prev,
+                username: prev.username || me.email.split('@')[0],
+            }))
+        }
+    }, [me?.email])
 
     const questions = getQuestions(answers.primaryUsage)
     const current = questions[activeIndex]

--- a/web/src/routes/_onBoarding/gettingToKnowYou.tsx
+++ b/web/src/routes/_onBoarding/gettingToKnowYou.tsx
@@ -4,7 +4,7 @@ import { Button } from "#/components/ui/button.tsx"
 import { Input } from "#/components/ui/input.tsx"
 import { Textarea } from "#/components/ui/textarea.tsx"
 import { meQueryOptions, useUpdateAppUsageMode } from "#/lib/queries/AuthQueries.ts"
-import { useOwnProfile, useUpdateProfile } from "#/lib/queries/ProfileQueries.ts"
+import { useOwnProfile, useUpdateProfile, useUpdateUsername } from "#/lib/queries/ProfileQueries.ts"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute, useRouter } from '@tanstack/react-router'
 import { useState } from 'react'
@@ -25,6 +25,7 @@ type UserAnswers = {
     bio: string
     learnSkills: string[]
     teachSkills: string[]
+    username: string
 }
 
 type Question = {
@@ -32,7 +33,7 @@ type Question = {
     question: string
     clarification: string
     mutedText?: string
-    type: 'text' | 'textarea' | 'choice' | 'skills'
+    type: 'text' | 'textarea' | 'choice' | 'skills' | 'username'
     skillsKey?: 'learnSkills' | 'teachSkills'
     validate: (answers: UserAnswers) => string | null
 }
@@ -100,9 +101,21 @@ const MENTOR_QUESTIONS: Question[] = [
     },
 ]
 
+const USERNAME_QUESTION: Question = {
+    key: 'username',
+    question: "Choose a username.",
+    clarification: "Your username is separate from your display name and identifies your public profile.",
+    type: 'username',
+    validate: ({ username }) => {
+        if (username.trim().length < 3) return "Username must be at least 3 characters."
+        if (!/^[a-zA-Z0-9_-]+$/.test(username)) return "Username can only contain letters, numbers, underscores, and hyphens."
+        return null
+    },
+}
+
 function getQuestions(primaryUsage: UserAnswers['primaryUsage']): Question[] {
-    if (primaryUsage === 'mentor') return [...BASE_QUESTIONS, ...MENTOR_QUESTIONS]
-    return [...BASE_QUESTIONS, ...MENTEE_QUESTIONS]
+    const skillsQuestions = primaryUsage === 'mentor' ? MENTOR_QUESTIONS : MENTEE_QUESTIONS
+    return [...BASE_QUESTIONS, ...skillsQuestions, USERNAME_QUESTION]
 }
 
 // ---------------------------------------------------------------------------
@@ -123,6 +136,7 @@ function RouteComponent() {
         bio: '',
         learnSkills: [],
         teachSkills: [],
+        username: me?.email?.split('@')[0] ?? '',
     })
     const [error, setError] = useState<string | null>(null)
 
@@ -131,9 +145,10 @@ function RouteComponent() {
 
     const updateUsageMode = useUpdateAppUsageMode()
     const updateProfile = useUpdateProfile()
+    const updateUsername = useUpdateUsername()
 
-    const isSubmitting = updateUsageMode.isPending || updateProfile.isPending
-    const submitError = updateUsageMode.error?.message || updateProfile.error?.message
+    const isSubmitting = updateUsageMode.isPending || updateProfile.isPending || updateUsername.isPending
+    const submitError = updateUsageMode.error?.message || updateProfile.error?.message || updateUsername.error?.message
 
     const handleFinish = () => {
         if (!me?.username) return
@@ -156,8 +171,15 @@ function RouteComponent() {
                         },
                         {
                             onSuccess: () => {
-                                queryClient.invalidateQueries({ queryKey: ['me'] })
-                                router.navigate({ to: '/dashboard' })
+                                updateUsername.mutate(
+                                    answers.username,
+                                    {
+                                        onSuccess: () => {
+                                            queryClient.invalidateQueries({ queryKey: ['me'] })
+                                            router.navigate({ to: '/dashboard' })
+                                        },
+                                    }
+                                )
                             },
                         }
                     )
@@ -251,6 +273,26 @@ function RouteComponent() {
                                     {option}
                                 </button>
                             ))}
+                        </div>
+                    )}
+
+                    {current.type === 'username' && (
+                        <div className="flex flex-col gap-2">
+                            <Input
+                                className="bg-background"
+                                placeholder="username"
+                                value={answers.username}
+                                onChange={e =>
+                                    setAnswers(prev => ({ ...prev, username: e.target.value }))
+                                }
+                                onKeyDown={e => e.key === 'Enter' && handleNext()}
+                            />
+                            <div className="flex flex-col gap-0.5">
+                                <Muted className="text-xs">Your profile URL will be:</Muted>
+                                <Muted className="text-sm font-mono">
+                                    https://neighborship.app/profiles/{answers.username || '...'}
+                                </Muted>
+                            </div>
                         </div>
                     )}
 


### PR DESCRIPTION
## Related Issue                                                                                                                                                                            
                                                                                                                                                                                              
  Closes #400                                                                                                                                                               
                                                                                                                                                                                              
  ## Description                                                                                                                                                                              
                  
  Adds a **username step** to the onboarding flow (`gettingToKnowYou`) and fixes a few notification system issues found along the way.                                                        
   
  ### Username onboarding (main change)                                                                                                                                                       
  - New final step in the onboarding wizard asking the user to pick a username, with validation (min 3 chars, alphanumeric + `_`/`-`).
  - Pre-fills the input with the local part of the user's email (e.g. `inan@…` → `inan`) via a `useEffect` synced to `me.email`, so stale query-cache data from a previous session can't leak 
  into the default.                                                                                                                                                                           
  - Shows a live preview of the resulting profile URL (`https://neighborship.app/profiles/{username}`) under the input.                                                                       
  - Added `useUpdateUsername` in `ProfileQueries.ts` that PATCHes `/api/profiles/me/username/`. Chained after `updateUsageMode` and `updateProfile` in `handleFinish`, then navigates to the  
  dashboard.                                                                                                                                                                                  
                                                                                                                                                                                              
  ### Notification system fixes (secondary)                                                                                                                                                   
  - **Ghost notifications**: dashboard and header dots kept showing already-read notifications. Both now check `is_read` properly.
  - **Double-fetching on mount**: the notification `useEffect` was invalidating mentorship queries while they were still in flight, causing each endpoint to be fetched twice. Added an       
  `isFirstRun` ref so invalidation only runs for notifications arriving *after* mount.                                                                                                        
  - **Missing invalidations**: `NOTIFICATION_INVALIDATION_MAP` now also busts `['availability-slots']` on slot/session lifecycle events and `['mentorship', 'requests']` on                   
  `match_deactivated`.                                                                                                                                                                        
                  
  ## Type of Change                                                                                                                                                                           
                  
  - [x] Bug fix                                                                                                                                                                               
  - [x] New feature
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation
  - [ ] CI/CD or configuration
                                                                                                                                                                                              
  ## Checklist
                                                                                                                                                                                              
  - [x] I have tested my changes locally
  - [x] My code builds without errors
  - [ ] I have written or updated tests where applicable
  - [x] I have performed a self-review of my code
                                                                                                                                                                                              
  ## Notes
                                                                                                                                                                                              
  Username is the last step of onboarding so the user sees the computed profile URL before committing. Backend endpoint expects `{ "username": "..." }` on `PATCH /api/profiles/me/username/`