### PR TITLE
feat(profiles): Community Tag members list API

### DIFF
--- a/backend/profiles/tests.py
+++ b/backend/profiles/tests.py
@@ -2959,3 +2959,154 @@ class CommunityTagsAPITests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.json()["is_member"])
 
+    # ---- Members List Tests (#432) ----
+
+    def test_members_list_public_access(self) -> None:
+        """Anyone can list a tag's members without authentication."""
+        create_resp = self._create_tag("Members Public")
+        tag_id = create_resp.json()["id"]
+
+        # creator joins
+        self._auth()
+        self.client.post(f"/api/profiles/tags/{tag_id}/join/")
+        # another user joins
+        self._auth(self.access_token2)
+        self.client.post(f"/api/profiles/tags/{tag_id}/join/")
+
+        self.client.credentials()
+        response = self.client.get(f"/api/profiles/tags/{tag_id}/members/")
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["count"], 2)
+        self.assertEqual(len(data["results"]), 2)
+
+    def test_members_list_orders_by_recent_join(self) -> None:
+        """Members are listed with most recently joined first."""
+        create_resp = self._create_tag("Order Tag")
+        tag_id = create_resp.json()["id"]
+
+        self._auth()
+        self.client.post(f"/api/profiles/tags/{tag_id}/join/")
+        self._auth(self.access_token2)
+        self.client.post(f"/api/profiles/tags/{tag_id}/join/")
+
+        self.client.credentials()
+        response = self.client.get(f"/api/profiles/tags/{tag_id}/members/")
+
+        self.assertEqual(response.status_code, 200)
+        ids = [r["id"] for r in response.json()["results"]]
+        self.assertEqual(ids[0], str(self.profile2.id))
+        self.assertEqual(ids[1], str(self.profile.id))
+
+    def test_members_list_pagination(self) -> None:
+        """Pagination respects pageSize and reports total count."""
+        from accounts.models import AppUsageMode
+
+        create_resp = self._create_tag("Pagination Tag")
+        tag_id = create_resp.json()["id"]
+
+        # add three members
+        self._auth()
+        self.client.post(f"/api/profiles/tags/{tag_id}/join/")
+        self._auth(self.access_token2)
+        self.client.post(f"/api/profiles/tags/{tag_id}/join/")
+
+        user3 = User.objects.create_user(
+            email="tag-user3@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTOR,
+        )
+        Profile.objects.create(user=user3, display_name="Tag User 3", is_visible=True)
+        token3 = str(RefreshToken.for_user(user3).access_token)
+        self._auth(token3)
+        self.client.post(f"/api/profiles/tags/{tag_id}/join/")
+
+        self.client.credentials()
+        response = self.client.get(
+            f"/api/profiles/tags/{tag_id}/members/",
+            {"page": 1, "pageSize": 2},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["count"], 3)
+        self.assertEqual(len(data["results"]), 2)
+        self.assertEqual(data["page"], 1)
+        self.assertEqual(data["pageSize"], 2)
+
+    def test_members_list_excludes_hidden_profiles(self) -> None:
+        """Profiles with is_visible=False are not included in the response."""
+        create_resp = self._create_tag("Hidden Tag")
+        tag_id = create_resp.json()["id"]
+
+        self._auth()
+        self.client.post(f"/api/profiles/tags/{tag_id}/join/")
+        self._auth(self.access_token2)
+        self.client.post(f"/api/profiles/tags/{tag_id}/join/")
+
+        # hide profile2
+        self.profile2.is_visible = False
+        self.profile2.save(update_fields=["is_visible"])
+
+        self.client.credentials()
+        response = self.client.get(f"/api/profiles/tags/{tag_id}/members/")
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["count"], 1)
+        ids = [r["id"] for r in data["results"]]
+        self.assertIn(str(self.profile.id), ids)
+        self.assertNotIn(str(self.profile2.id), ids)
+
+    def test_members_list_honors_show_initials_only(self) -> None:
+        """When a member has show_initials_only, the response shows initials."""
+        create_resp = self._create_tag("Initials Tag")
+        tag_id = create_resp.json()["id"]
+
+        self.profile.show_initials_only = True
+        self.profile.save(update_fields=["show_initials_only"])
+
+        self._auth()
+        self.client.post(f"/api/profiles/tags/{tag_id}/join/")
+
+        self.client.credentials()
+        response = self.client.get(f"/api/profiles/tags/{tag_id}/members/")
+
+        self.assertEqual(response.status_code, 200)
+        result = next(r for r in response.json()["results"] if r["id"] == str(self.profile.id))
+        # display_name "Tag User" → initials "TU"
+        self.assertNotEqual(result["full_name"], "Tag User")
+
+    def test_members_list_empty_tag(self) -> None:
+        """An empty tag returns an empty results array with count zero."""
+        create_resp = self._create_tag("Empty Tag")
+        tag_id = create_resp.json()["id"]
+
+        self.client.credentials()
+        response = self.client.get(f"/api/profiles/tags/{tag_id}/members/")
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["count"], 0)
+        self.assertEqual(data["results"], [])
+
+    def test_members_list_nonexistent_tag_returns_404(self) -> None:
+        """Requesting members of a nonexistent tag returns 404."""
+        fake_id = uuid.uuid4()
+        response = self.client.get(f"/api/profiles/tags/{fake_id}/members/")
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_members_list_invalid_pagination_returns_400(self) -> None:
+        """Non-integer page/pageSize returns 400."""
+        create_resp = self._create_tag("Bad Pagination")
+        tag_id = create_resp.json()["id"]
+
+        response = self.client.get(
+            f"/api/profiles/tags/{tag_id}/members/",
+            {"page": "abc"},
+        )
+
+        self.assertEqual(response.status_code, 400)
+

--- a/backend/profiles/urls.py
+++ b/backend/profiles/urls.py
@@ -9,6 +9,7 @@ from .views import (
     CommunityTagJoinAPIView,
     CommunityTagLeaveAPIView,
     CommunityTagListCreateAPIView,
+    CommunityTagMembersListAPIView,
     MentorPublicAverageRatingAPIView,
     MyAvailabilitySlotDetailAPIView,
     MyAvailabilitySlotListCreateAPIView,
@@ -80,6 +81,11 @@ urlpatterns = [
         "tags/<uuid:tag_id>/leave/",
         CommunityTagLeaveAPIView.as_view(),
         name="community-tag-leave",
+    ),
+    path(
+        "tags/<uuid:tag_id>/members/",
+        CommunityTagMembersListAPIView.as_view(),
+        name="community-tag-members",
     ),
     path("me/tags/", MyTagsListAPIView.as_view(), name="my-tags-list"),
     # Catch-all username route (must stay last)

--- a/backend/profiles/views.py
+++ b/backend/profiles/views.py
@@ -1232,3 +1232,62 @@ class MyTagsListAPIView(ProfileLookupMixin, APIView):
             CommunityTagListSerializer(tags, many=True).data,
             status=status.HTTP_200_OK,
         )
+
+
+class CommunityTagMembersListAPIView(APIView):
+    """List the visible profiles enrolled in a community tag."""
+
+    permission_classes = [AllowAny]
+
+    @extend_schema(
+        operation_id="community_tags_members_list",
+        responses={
+            200: PublicMentorProfileSearchListResponseSerializer,
+            400: OpenApiResponse(description="Invalid pagination params."),
+            404: OpenApiResponse(description="Tag not found."),
+        },
+        description=(
+            "List the profiles that have joined a given community tag, ordered by "
+            "most recently joined first. Hidden profiles are excluded. Pagination via "
+            "`page` and `pageSize`."
+        ),
+        tags=["Community Tags"],
+    )
+    def get(self, request: Request, tag_id: str) -> Response:
+        if not CommunityTag.objects.filter(id=tag_id).exists():
+            return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
+
+        try:
+            page = int(request.query_params.get("page", 1))
+            page_size = int(request.query_params.get("pageSize", 20))
+        except (TypeError, ValueError):
+            return Response(
+                {"detail": "`page` and `pageSize` must be integers."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        page = max(page, 1)
+        page_size = max(1, min(page_size, 50))
+
+        memberships = (
+            CommunityTagMembership.objects
+            .filter(tag_id=tag_id, profile__is_visible=True)
+            .select_related("profile__user")
+            .order_by("-joined_at")
+        )
+
+        total = memberships.count()
+        offset = (page - 1) * page_size
+        page_items = memberships[offset : offset + page_size]
+        profiles = [m.profile for m in page_items]
+
+        serializer = PublicMentorProfileSearchResultSerializer(profiles, many=True)
+        return Response(
+            {
+                "count": total,
+                "page": page,
+                "pageSize": page_size,
+                "results": serializer.data,
+            },
+            status=status.HTTP_200_OK,
+        )


### PR DESCRIPTION
## Summary

Adds the `GET /api/profiles/tags/{tag_id}/members/` endpoint requested in #432. Returns the profiles enrolled in a community tag, ordered by most recent join, with hidden profiles excluded and the existing public mentor projection reused so visibility toggles (`show_initials_only`, etc.) stay honored.

## ⚠️ Do not merge before #436

This PR is **stacked on top of #436** (Community Tags API). The base branch is `feat/community-tags-api`, not `dev`. Once #436 is merged into `dev`, GitHub will automatically retarget this PR to `dev`. **Please do not merge this PR until #436 has been merged first**, otherwise the tag models it depends on will not exist on the target branch.

## What changed

- New `CommunityTagMembersListAPIView` in `backend/profiles/views.py`.
- New URL: `tags/<uuid:tag_id>/members/` under the existing community tags routes.
- 8 new unit tests covering public access, ordering, pagination, hidden-profile exclusion, `show_initials_only` honoring, empty tag, 404 on nonexistent tag, and 400 on bad pagination.

## API

`GET /api/profiles/tags/{tag_id}/members/`

- Public (guest + authenticated).
- Query params: `page` (default 1), `pageSize` (default 20, capped at 50).
- Hidden profiles (`is_visible=False`) are filtered out.
- Ordering: most recently joined first (uses `joined_at` from the through table).
- Response shape mirrors the existing paginated public mentor search response.

## Test plan

- [x] All 34 community-tag tests pass locally (`python manage.py test profiles.tests.CommunityTagsAPITests`).
- [ ] CI green.
- [ ] Manual smoke test: join a tag, hit the members endpoint as a guest, verify ordering and that hidden profiles are excluded.

Closes #432