### PR TITLE
Feat/friendly error messages 373

### DIFF
--- a/web/src/components/profile/AvailabilityCalendar.tsx
+++ b/web/src/components/profile/AvailabilityCalendar.tsx
@@ -96,9 +96,7 @@ function CancelModal({ slot, username, onClose, onSuccess }: CancelModalProps) {
                 onSuccess()
             },
             onError: (err) => {
-                toast.error('Could not cancel', {
-                    description: err.message,
-                })
+                toast.error(err.message)
             },
         })
     }
@@ -167,9 +165,7 @@ function BookingModal({ slot, mentorUsername, isFirstTime, onClose, onSuccess }:
                         onSuccess()
                     },
                     onError: (err) => {
-                        toast.error('Failed to send request', {
-                            description: err.message,
-                        })
+                        toast.error(err.message)
                     },
                 }
             )
@@ -184,9 +180,7 @@ function BookingModal({ slot, mentorUsername, isFirstTime, onClose, onSuccess }:
                         onSuccess()
                     },
                     onError: (err) => {
-                        toast.error('Booking failed', {
-                            description: err.message,
-                        })
+                        toast.error(err.message)
                     },
                 }
             )
@@ -317,9 +311,7 @@ export function AvailabilityCalendar({ username, isOwner, isAuthenticated }: Ava
                     setTogglingSlotKey(null)
                 },
                 onError: (err) => {
-                    toast.error('Failed to remove slot', {
-                        description: err.message,
-                    })
+                    toast.error(err.message)
                     setTogglingSlotKey(null)
                 },
             })
@@ -340,9 +332,7 @@ export function AvailabilityCalendar({ username, isOwner, isAuthenticated }: Ava
                         setTogglingSlotKey(null)
                     },
                     onError: (err) => {
-                        toast.error('Failed to add slot', {
-                            description: err.message,
-                        })
+                        toast.error(err.message)
                         setTogglingSlotKey(null)
                     },
                 }

--- a/web/src/lib/__tests__/apiError.test.ts
+++ b/web/src/lib/__tests__/apiError.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import { throwApiError } from '../apiError'
+
+function mockResponse(body: unknown, status = 400): Response {
+    return {
+        ok: false,
+        status,
+        json: async () => body,
+    } as unknown as Response
+}
+
+function mockTextResponse(_text: string, status = 500): Response {
+    return {
+        ok: false,
+        status,
+        json: async () => { throw new Error('not json') },
+    } as unknown as Response
+}
+
+describe('throwApiError', () => {
+    it('maps a known backend detail to a friendly message', async () => {
+        const res = mockResponse({
+            detail: 'You already have a pending request with this mentor.',
+        })
+
+        await expect(throwApiError(res)).rejects.toThrow(
+            'You already sent a request to this mentor. Please wait for a response.',
+        )
+    })
+
+    it('passes through unknown detail messages as-is', async () => {
+        const res = mockResponse({ detail: 'Some brand-new error from backend.' })
+
+        await expect(throwApiError(res)).rejects.toThrow(
+            'Some brand-new error from backend.',
+        )
+    })
+
+    it('handles field-level validation errors', async () => {
+        const res = mockResponse({
+            email: ['This field may not be blank.'],
+            password: ['This field may not be blank.'],
+        })
+
+        await expect(throwApiError(res)).rejects.toThrow(
+            'Please fill in all required fields. Please fill in all required fields.',
+        )
+    })
+
+    it('returns generic message for non-JSON responses', async () => {
+        const res = mockTextResponse('Internal Server Error')
+
+        await expect(throwApiError(res)).rejects.toThrow(
+            'Something went wrong. Please try again.',
+        )
+    })
+
+    it('maps login failure detail', async () => {
+        const res = mockResponse({
+            detail: 'No active account found with the given credentials',
+        })
+
+        await expect(throwApiError(res)).rejects.toThrow(
+            'Incorrect email or password. Please try again.',
+        )
+    })
+
+    it('maps permission denied detail', async () => {
+        const res = mockResponse({
+            detail: 'You do not have permission to perform this action.',
+        })
+
+        await expect(throwApiError(res)).rejects.toThrow(
+            "You don't have permission to do this.",
+        )
+    })
+
+    it('maps duplicate email registration error', async () => {
+        const res = mockResponse({
+            email: ['user with this email already exists.'],
+        })
+
+        await expect(throwApiError(res)).rejects.toThrow(
+            'An account with this email already exists. Try logging in instead.',
+        )
+    })
+
+    it('maps mentee-only request error', async () => {
+        const res = mockResponse({
+            detail: 'You need a MENTEE profile to send mentorship requests.',
+        })
+
+        await expect(throwApiError(res)).rejects.toThrow(
+            'Only mentees can send mentorship requests.',
+        )
+    })
+})

--- a/web/src/lib/apiError.ts
+++ b/web/src/lib/apiError.ts
@@ -1,0 +1,122 @@
+/**
+ * Extracts a user-friendly message from a failed API response.
+ *
+ * The Django backend returns errors in `{ "detail": "..." }` format.
+ * This module maps those raw messages to polished UI copy and provides
+ * a helper that query functions can call instead of `throw new Error(...)`.
+ */
+
+// ---------------------------------------------------------------------------
+// Backend → UI message mapping
+// ---------------------------------------------------------------------------
+
+const FRIENDLY_MESSAGES: Record<string, string> = {
+    // Auth
+    'no active account found with the given credentials':
+        'Incorrect email or password. Please try again.',
+    'unable to log in with provided credentials.':
+        'Incorrect email or password. Please try again.',
+    'invalid email or password.':
+        'Incorrect email or password. Please try again.',
+    'user with this email already exists.':
+        'An account with this email already exists. Try logging in instead.',
+    'this field may not be blank.':
+        'Please fill in all required fields.',
+    'invalid token':
+        'Your session has expired. Please log in again.',
+
+    // Mentorship
+    'you already have a pending request with this mentor.':
+        'You already sent a request to this mentor. Please wait for a response.',
+    'only pending requests can be accepted or rejected.':
+        'This request has already been handled.',
+    'you need a mentee profile to send mentorship requests.':
+        'Only mentees can send mentorship requests.',
+    'you need a mentor profile to access this resource.':
+        'Only mentors can access this feature.',
+    'profile not found.':
+        'This profile could not be found.',
+    'selected slot could not be booked while accepting this request.':
+        'The selected time slot is no longer available.',
+    'this session has no active booking to cancel.':
+        'This session has already been cancelled.',
+
+    // Slots
+    'booking failed':
+        'Could not book this slot. It may have already been taken.',
+    'failed to create slot':
+        'Could not create the availability slot. Please try again.',
+    'failed to delete slot':
+        'Could not remove the slot. Please try again.',
+
+    // General
+    'not found.':
+        'The requested resource was not found.',
+    'you do not have permission to perform this action.':
+        'You don\'t have permission to do this.',
+    'authentication credentials were not provided.':
+        'Please log in to continue.',
+}
+
+// ---------------------------------------------------------------------------
+// Core helper
+// ---------------------------------------------------------------------------
+
+function lookup(raw: string): string {
+    const key = raw.toLowerCase().trim().replace(/\s+/g, ' ')
+    return FRIENDLY_MESSAGES[key] ?? raw
+}
+
+/**
+ * Parse the body of a failed `fetch` Response and return a friendly message.
+ *
+ * Handles the common Django / DRF shapes:
+ *   - `{ "detail": "..." }`
+ *   - `{ "field_name": ["error1", "error2"] }`
+ *   - plain text body
+ */
+async function parseResponseBody(res: Response): Promise<string> {
+    try {
+        const body = await res.json()
+
+        // { "detail": "..." }
+        if (typeof body.detail === 'string') {
+            return lookup(body.detail)
+        }
+
+        // { "field": ["msg", ...], ... }  — collect first error per field
+        if (typeof body === 'object' && body !== null) {
+            const messages: string[] = []
+            for (const [, value] of Object.entries(body)) {
+                if (Array.isArray(value)) {
+                    messages.push(lookup(String(value[0])))
+                } else if (typeof value === 'string') {
+                    messages.push(lookup(value))
+                }
+            }
+            if (messages.length > 0) return messages.join(' ')
+        }
+    } catch {
+        // not JSON — fall through
+    }
+
+    return 'Something went wrong. Please try again.'
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Call this in place of `throw new Error('...')` inside fetch-based query
+ * functions.  It reads the response body once and throws an `Error` whose
+ * `.message` is already user-friendly.
+ *
+ * @example
+ *   const res = await fetch(url, options)
+ *   if (!res.ok) await throwApiError(res)
+ */
+export async function throwApiError(res: Response, fallback?: string): Promise<never> {
+    const message = await parseResponseBody(res)
+    throw new Error(message || fallback || 'Something went wrong. Please try again.')
+}

--- a/web/src/lib/queries/AuthQueries.ts
+++ b/web/src/lib/queries/AuthQueries.ts
@@ -1,5 +1,6 @@
 // lib/queries/auth.ts
 import { queryClient, router } from "#/router.tsx"
+import { throwApiError } from "#/lib/apiError.ts"
 import { queryOptions, useMutation } from "@tanstack/react-query"
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
@@ -111,7 +112,7 @@ export async function loginFn(credentials: { email: string; password: string }) 
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(credentials),
     })
-    if (!res.ok) throw new Error('Invalid credentials')
+    if (!res.ok) await throwApiError(res)
     return res.json() as Promise<AuthResponse>
 }
 
@@ -121,7 +122,7 @@ export async function registerFn(credentials: { email: string; password: string;
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(credentials),
     })
-    if (!res.ok) throw new Error('Registration failed')
+    if (!res.ok) await throwApiError(res)
     return res.json() as Promise<AuthResponse>
 }
 
@@ -135,7 +136,7 @@ export async function updateAppUsageModeFn({ app_usage_mode }: {
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify({ app_usage_mode }),
     })
-    if (!res.ok) throw new Error('Failed to update usage mode')
+    if (!res.ok) await throwApiError(res)
     return res.json()
 }
 

--- a/web/src/lib/queries/DiscoverQueries.ts
+++ b/web/src/lib/queries/DiscoverQueries.ts
@@ -1,3 +1,4 @@
+import { throwApiError } from '#/lib/apiError.ts'
 import { queryOptions, infiniteQueryOptions } from '@tanstack/react-query'
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
@@ -46,13 +47,13 @@ export async function fetchMentors(
     if (params.skills?.length) params.skills.forEach(s => url.searchParams.append('skill', s))
 
     const res = await fetch(url.toString())
-    if (!res.ok) throw new Error('Failed to fetch mentors')
+    if (!res.ok) await throwApiError(res)
     return res.json()
 }
 
 export async function fetchAllSkills(): Promise<Skill[]> {
     const res = await fetch(`${API_BASE_URL}/profiles/skills/`)
-    if (!res.ok) throw new Error('Failed to fetch skills')
+    if (!res.ok) await throwApiError(res)
     return res.json()
 }
 
@@ -78,7 +79,7 @@ export async function fetchPopularMentors(limit = 6): Promise<PublicMentorProfil
     const url = new URL(`${API_BASE_URL}/profiles/popular/`, window.location.origin)
     url.searchParams.set('limit', String(limit))
     const res = await fetch(url.toString())
-    if (!res.ok) throw new Error('Failed to fetch popular mentors')
+    if (!res.ok) await throwApiError(res)
     const data = await res.json()
     return data.results
 }
@@ -87,7 +88,7 @@ export async function fetchRecentlyAddedMentors(limit = 6): Promise<PublicMentor
     const url = new URL(`${API_BASE_URL}/profiles/recently-added/`, window.location.origin)
     url.searchParams.set('limit', String(limit))
     const res = await fetch(url.toString())
-    if (!res.ok) throw new Error('Failed to fetch recently added mentors')
+    if (!res.ok) await throwApiError(res)
     const data = await res.json()
     return data.results
 }

--- a/web/src/lib/queries/MentorshipQueries.ts
+++ b/web/src/lib/queries/MentorshipQueries.ts
@@ -1,3 +1,4 @@
+import { throwApiError } from "#/lib/apiError.ts"
 import { queryOptions, useMutation, useQuery } from "@tanstack/react-query"
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
@@ -74,7 +75,7 @@ async function fetchMyMatches(): Promise<Match[]> {
     const res = await fetch(`${API_BASE_URL}/mentorship/matches/me/`, {
         headers: token ? { Authorization: `Bearer ${token}` } : {},
     })
-    if (!res.ok) throw new Error('Failed to fetch matches')
+    if (!res.ok) await throwApiError(res)
     return res.json()
 }
 
@@ -92,7 +93,7 @@ async function sendMentorshipRequest(body: {
         },
         body: JSON.stringify(body),
     })
-    if (!res.ok) throw new Error('Failed to send mentorship request')
+    if (!res.ok) await throwApiError(res)
     return res.json()
 }
 
@@ -101,7 +102,7 @@ export async function fetchMyRequests(): Promise<MentorshipRequest[]> {
     const res = await fetch(`${API_BASE_URL}/mentorship/requests/me/`, {
         headers: token ? { Authorization: `Bearer ${token}` } : {},
     })
-    if (!res.ok) throw new Error('Failed to fetch requests')
+    if (!res.ok) await throwApiError(res)
     return res.json()
 }
 
@@ -114,7 +115,7 @@ async function respondToRequest(requestId: string, action: 'accept' | 'reject'):
         headers: token ? { Authorization: `Bearer ${token}` } : {},
         body: formData,
     })
-    if (!res.ok) throw new Error('Failed to respond to request')
+    if (!res.ok) await throwApiError(res)
     return res.json()
 }
 
@@ -139,7 +140,7 @@ async function fetchMeetingSessions(params: MeetingSessionQueryParams = {}): Pro
     const res = await fetch(url, {
         headers: withAuthHeaders(),
     })
-    if (!res.ok) throw new Error('Failed to fetch meeting sessions')
+    if (!res.ok) await throwApiError(res)
     return res.json()
 }
 
@@ -148,7 +149,7 @@ async function cancelSession(sessionId: string): Promise<MentorshipRequest> {
         method: 'POST',
         headers: withAuthHeaders(),
     })
-    if (!res.ok) throw new Error('Failed to cancel session')
+    if (!res.ok) await throwApiError(res)
     return res.json()
 }
 

--- a/web/src/lib/queries/MessagingQueries.ts
+++ b/web/src/lib/queries/MessagingQueries.ts
@@ -1,3 +1,4 @@
+import { throwApiError } from '#/lib/apiError.ts'
 import { queryOptions, useMutation, useQuery } from '@tanstack/react-query'
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
@@ -43,7 +44,7 @@ async function fetchConversations(): Promise<Conversation[]> {
     const res = await fetch(`${API_BASE_URL}/messages/conversations/`, {
         headers: authHeaders(),
     })
-    if (!res.ok) throw new Error('Failed to fetch conversations')
+    if (!res.ok) await throwApiError(res)
     return res.json()
 }
 
@@ -52,7 +53,7 @@ async function fetchMessages(conversationId: string, page = 1, pageSize = 50): P
         `${API_BASE_URL}/messages/conversations/${conversationId}/?page=${page}&pageSize=${pageSize}`,
         { headers: authHeaders() },
     )
-    if (!res.ok) throw new Error('Failed to fetch messages')
+    if (!res.ok) await throwApiError(res)
     return res.json()
 }
 
@@ -62,7 +63,7 @@ async function sendMessage(conversationId: string, body: string): Promise<Messag
         headers: { ...authHeaders(), 'Content-Type': 'application/json' },
         body: JSON.stringify({ body }),
     })
-    if (!res.ok) throw new Error('Failed to send message')
+    if (!res.ok) await throwApiError(res)
     return res.json()
 }
 

--- a/web/src/lib/queries/NotificationQueries.ts
+++ b/web/src/lib/queries/NotificationQueries.ts
@@ -1,3 +1,4 @@
+import { throwApiError } from '#/lib/apiError.ts'
 import { queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
@@ -36,7 +37,7 @@ async function fetchNotifications(): Promise<Notification[]> {
     const res = await fetch(`${API_BASE_URL}/notifications/`, {
         headers: authHeaders(),
     })
-    if (!res.ok) throw new Error(`${res.status}`)
+    if (!res.ok) await throwApiError(res)
     return res.json()
 }
 
@@ -45,7 +46,7 @@ async function markNotificationRead(id: string): Promise<void> {
         method: 'PUT',
         headers: authHeaders(),
     })
-    if (!res.ok) throw new Error(`${res.status}`)
+    if (!res.ok) await throwApiError(res)
 }
 
 export const notificationsQueryOptions = queryOptions({

--- a/web/src/lib/queries/ProfileQueries.ts
+++ b/web/src/lib/queries/ProfileQueries.ts
@@ -1,3 +1,4 @@
+import { throwApiError } from "#/lib/apiError.ts"
 import { queryOptions, useMutation, useQuery } from "@tanstack/react-query"
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
@@ -67,7 +68,7 @@ async function fetchProfile(username: string): Promise<ProfileResponse> {
     const res = await fetch(`${API_BASE_URL}/profiles/${username}/`, {
         headers: token ? { Authorization: `Bearer ${token}` } : {},
     })
-    if (!res.ok) throw new Error(`${res.status}`)
+    if (!res.ok) await throwApiError(res)
     return res.json()
 }
 
@@ -78,7 +79,7 @@ async function fetchOwnProfile(): Promise<OwnProfileResponse> {
     const res = await fetch(`${API_BASE_URL}/profiles/me/`, {
         headers: token ? { Authorization: `Bearer ${token}` } : {},
     })
-    if (!res.ok) throw new Error(`${res.status}`)
+    if (!res.ok) await throwApiError(res)
     return res.json()
 }
 
@@ -92,7 +93,7 @@ async function patchProfile(body: UpdateProfileBody): Promise<void> {
         },
         body: JSON.stringify(body),
     })
-    if (!res.ok) throw new Error('Failed to update profile')
+    if (!res.ok) await throwApiError(res)
 }
 
 // ---- Query Options ----
@@ -138,7 +139,7 @@ async function patchUsername(newUsername: string): Promise<void> {
         },
         body: JSON.stringify({ username: newUsername }),
     })
-    if (!res.ok) throw new Error('Failed to update username')
+    if (!res.ok) await throwApiError(res)
 }
 
 export function useUpdateUsername() {

--- a/web/src/lib/queries/ProfileTimeSlotQueries.ts
+++ b/web/src/lib/queries/ProfileTimeSlotQueries.ts
@@ -1,3 +1,4 @@
+import { throwApiError } from "#/lib/apiError.ts"
 import { queryOptions, useMutation, useQuery } from "@tanstack/react-query";
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
@@ -33,7 +34,7 @@ async function bookSlot(username: string, slotId: string, message?: string): Pro
         headers: { 'Content-Type': 'application/json', ...(token ? { Authorization: `Bearer ${token}` } : {}) },
         body: JSON.stringify({ message }),
     })
-    if (!res.ok) throw new Error('Booking failed')
+    if (!res.ok) await throwApiError(res)
     return res.json()
 }
 
@@ -44,7 +45,7 @@ async function createSlot(body: CreateSlotBody): Promise<AvailabilitySlot> {
         headers: { 'Content-Type': 'application/json', ...(token ? { Authorization: `Bearer ${token}` } : {}) },
         body: JSON.stringify(body),
     })
-    if (!res.ok) throw new Error('Failed to create slot')
+    if (!res.ok) await throwApiError(res)
     return res.json()
 }
 
@@ -54,7 +55,7 @@ async function deleteSlot(slotId: string): Promise<void> {
         method: 'DELETE',
         headers: token ? { Authorization: `Bearer ${token}` } : {},
     })
-    if (!res.ok) throw new Error('Failed to delete slot')
+    if (!res.ok) await throwApiError(res)
 }
 
 // ---- Hooks ----
@@ -87,7 +88,7 @@ export const availabilitySlotsQueryOptions = (username: string) =>
             const res = await fetch(`${API_BASE_URL}/profiles/${username}/availability-slots/`, {
                 headers: token ? { Authorization: `Bearer ${token}` } : {},
             })
-            if (!res.ok) throw new Error(`${res.status}`)
+            if (!res.ok) await throwApiError(res)
             return res.json() as Promise<AvailabilitySlot[]>
         },
         staleTime: 60 * 1000,

--- a/web/src/lib/queries/__tests__/AuthQueries.test.ts
+++ b/web/src/lib/queries/__tests__/AuthQueries.test.ts
@@ -173,7 +173,7 @@ describe('AuthQueries', () => {
 
     await expect(
       loginFn({ email: 'alex@example.com', password: 'bad-password' }),
-    ).rejects.toThrow('Invalid credentials')
+    ).rejects.toThrow('Something went wrong. Please try again.')
 
     await expect(
       registerFn({
@@ -181,7 +181,7 @@ describe('AuthQueries', () => {
         password: 'short',
         confirm_password: 'short',
       }),
-    ).rejects.toThrow('Registration failed')
+    ).rejects.toThrow('Something went wrong. Please try again.')
   })
 
   it('returns payload for successful login and register calls', async () => {
@@ -253,6 +253,6 @@ describe('AuthQueries', () => {
 
     await expect(
       updateAppUsageModeFn({ app_usage_mode: 'MENTEE' }),
-    ).rejects.toThrow('Failed to update usage mode')
+    ).rejects.toThrow('Something went wrong. Please try again.')
   })
 })

--- a/web/src/lib/queries/__tests__/DiscoverQueries.test.ts
+++ b/web/src/lib/queries/__tests__/DiscoverQueries.test.ts
@@ -52,13 +52,13 @@ describe('DiscoverQueries fetchers', () => {
 
     await expect(
       fetchMentors({ page: 1, pageSize: 6 }),
-    ).rejects.toThrow('Failed to fetch mentors')
+    ).rejects.toThrow('Something went wrong. Please try again.')
   })
 
   it('throws on skills API failure', async () => {
     fetchSpy.mockResolvedValueOnce(new Response(null, { status: 500 }))
 
-    await expect(fetchAllSkills()).rejects.toThrow('Failed to fetch skills')
+    await expect(fetchAllSkills()).rejects.toThrow('Something went wrong. Please try again.')
   })
 
   it('returns popular and recent mentors lists from API results payload', async () => {
@@ -75,7 +75,7 @@ describe('DiscoverQueries fetchers', () => {
       .mockResolvedValueOnce(new Response(null, { status: 500 }))
       .mockResolvedValueOnce(new Response(null, { status: 500 }))
 
-    await expect(fetchPopularMentors()).rejects.toThrow('Failed to fetch popular mentors')
-    await expect(fetchRecentlyAddedMentors()).rejects.toThrow('Failed to fetch recently added mentors')
+    await expect(fetchPopularMentors()).rejects.toThrow('Something went wrong. Please try again.')
+    await expect(fetchRecentlyAddedMentors()).rejects.toThrow('Something went wrong. Please try again.')
   })
 })

--- a/web/src/lib/queries/__tests__/MentorshipQueries.test.ts
+++ b/web/src/lib/queries/__tests__/MentorshipQueries.test.ts
@@ -58,7 +58,7 @@ describe('MentorshipQueries query options', () => {
   it('throws when fetching my requests fails', async () => {
     fetchSpy.mockResolvedValueOnce(new Response(null, { status: 500 }))
 
-    await expect(myRequestsQueryOptions.queryFn!({} as never)).rejects.toThrow('Failed to fetch requests')
+    await expect(myRequestsQueryOptions.queryFn!({} as never)).rejects.toThrow('Something went wrong. Please try again.')
   })
 
   it('requests my requests with bearer auth when token exists', async () => {
@@ -121,6 +121,6 @@ describe('MentorshipQueries query options', () => {
 
     await expect(
       meetingSessionsQueryOptions({ role: 'mentee', status: 'upcoming' }).queryFn!({} as never),
-    ).rejects.toThrow('Failed to fetch meeting sessions')
+    ).rejects.toThrow('Something went wrong. Please try again.')
   })
 })

--- a/web/src/routes/_authorized/__tests__/dashboard.test.tsx
+++ b/web/src/routes/_authorized/__tests__/dashboard.test.tsx
@@ -359,12 +359,7 @@ describe('DashboardHome', () => {
 
     await user.click(screen.getByRole('button', { name: /Accept/i }))
 
-    expect(toastErrorMock).toHaveBeenCalledWith(
-      'Failed to respond',
-      expect.objectContaining({
-        description: 'Server is unavailable',
-      }),
-    )
+    expect(toastErrorMock).toHaveBeenCalledWith('Server is unavailable')
   })
 
   it('shows the "View all requests" button when more than three pending requests exist', () => {

--- a/web/src/routes/_authorized/dashboard.tsx
+++ b/web/src/routes/_authorized/dashboard.tsx
@@ -394,9 +394,7 @@ function MentorDashboardView() {
             queryClient.invalidateQueries({ queryKey: ['mentorship', 'meeting-sessions', 'me'] })
           },
           onError: (err) => {
-            toast.error('Failed to respond', {
-              description: err.message,
-            })
+            toast.error(err.message)
           },
         }
     )


### PR DESCRIPTION
## Related Issue

Closes #373

## Description

Implements user-friendly API error messages for the web frontend. Previously, raw backend error messages or hardcoded generic strings (e.g., "Failed to fetch requests") were shown to users. Now, backend responses are parsed and mapped to clean, readable messages through a centralized `apiError` utility.

**What changed:**
- Added `web/src/lib/apiError.ts` — parses Django/DRF error responses and maps them to friendly UI messages (15+ mappings)
- Updated all 7 query files to use `throwApiError(res)` instead of `throw new Error('hardcoded string')`
- Simplified toast error calls in AvailabilityCalendar and Dashboard to show the friendly message directly
- Added 8 new tests for the apiError utility, updated existing tests

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or configuration

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code

## Notes

- 128/128 unit tests passing
- Manual testing: login with wrong password shows "Incorrect email or password. Please try again." instead of raw backend message
- Only frontend changes, no backend modifications
