### PR TITLE
feat: add session reschedule and cancel to web dashboard

### DIFF
--- a/web/src/components/dashboard/SessionManagementModal.tsx
+++ b/web/src/components/dashboard/SessionManagementModal.tsx
@@ -1,4 +1,6 @@
 // web/src/components/dashboard/SessionManagementModal.tsx
+import { useRescheduleSession } from '#/lib/queries/MentorshipQueries.ts'
+import { useAvailabilitySlots, type AvailabilitySlot } from '#/lib/queries/ProfileTimeSlotQueries.ts'
 import { Body, Muted } from '@/components/Typography'
 import { Button } from '@/components/ui/button'
 import {
@@ -11,8 +13,13 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
-import { Calendar, CalendarDays, Clock, Link2, XCircle } from 'lucide-react'
+import { useQueryClient } from '@tanstack/react-query'
+import { ArrowLeft, Calendar, CalendarDays, ChevronLeft, ChevronRight, Clock, Link2, Loader2, XCircle } from 'lucide-react'
 import { useState } from 'react'
+import { toast } from 'sonner'
+
+// ---- Types ----
+
 interface SessionParticipant {
   id: string
   username: string
@@ -37,10 +44,166 @@ interface SessionManagementModalProps {
   session: SessionManagementData
 }
 
+// ---- Helpers ----
+
+function getMonday(date: Date): Date {
+  const d = new Date(date)
+  const day = d.getDay()
+  d.setDate(d.getDate() - day + (day === 0 ? -6 : 1))
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+function addDays(date: Date, days: number): Date {
+  const d = new Date(date)
+  d.setDate(d.getDate() + days)
+  return d
+}
+
+function toDateString(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+}
+
+// ---- Reschedule View ----
+
+interface RescheduleViewProps {
+  sessionId: string
+  mentorUsername: string
+  onBack: () => void
+  onSuccess: () => void
+}
+
+function RescheduleView({ sessionId, mentorUsername, onBack, onSuccess }: RescheduleViewProps) {
+  const [weekOffset, setWeekOffset] = useState(0)
+  const [selectedSlotId, setSelectedSlotId] = useState<string | null>(null)
+  const queryClient = useQueryClient()
+  const reschedule = useRescheduleSession()
+  const { data: slots = [], isLoading } = useAvailabilitySlots(mentorUsername)
+
+  const monday = getMonday(addDays(new Date(), weekOffset * 7))
+  const weekDayStrings = Array.from({ length: 7 }, (_, i) => toDateString(addDays(monday, i)))
+  const weekLabel = `${monday.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })} – ${addDays(monday, 6).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}`
+
+  const slotsThisWeek = slots
+    .filter((s: AvailabilitySlot) => s.status === 'AVAILABLE' && weekDayStrings.includes(s.date))
+    .sort((a: AvailabilitySlot, b: AvailabilitySlot) => `${a.date}${a.startTime}`.localeCompare(`${b.date}${b.startTime}`))
+
+  const handleConfirm = () => {
+    if (!selectedSlotId) return
+    reschedule.mutate(
+      { sessionId, newSlotId: selectedSlotId },
+      {
+        onSuccess: () => {
+          toast.success('Session rescheduled', {
+            description: 'Your session has been moved to the new time slot.',
+          })
+          queryClient.invalidateQueries({ queryKey: ['mentorship', 'meeting-sessions', 'me'] })
+          queryClient.invalidateQueries({ queryKey: ['availability-slots', mentorUsername] })
+          onSuccess()
+        },
+        onError: (err) => {
+          toast.error(err.message)
+        },
+      },
+    )
+  }
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2">
+          <button onClick={onBack} className="rounded-md p-1 hover:bg-black/5 transition-colors text-ink-soft hover:text-ink -ml-1">
+            <ArrowLeft className="w-4 h-4" />
+          </button>
+          Pick a New Time Slot
+        </DialogTitle>
+        <DialogDescription>
+          Select an available slot from {mentorUsername}'s calendar.
+        </DialogDescription>
+      </DialogHeader>
+
+      {/* Week navigation */}
+      <div className="flex items-center justify-between py-1">
+        <Button
+          variant="ghost" size="sm"
+          onClick={() => { setWeekOffset(o => o - 1); setSelectedSlotId(null) }}
+          disabled={weekOffset === 0}
+        >
+          <ChevronLeft className="w-4 h-4" />
+        </Button>
+        <Muted className="text-sm font-medium">{weekLabel}</Muted>
+        <Button
+          variant="ghost" size="sm"
+          onClick={() => { setWeekOffset(o => o + 1); setSelectedSlotId(null) }}
+        >
+          <ChevronRight className="w-4 h-4" />
+        </Button>
+      </div>
+
+      {/* Slot list */}
+      <div className="flex flex-col gap-2 max-h-60 overflow-y-auto">
+        {isLoading && (
+          <div className="flex justify-center py-8">
+            <Loader2 className="w-5 h-5 animate-spin text-ink-soft" />
+          </div>
+        )}
+        {!isLoading && slotsThisWeek.length === 0 && (
+          <div className="py-8 text-center">
+            <Muted className="text-sm">No available slots this week.</Muted>
+          </div>
+        )}
+        {slotsThisWeek.map((slot: AvailabilitySlot) => {
+          const isSelected = slot.id === selectedSlotId
+          const label = new Date(`${slot.date}T00:00:00`).toLocaleDateString('en-US', {
+            weekday: 'short', month: 'short', day: 'numeric',
+          })
+          const timeLabel = `${slot.startTime.slice(0, 5)} – ${slot.endTime.slice(0, 5)}`
+          return (
+            <button
+              key={slot.id}
+              onClick={() => setSelectedSlotId(isSelected ? null : slot.id)}
+              className={`flex items-center justify-between px-4 py-3 rounded-lg border text-left transition-colors ${
+                isSelected
+                  ? 'border-accent bg-accent/5 text-ink'
+                  : 'border-line bg-white hover:border-accent/40 text-ink-soft hover:text-ink'
+              }`}
+            >
+              <Body className="text-sm font-medium">{label}</Body>
+              <Muted className={`text-sm ${isSelected ? 'text-accent font-medium' : ''}`}>{timeLabel}</Muted>
+            </button>
+          )
+        })}
+      </div>
+
+      <DialogFooter>
+        <Button variant="outline" onClick={onBack} className="border-line text-ink-soft" disabled={reschedule.isPending}>
+          Back
+        </Button>
+        <Button
+          onClick={handleConfirm}
+          disabled={!selectedSlotId || reschedule.isPending}
+          className="bg-accent hover:bg-accent/90 text-white min-w-[140px]"
+        >
+          {reschedule.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : 'Confirm Reschedule'}
+        </Button>
+      </DialogFooter>
+    </>
+  )
+}
+
+// ---- Main Modal ----
+
 export function SessionManagementModal({ session }: Readonly<SessionManagementModalProps>) {
   const [isOpen, setIsOpen] = useState(false)
+  const [view, setView] = useState<'manage' | 'reschedule'>('manage')
   const [meetingLink, setMeetingLink] = useState('')
   const [isSaved, setIsSaved] = useState(false)
+
+  const handleClose = () => {
+    setIsOpen(false)
+    setView('manage')
+    setIsSaved(false)
+  }
 
   const handleSaveLink = (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault()
@@ -56,8 +219,7 @@ export function SessionManagementModal({ session }: Readonly<SessionManagementMo
   }
 
   const handleReschedule = () => {
-    // FUTURE: Open a date/time picker flow to reschedule the session
-    console.log('Reschedule placeholder for session:', session.id)
+    setView('reschedule')
   }
 
   const sessionDate = new Date(session.startAt).toLocaleDateString('en-US', {
@@ -71,7 +233,7 @@ export function SessionManagementModal({ session }: Readonly<SessionManagementMo
   })
 
   return (
-    <Dialog open={isOpen} onOpenChange={(open) => { setIsOpen(open); if (!open) setIsSaved(false) }}>
+    <Dialog open={isOpen} onOpenChange={(open) => { if (!open) handleClose(); else setIsOpen(true) }}>
       <DialogTrigger asChild>
         <Button
           variant="outline"
@@ -83,94 +245,105 @@ export function SessionManagementModal({ session }: Readonly<SessionManagementMo
       </DialogTrigger>
 
       <DialogContent className="sm:max-w-[460px] island-shell border-line">
-        <DialogHeader>
-          <DialogTitle>{session.title}</DialogTitle>
-          <DialogDescription>
-            Manage the details for this upcoming session.
-          </DialogDescription>
-        </DialogHeader>
+        {view === 'reschedule' ? (
+          <RescheduleView
+            sessionId={session.id}
+            mentorUsername={session.host.username}
+            onBack={() => setView('manage')}
+            onSuccess={handleClose}
+          />
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>{session.title}</DialogTitle>
+              <DialogDescription>
+                Manage the details for this upcoming session.
+              </DialogDescription>
+            </DialogHeader>
 
-        <div className="flex flex-col gap-5 py-2">
+            <div className="flex flex-col gap-5 py-2">
 
-          {/* Session Info */}
-          <div className="flex flex-col gap-2 p-4 bg-black/[0.02] rounded-lg border border-line">
-            <div className="flex items-center gap-2 text-sm text-ink-soft">
-              <CalendarDays className="w-4 h-4 shrink-0" />
-              <Body className="text-sm">{sessionDate}</Body>
+              {/* Session Info */}
+              <div className="flex flex-col gap-2 p-4 bg-black/[0.02] rounded-lg border border-line">
+                <div className="flex items-center gap-2 text-sm text-ink-soft">
+                  <CalendarDays className="w-4 h-4 shrink-0" />
+                  <Body className="text-sm">{sessionDate}</Body>
+                </div>
+                <div className="flex items-center gap-2 text-sm text-ink-soft">
+                  <Clock className="w-4 h-4 shrink-0" />
+                  <Body className="text-sm">{sessionTime}</Body>
+                </div>
+              </div>
+
+              {/* Meeting Link Input */}
+              <div className="flex flex-col gap-2">
+                <Body className="text-sm font-medium flex items-center gap-1.5">
+                  <Link2 className="w-4 h-4 text-accent" />
+                  Meeting Link
+                </Body>
+                <Muted className="text-xs text-ink-soft">
+                  Paste a Zoom or Google Meet link to share with your mentee.
+                </Muted>
+                <form onSubmit={handleSaveLink} className="flex gap-2 mt-1">
+                  <Input
+                    placeholder="https://zoom.us/j/... or meet.google.com/..."
+                    value={meetingLink}
+                    onChange={(e) => { setMeetingLink(e.target.value); setIsSaved(false) }}
+                    className="border-line"
+                  />
+                  <Button
+                    type="submit"
+                    variant="secondary"
+                    className="shrink-0 border border-line bg-white hover:bg-black/[0.02]"
+                    disabled={!meetingLink.trim()}
+                  >
+                    Save
+                  </Button>
+                </form>
+                {isSaved && (
+                  <Muted className="text-xs text-green-600 font-medium">
+                    Meeting link saved successfully.
+                  </Muted>
+                )}
+              </div>
+
+              {/* Divider */}
+              <div className="border-t border-line" />
+
+              {/* Session Actions */}
+              <div className="flex flex-col gap-2">
+                <Body className="text-sm font-medium text-ink-soft">Session Actions</Body>
+                <div className="flex gap-3">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="flex-1 border-line text-ink-soft hover:text-ink gap-1.5"
+                    onClick={handleReschedule}
+                  >
+                    <Calendar className="w-4 h-4" />
+                    Reschedule
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="flex-1 border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700 gap-1.5"
+                    onClick={handleCancelSession}
+                  >
+                    <XCircle className="w-4 h-4" />
+                    Cancel Session
+                  </Button>
+                </div>
+              </div>
+
             </div>
-            <div className="flex items-center gap-2 text-sm text-ink-soft">
-              <Clock className="w-4 h-4 shrink-0" />
-              <Body className="text-sm">{sessionTime}</Body>
-            </div>
-          </div>
 
-          {/* Meeting Link Input */}
-          <div className="flex flex-col gap-2">
-            <Body className="text-sm font-medium flex items-center gap-1.5">
-              <Link2 className="w-4 h-4 text-accent" />
-              Meeting Link
-            </Body>
-            <Muted className="text-xs text-ink-soft">
-              Paste a Zoom or Google Meet link to share with your mentee.
-            </Muted>
-            <form onSubmit={handleSaveLink} className="flex gap-2 mt-1">
-              <Input
-                placeholder="https://zoom.us/j/... or meet.google.com/..."
-                value={meetingLink}
-                onChange={(e) => { setMeetingLink(e.target.value); setIsSaved(false) }}
-                className="border-line"
-              />
-              <Button
-                type="submit"
-                variant="secondary"
-                className="shrink-0 border border-line bg-white hover:bg-black/[0.02]"
-                disabled={!meetingLink.trim()}
-              >
-                Save
+            <DialogFooter className='border-line'>
+              <Button variant="outline" onClick={handleClose} className="border-line text-ink-soft">
+                Close
               </Button>
-            </form>
-            {isSaved && (
-              <Muted className="text-xs text-green-600 font-medium">
-                Meeting link saved successfully.
-              </Muted>
-            )}
-          </div>
-
-          {/* Divider */}
-          <div className="border-t border-line" />
-
-          {/* Placeholder Actions */}
-          <div className="flex flex-col gap-2">
-            <Body className="text-sm font-medium text-ink-soft">Session Actions</Body>
-            <div className="flex gap-3">
-              <Button
-                variant="outline"
-                size="sm"
-                className="flex-1 border-line text-ink-soft hover:text-ink gap-1.5"
-                onClick={handleReschedule}
-              >
-                <Calendar className="w-4 h-4" />
-                Reschedule
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                className="flex-1 border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700 gap-1.5"
-                onClick={handleCancelSession}
-              >
-                <XCircle className="w-4 h-4" />
-                Cancel Session
-              </Button>
-            </div>
-          </div>
-
-        </div>
-
-        <DialogFooter className='border-line'>
-          <Button variant="outline" onClick={() => setIsOpen(false)} className="border-line text-ink-soft">
-            Close
-          </Button>
-        </DialogFooter>
+            </DialogFooter>
+          </>
+        )}
       </DialogContent>
     </Dialog>
   )

--- a/web/src/components/dashboard/SessionManagementModal.tsx
+++ b/web/src/components/dashboard/SessionManagementModal.tsx
@@ -1,5 +1,5 @@
 // web/src/components/dashboard/SessionManagementModal.tsx
-import { useRescheduleSession } from '#/lib/queries/MentorshipQueries.ts'
+import { useCancelSession, useRescheduleSession } from '#/lib/queries/MentorshipQueries.ts'
 import { useAvailabilitySlots, type AvailabilitySlot } from '#/lib/queries/ProfileTimeSlotQueries.ts'
 import { Body, Muted } from '@/components/Typography'
 import { Button } from '@/components/ui/button'
@@ -198,6 +198,8 @@ export function SessionManagementModal({ session }: Readonly<SessionManagementMo
   const [view, setView] = useState<'manage' | 'reschedule'>('manage')
   const [meetingLink, setMeetingLink] = useState('')
   const [isSaved, setIsSaved] = useState(false)
+  const queryClient = useQueryClient()
+  const cancelSession = useCancelSession()
 
   const handleClose = () => {
     setIsOpen(false)
@@ -214,8 +216,18 @@ export function SessionManagementModal({ session }: Readonly<SessionManagementMo
   }
 
   const handleCancelSession = () => {
-    // FUTURE: Trigger TanStack Query mutation to cancel the session on the backend
-    console.log('Cancel session placeholder for session:', session.id)
+    cancelSession.mutate(session.id, {
+      onSuccess: () => {
+        toast.success('Session cancelled', {
+          description: 'Your session has been cancelled.',
+        })
+        queryClient.invalidateQueries({ queryKey: ['mentorship', 'meeting-sessions', 'me'] })
+        handleClose()
+      },
+      onError: (err) => {
+        toast.error(err.message)
+      },
+    })
   }
 
   const handleReschedule = () => {
@@ -328,8 +340,9 @@ export function SessionManagementModal({ session }: Readonly<SessionManagementMo
                     size="sm"
                     className="flex-1 border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700 gap-1.5"
                     onClick={handleCancelSession}
+                    disabled={cancelSession.isPending}
                   >
-                    <XCircle className="w-4 h-4" />
+                    {cancelSession.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <XCircle className="w-4 h-4" />}
                     Cancel Session
                   </Button>
                 </div>

--- a/web/src/lib/queries/MentorshipQueries.ts
+++ b/web/src/lib/queries/MentorshipQueries.ts
@@ -153,6 +153,19 @@ async function cancelSession(sessionId: string): Promise<MentorshipRequest> {
     return res.json()
 }
 
+export async function rescheduleSession(sessionId: string, newSlotId: string): Promise<MeetingSession> {
+    const res = await fetch(`${API_BASE_URL}/mentorship/sessions/${sessionId}/reschedule/`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            ...withAuthHeaders(),
+        },
+        body: JSON.stringify({ new_slot_id: newSlotId }),
+    })
+    if (!res.ok) await throwApiError(res)
+    return res.json()
+}
+
 
 // ---- Query Options ----
 
@@ -212,6 +225,13 @@ export function useMeetingSessions(params: MeetingSessionQueryParams = {}) {
 export function useCancelSession() {
     return useMutation({
         mutationFn: cancelSession,
+    })
+}
+
+export function useRescheduleSession() {
+    return useMutation({
+        mutationFn: ({ sessionId, newSlotId }: { sessionId: string; newSlotId: string }) =>
+            rescheduleSession(sessionId, newSlotId),
     })
 }
 

--- a/web/src/lib/queries/__tests__/MentorshipQueries.test.ts
+++ b/web/src/lib/queries/__tests__/MentorshipQueries.test.ts
@@ -3,6 +3,7 @@ import {
   meetingSessionsQueryOptions,
   myMatchesQueryOptions,
   myRequestsQueryOptions,
+  rescheduleSession,
 } from '../MentorshipQueries'
 
 function jsonResponse(data: unknown, init?: ResponseInit): Response {
@@ -122,5 +123,70 @@ describe('MentorshipQueries query options', () => {
     await expect(
       meetingSessionsQueryOptions({ role: 'mentee', status: 'upcoming' }).queryFn!({} as never),
     ).rejects.toThrow('Something went wrong. Please try again.')
+  })
+})
+
+describe('rescheduleSession', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn<typeof globalThis, 'fetch'>>
+
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  it('POSTs to the correct reschedule URL with new_slot_id in body', async () => {
+    localStorage.setItem('access_token', 'tok-1')
+    const mockSession = { session_id: 'sess-1', status: 'RESCHEDULED' }
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify(mockSession), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    const result = await rescheduleSession('sess-1', 'slot-42')
+
+    expect(result).toEqual(mockSession)
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit]
+    expect(new URL(url, globalThis.location.origin).pathname).toBe(
+      '/api/mentorship/sessions/sess-1/reschedule/',
+    )
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body as string)).toEqual({ new_slot_id: 'slot-42' })
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer tok-1')
+  })
+
+  it('includes bearer token when access_token is present', async () => {
+    localStorage.setItem('access_token', 'my-token')
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    )
+
+    await rescheduleSession('sess-2', 'slot-99')
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit]
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer my-token')
+  })
+
+  it('sends no Authorization header when no token is present', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    )
+
+    await rescheduleSession('sess-3', 'slot-1')
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit]
+    expect((init.headers as Record<string, string>)['Authorization']).toBeUndefined()
+  })
+
+  it('throws when the API returns an error', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 403 }))
+
+    await expect(rescheduleSession('sess-4', 'slot-2')).rejects.toThrow()
   })
 })

--- a/web/src/routes/_authorized/__tests__/dashboard.test.tsx
+++ b/web/src/routes/_authorized/__tests__/dashboard.test.tsx
@@ -69,6 +69,14 @@ vi.mock('#/lib/queries/MentorshipQueries.ts', () => ({
     queryFn: async () => [],
     staleTime: Infinity,
   }),
+  useCancelSession: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }),
+  useRescheduleSession: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }),
 }))
 
 vi.mock('#/lib/queries/AuthQueries.ts', () => ({

--- a/web/src/routes/_authorized/dashboard.tsx
+++ b/web/src/routes/_authorized/dashboard.tsx
@@ -13,7 +13,35 @@ import { ArrowRight, Bell, CalendarDays, Check, CheckCircle2, Clock, Loader2, St
 import { useState, useEffect, useRef, useMemo } from "react"
 import type { Notification } from "#/lib/queries/NotificationQueries.ts"
 import { RatingModal } from '#/components/RatingModal.tsx'
-import {toast} from "sonner";
+import { SessionManagementModal } from '#/components/dashboard/SessionManagementModal.tsx'
+import { toast } from "sonner"
+import type { MeetingSession } from '#/lib/queries/MentorshipQueries.ts'
+
+function toSessionManagementData(session: MeetingSession) {
+  return {
+    id: session.session_id,
+    title: `Session with ${session.mentor.display_name}`,
+    description: '',
+    startAt: session.scheduled_start_at,
+    endAt: session.scheduled_end_at,
+    type: 'video' as const,
+    status: 'upcoming' as const,
+    host: {
+      id: session.mentor.username,
+      username: session.mentor.username,
+      fullName: session.mentor.display_name,
+      avatarUrl: session.mentor.picture_url,
+      role: 'mentor' as const,
+    },
+    attendee: {
+      id: session.mentee.username,
+      username: session.mentee.username,
+      fullName: session.mentee.display_name,
+      avatarUrl: session.mentee.picture_url,
+      role: 'mentee' as const,
+    },
+  }
+}
 
 
 export const Route = createFileRoute('/_authorized/dashboard')({
@@ -279,13 +307,16 @@ function MenteeDashboardView() {
                           </Muted>
                         </div>
                       </div>
-                      <Link
-                          to="/profiles/$username"
-                          params={{ username: session.mentor.username }}
-                          className="text-xs text-accent hover:underline underline-offset-4 shrink-0"
-                      >
-                        View profile
-                      </Link>
+                      <div className="flex flex-col items-end gap-2 shrink-0">
+                        <Link
+                            to="/profiles/$username"
+                            params={{ username: session.mentor.username }}
+                            className="text-xs text-accent hover:underline underline-offset-4"
+                        >
+                          View profile
+                        </Link>
+                        <SessionManagementModal session={toSessionManagementData(session)} />
+                      </div>
                     </CardContent>
                   </Card>
               ))}
@@ -580,15 +611,18 @@ function MentorDashboardView() {
                             </Muted>
                           </div>
                         </div>
-                        {session.mentee.username && (
-                            <Link
-                                to="/profiles/$username"
-                                params={{ username: session.mentee.username }}
-                                className="text-xs text-accent hover:underline underline-offset-4 shrink-0"
-                            >
-                              View profile
-                            </Link>
-                        )}
+                        <div className="flex flex-col items-end gap-2 shrink-0">
+                          {session.mentee.username && (
+                              <Link
+                                  to="/profiles/$username"
+                                  params={{ username: session.mentee.username }}
+                                  className="text-xs text-accent hover:underline underline-offset-4"
+                              >
+                                View profile
+                              </Link>
+                          )}
+                          <SessionManagementModal session={toSessionManagementData(session)} />
+                        </div>
                       </CardContent>
                     </Card>
                 )

--- a/web/src/routes/_authorized/dashboard.tsx
+++ b/web/src/routes/_authorized/dashboard.tsx
@@ -34,10 +34,10 @@ function toSessionManagementData(session: MeetingSession) {
       role: 'mentor' as const,
     },
     attendee: {
-      id: session.mentee.username,
-      username: session.mentee.username,
-      fullName: session.mentee.display_name,
-      avatarUrl: session.mentee.picture_url,
+      id: session.mentee?.username ?? '',
+      username: session.mentee?.username ?? '',
+      fullName: session.mentee?.display_name ?? '',
+      avatarUrl: session.mentee?.picture_url ?? '',
       role: 'mentee' as const,
     },
   }

--- a/web/src/routes/profiles.$username.tsx
+++ b/web/src/routes/profiles.$username.tsx
@@ -66,7 +66,7 @@ function PublicProfileRoute() {
             picture_url: profile.picture_url,
             title: profile.title,
             skills: profile.skills ?? [],
-            average_rating: profile.average_rating,
+            average_rating: Number(profile.average_rating),
             total_mentee_count: profile.total_mentee_count,
             username: username,
         }


### PR DESCRIPTION
## Related Issue
                                                                                                                       
  Closes #422                                                                                           
   
  ## Description                                                                                                          
                  
  Adds reschedule and cancel session functionality to the `SessionManagementModal` on the web dashboard. The reschedule   
  flow opens an inline week-by-week slot picker that fetches the mentor's available slots, lets the user select one, and  
  confirms the change via the backend API. Cancel immediately calls the cancel endpoint and closes the modal. Both actions
   invalidate the relevant session queries, show toast feedback, and display loading/disabled states during the request.


  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation
  - [ ] CI/CD or configuration
                                                                                                                          
  ## Checklist
                                                                                                                          
  - [x] I have tested my changes locally
  - [x] My code builds without errors
  - [ ] I have written or updated tests where applicable
  - [x] I have performed a self-review of my code
                                                                                                                          
  ## Notes
                                                                                                                          
  The meeting link save button is still a local-only placeholder pending a backend endpoint for updating session meeting
  links.