### PR TITLE
feat: mentorship journey

### DIFF
--- a/backend/mentorship/serializers.py
+++ b/backend/mentorship/serializers.py
@@ -337,3 +337,30 @@ class FeedbackCreateSerializer(serializers.Serializer):
 
     rating = serializers.IntegerField(min_value=1, max_value=5)
     text = serializers.CharField(required=False, default="", allow_blank=True)
+
+
+class JourneyQueryParamsSerializer(serializers.Serializer):
+    """Validate offset/limit query parameters for match journey feed."""
+
+    offset = serializers.IntegerField(required=False, min_value=0, default=0)
+    limit = serializers.IntegerField(required=False, min_value=1, max_value=200, default=50)
+
+
+class JourneyEventSerializer(serializers.Serializer):
+    """Read serializer for a single match journey event item."""
+
+    id = serializers.CharField(read_only=True)
+    type = serializers.CharField(read_only=True)
+    timestamp = serializers.DateTimeField(read_only=True)
+    actor_role = serializers.CharField(read_only=True)
+    payload = serializers.JSONField(read_only=True)
+
+
+class JourneyFeedSerializer(serializers.Serializer):
+    """Read serializer for the paginated match journey feed envelope."""
+
+    ordering = serializers.ChoiceField(choices=["desc"], read_only=True)
+    count = serializers.IntegerField(read_only=True)
+    offset = serializers.IntegerField(read_only=True)
+    limit = serializers.IntegerField(read_only=True)
+    results = JourneyEventSerializer(many=True, read_only=True)

--- a/backend/mentorship/serializers.py
+++ b/backend/mentorship/serializers.py
@@ -1,10 +1,10 @@
 """Serializers for mentorship request and match API endpoints."""
 
 from django.utils import timezone
-from core.utils.timezone import to_local_time
 from rest_framework import serializers
 
 from accounts.models import AppUsageMode
+from core.utils.timezone import to_local_time
 from profiles.models import AvailabilitySlot, Profile
 
 from .models import Feedback, Match, MeetingSession, MentorshipRequest

--- a/backend/mentorship/services.py
+++ b/backend/mentorship/services.py
@@ -8,8 +8,8 @@ from django.conf import settings
 from django.db import IntegrityError, transaction
 from django.db.models import Avg, F
 from django.utils import timezone
-from core.utils.timezone import to_local_time
 
+from core.utils.timezone import to_local_time
 from notifications.models import Notification, NotificationType
 from profiles.models import AvailabilitySlot, Profile
 from profiles.services import (

--- a/backend/mentorship/services.py
+++ b/backend/mentorship/services.py
@@ -1,5 +1,6 @@
 """Domain services for mentorship lifecycle operations."""
 
+from collections.abc import Iterable
 from decimal import Decimal
 from typing import Any
 
@@ -22,6 +23,197 @@ from profiles.services import (
 )
 
 from .models import Feedback, Match, MeetingSession, MentorshipRequest
+
+
+def _serialize_optional_datetime(value: Any) -> str | None:
+    """Serialize optional timezone-aware datetimes to ISO 8601 strings."""
+    if value is None:
+        return None
+    return value.isoformat()
+
+
+def _actor_role_from_canceled_by(canceled_by_role: str) -> str:
+    """Normalize canceled-by role values to public actor role values."""
+    if canceled_by_role == MeetingSession.CanceledByRole.MENTOR:
+        return "mentor"
+    if canceled_by_role == MeetingSession.CanceledByRole.MENTEE:
+        return "mentee"
+    return "system"
+
+
+def _actor_role_for_deactivation(*, actor_id: Any, match: Match) -> str:
+    """Resolve match deactivation actor role from notification actor id."""
+    if actor_id == match.mentor_id:
+        return "mentor"
+    if actor_id == match.mentee_id:
+        return "mentee"
+    return "system"
+
+
+def _build_request_events(*, request_rows: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Build journey events from mentorship request rows."""
+    events: list[dict[str, Any]] = []
+    for row in request_rows:
+        if row["status"] != MentorshipRequest.Status.ACCEPTED or row["responded_at"] is None:
+            continue
+
+        events.append(
+            {
+                "id": f"request_accepted:{row['id']}",
+                "type": "request_accepted",
+                "timestamp": row["responded_at"],
+                "actor_role": "mentor",
+                "payload": {
+                    "request_id": str(row["id"]),
+                    "initial_session_start_at": _serialize_optional_datetime(
+                        row["initial_session_start_at"]
+                    ),
+                    "initial_session_end_at": _serialize_optional_datetime(
+                        row["initial_session_end_at"]
+                    ),
+                },
+            }
+        )
+    return events
+
+
+def _build_session_events(*, session_rows: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Build journey events from canonical meeting session rows."""
+    events: list[dict[str, Any]] = []
+    for row in session_rows:
+        payload = {
+            "session_id": str(row["id"]),
+            "scheduled_start_at_utc": row["scheduled_start_at_utc"].isoformat(),
+            "scheduled_end_at_utc": row["scheduled_end_at_utc"].isoformat(),
+        }
+
+        if row["status"] == MeetingSession.Status.SCHEDULED:
+            events.append(
+                {
+                    "id": f"session_scheduled:{row['id']}",
+                    "type": "session_scheduled",
+                    "timestamp": row["created_at"],
+                    "actor_role": "system",
+                    "payload": payload,
+                }
+            )
+            continue
+
+        if row["status"] == MeetingSession.Status.RESCHEDULED:
+            events.append(
+                {
+                    "id": f"session_rescheduled:{row['id']}",
+                    "type": "session_rescheduled",
+                    "timestamp": row["updated_at"],
+                    "actor_role": "mentee",
+                    "payload": payload,
+                }
+            )
+            continue
+
+        if row["status"] == MeetingSession.Status.CANCELED:
+            payload_with_cancel = {
+                **payload,
+                "cancel_reason": row["cancel_reason"],
+            }
+            events.append(
+                {
+                    "id": f"session_canceled:{row['id']}",
+                    "type": "session_canceled",
+                    "timestamp": row["updated_at"],
+                    "actor_role": _actor_role_from_canceled_by(row["canceled_by_role"]),
+                    "payload": payload_with_cancel,
+                }
+            )
+            continue
+
+        if row["status"] == MeetingSession.Status.COMPLETED:
+            events.append(
+                {
+                    "id": f"session_completed:{row['id']}",
+                    "type": "session_completed",
+                    "timestamp": row["updated_at"],
+                    "actor_role": "system",
+                    "payload": payload,
+                }
+            )
+
+    return events
+
+
+def _build_mentorship_ended_event(*, match: Match) -> list[dict[str, Any]]:
+    """Build the mentorship_ended event from existing deactivation notifications."""
+    if match.is_active:
+        return []
+
+    notification = (
+        Notification.objects.filter(
+            type=NotificationType.MATCH_DEACTIVATED,
+            resource_type="match",
+            resource_id=match.id,
+        )
+        .order_by("-created_at")
+        .values("id", "created_at", "actor_id")
+        .first()
+    )
+
+    if notification is None:
+        return []
+
+    return [
+        {
+            "id": f"mentorship_ended:{notification['id']}",
+            "type": "mentorship_ended",
+            "timestamp": notification["created_at"],
+            "actor_role": _actor_role_for_deactivation(
+                actor_id=notification["actor_id"],
+                match=match,
+            ),
+            "payload": {
+                "match_id": str(match.id),
+                "notification_id": str(notification["id"]),
+            },
+        }
+    ]
+
+
+def list_match_journey_events(*, match: Match, offset: int, limit: int) -> dict[str, Any]:
+    """Return a paginated journey timeline merged from mentorship-domain source tables."""
+    request_rows = MentorshipRequest.objects.filter(id=match.request_id).values(
+        "id",
+        "status",
+        "responded_at",
+        "initial_session_start_at",
+        "initial_session_end_at",
+    )
+    session_rows = MeetingSession.objects.filter(match_id=match.id).values(
+        "id",
+        "status",
+        "scheduled_start_at_utc",
+        "scheduled_end_at_utc",
+        "canceled_by_role",
+        "cancel_reason",
+        "created_at",
+        "updated_at",
+    )
+
+    all_events = [
+        *_build_request_events(request_rows=request_rows),
+        *_build_session_events(session_rows=session_rows),
+        *_build_mentorship_ended_event(match=match),
+    ]
+    all_events.sort(key=lambda event: (event["timestamp"], event["id"]), reverse=True)
+
+    total_count = len(all_events)
+    end = offset + limit
+
+    return {
+        "ordering": "desc",
+        "count": total_count,
+        "offset": offset,
+        "limit": limit,
+        "results": all_events[offset:end],
+    }
 
 
 class MentorshipServiceError(Exception):
@@ -581,6 +773,7 @@ __all__ = [
     "create_match_feedback",
     "delete_match_feedback",
     "book_match_session",
+    "list_match_journey_events",
     "BookingCancelNotAllowedError",
     "SlotNotBookedError",
     "SlotAlreadyBookedError",

--- a/backend/mentorship/tests.py
+++ b/backend/mentorship/tests.py
@@ -7,8 +7,9 @@ from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, connection, transaction
 from django.test import TestCase, override_settings
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 from rest_framework.test import APIClient, APIRequestFactory
 from rest_framework_simplejwt.tokens import RefreshToken
@@ -710,6 +711,176 @@ class DeactivateMatchAPIViewTests(FeedbackAPIBaseTestCase):
         response = self.mentor_client.get(self.MATCHES_ME_URL)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, [])
+
+
+class MatchJourneyAPIViewTests(FeedbackAPIBaseTestCase):
+    """Tests for GET /api/mentorship/matches/<match_id>/journey/."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.journey_url = f"/api/mentorship/matches/{self.match.id}/journey/"
+
+    def _set_request_accepted_time(self, dt) -> None:
+        MentorshipRequest.objects.filter(id=self.mentorship_request.id).update(responded_at=dt)
+
+    def _create_session(
+        self,
+        *,
+        status: str,
+        start_offset_days: int,
+        event_time,
+        canceled_by_role: str = "",
+        cancel_reason: str = "",
+    ) -> MeetingSession:
+        start_at = timezone.now() + timedelta(days=start_offset_days)
+        session = MeetingSession.objects.create(
+            match=self.match,
+            mentor=self.mentor_profile,
+            mentee=self.mentee_profile,
+            scheduled_start_at_utc=start_at,
+            scheduled_end_at_utc=start_at + timedelta(hours=1),
+            status=status,
+            canceled_by_role=canceled_by_role,
+            cancel_reason=cancel_reason,
+        )
+        MeetingSession.objects.filter(id=session.id).update(
+            created_at=event_time,
+            updated_at=event_time,
+        )
+        session.refresh_from_db()
+        return session
+
+    def test_unauthenticated_returns_401(self) -> None:
+        response = self.anon_client.get(self.journey_url)
+        self.assertEqual(response.status_code, 401)
+
+    def test_authenticated_outsider_can_access(self) -> None:
+        response = self.other_client.get(self.journey_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("results", response.data)
+
+    def test_fresh_match_with_only_request_returns_single_request_accepted(self) -> None:
+        response = self.mentor_client.get(self.journey_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(response.data["results"][0]["type"], "request_accepted")
+
+    def test_full_lifecycle_includes_all_scoped_event_types(self) -> None:
+        base_time = timezone.now() - timedelta(days=2)
+        self._set_request_accepted_time(base_time)
+
+        self._create_session(
+            status=MeetingSession.Status.SCHEDULED,
+            start_offset_days=1,
+            event_time=base_time + timedelta(hours=1),
+        )
+        self._create_session(
+            status=MeetingSession.Status.RESCHEDULED,
+            start_offset_days=2,
+            event_time=base_time + timedelta(hours=2),
+        )
+        self._create_session(
+            status=MeetingSession.Status.CANCELED,
+            start_offset_days=3,
+            event_time=base_time + timedelta(hours=3),
+            canceled_by_role=MeetingSession.CanceledByRole.MENTOR,
+            cancel_reason="Conflict",
+        )
+        self._create_session(
+            status=MeetingSession.Status.COMPLETED,
+            start_offset_days=-1,
+            event_time=base_time + timedelta(hours=4),
+        )
+        self.mentor_client.post(f"/api/mentorship/matches/{self.match.id}/deactivate/")
+
+        response = self.mentor_client.get(self.journey_url)
+        self.assertEqual(response.status_code, 200)
+        event_types = {item["type"] for item in response.data["results"]}
+
+        self.assertIn("request_accepted", event_types)
+        self.assertIn("session_scheduled", event_types)
+        self.assertIn("session_rescheduled", event_types)
+        self.assertIn("session_canceled", event_types)
+        self.assertIn("session_completed", event_types)
+        self.assertIn("mentorship_ended", event_types)
+        self.assertNotIn("request_created", event_types)
+
+    def test_cross_type_ordering_is_descending_by_timestamp(self) -> None:
+        base_time = timezone.now() - timedelta(days=1)
+        self._set_request_accepted_time(base_time)
+
+        self._create_session(
+            status=MeetingSession.Status.SCHEDULED,
+            start_offset_days=1,
+            event_time=base_time + timedelta(hours=1),
+        )
+        self._create_session(
+            status=MeetingSession.Status.COMPLETED,
+            start_offset_days=-1,
+            event_time=base_time + timedelta(hours=2),
+        )
+
+        response = self.mentor_client.get(self.journey_url)
+        self.assertEqual(response.status_code, 200)
+        timestamps = [item["timestamp"] for item in response.data["results"]]
+        self.assertEqual(timestamps, sorted(timestamps, reverse=True))
+
+    def test_offset_limit_slices_results(self) -> None:
+        base_time = timezone.now() - timedelta(days=1)
+        self._set_request_accepted_time(base_time)
+
+        self._create_session(
+            status=MeetingSession.Status.SCHEDULED,
+            start_offset_days=1,
+            event_time=base_time + timedelta(hours=1),
+        )
+        self._create_session(
+            status=MeetingSession.Status.COMPLETED,
+            start_offset_days=-1,
+            event_time=base_time + timedelta(hours=2),
+        )
+        self._create_session(
+            status=MeetingSession.Status.CANCELED,
+            start_offset_days=2,
+            event_time=base_time + timedelta(hours=3),
+            canceled_by_role=MeetingSession.CanceledByRole.MENTEE,
+            cancel_reason="No longer needed",
+        )
+
+        response = self.mentor_client.get(self.journey_url, {"offset": 1, "limit": 2})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["offset"], 1)
+        self.assertEqual(response.data["limit"], 2)
+        self.assertEqual(len(response.data["results"]), 2)
+
+    def test_invalid_offset_or_limit_returns_400(self) -> None:
+        offset_response = self.mentor_client.get(self.journey_url, {"offset": -1, "limit": 10})
+        self.assertEqual(offset_response.status_code, 400)
+
+        limit_response = self.mentor_client.get(self.journey_url, {"offset": 0, "limit": 0})
+        self.assertEqual(limit_response.status_code, 400)
+
+        cap_response = self.mentor_client.get(self.journey_url, {"offset": 0, "limit": 999})
+        self.assertEqual(cap_response.status_code, 400)
+
+    def test_query_count_stays_bounded_with_more_sessions(self) -> None:
+        with CaptureQueriesContext(connection) as baseline_ctx:
+            baseline_response = self.mentor_client.get(self.journey_url)
+        self.assertEqual(baseline_response.status_code, 200)
+
+        now = timezone.now()
+        for i in range(40):
+            self._create_session(
+                status=MeetingSession.Status.SCHEDULED,
+                start_offset_days=i + 1,
+                event_time=now + timedelta(minutes=i),
+            )
+
+        with CaptureQueriesContext(connection) as heavy_ctx:
+            heavy_response = self.mentor_client.get(self.journey_url)
+        self.assertEqual(heavy_response.status_code, 200)
+        self.assertEqual(len(heavy_ctx), len(baseline_ctx))
 
 
 @override_settings(RATING_UPDATE_THRESHOLD=5)

--- a/backend/mentorship/urls.py
+++ b/backend/mentorship/urls.py
@@ -6,8 +6,8 @@ from .views import (
     CancelSessionAPIView,
     CreateRequestAPIView,
     DeactivateMatchAPIView,
-    MatchJourneyAPIView,
     MatchFeedbackListCreateAPIView,
+    MatchJourneyAPIView,
     MyMatchesListAPIView,
     MyMeetingSessionsListAPIView,
     MyRequestsListAPIView,
@@ -44,7 +44,6 @@ urlpatterns = [
         MatchFeedbackListCreateAPIView.as_view(),
         name="mentorship-match-feedback",
     ),
-
     path(
         "sessions/<uuid:session_id>/cancel/",
         CancelSessionAPIView.as_view(),

--- a/backend/mentorship/urls.py
+++ b/backend/mentorship/urls.py
@@ -6,6 +6,7 @@ from .views import (
     CancelSessionAPIView,
     CreateRequestAPIView,
     DeactivateMatchAPIView,
+    MatchJourneyAPIView,
     MatchFeedbackListCreateAPIView,
     MyMatchesListAPIView,
     MyMeetingSessionsListAPIView,
@@ -32,6 +33,11 @@ urlpatterns = [
         "matches/<uuid:match_id>/deactivate/",
         DeactivateMatchAPIView.as_view(),
         name="mentorship-match-deactivate",
+    ),
+    path(
+        "matches/<uuid:match_id>/journey/",
+        MatchJourneyAPIView.as_view(),
+        name="mentorship-match-journey",
     ),
     path(
         "matches/<uuid:match_id>/feedback/",

--- a/backend/mentorship/views.py
+++ b/backend/mentorship/views.py
@@ -44,8 +44,8 @@ from .services import (
     create_match_feedback,
     create_mentorship_request,
     deactivate_match,
-    list_match_journey_events,
     delete_match_feedback,
+    list_match_journey_events,
     reschedule_match_session,
     respond_to_mentorship_request,
 )
@@ -553,16 +553,28 @@ class MatchJourneyAPIView(APIView):
             404: OpenApiResponse(description="Match not found."),
         },
         description=(
-            "Return the journey timeline for a single match, merged server-side from "
-            "MentorshipRequest acceptance, MeetingSession lifecycle rows, and match "
-            "deactivation notification signals. Results are globally sorted newest-first. "
-            "Pagination uses offset/limit after merge ordering, so clients should call with "
-            "offset=N and limit=M to read additional pages without re-merging multiple endpoints. "
-            "Event types: request_accepted, session_scheduled, session_rescheduled, "
-            "session_canceled, session_completed, mentorship_ended. Payload notes: "
-            "request_accepted includes request_id and optional initial session snapshot; "
-            "session_* includes session_id and scheduled window, with cancel_reason on "
-            "session_canceled; mentorship_ended includes match_id and notification_id."
+            "Return the journey timeline for a single match. The feed is assembled "
+            "server-side by merging three source tables — MentorshipRequest, "
+            "MeetingSession, and Notification — so clients receive a single "
+            "chronological list instead of stitching several endpoints together.\n\n"
+            "**Ordering:** All events are sorted newest-first (descending by timestamp) "
+            "across all source types before pagination is applied.\n\n"
+            "**Pagination:** Use `offset` (zero-based start index, default 0) and `limit` "
+            "(page size, default 50, max 200). Slicing is applied after the global "
+            "merge-sort, so page boundaries are stable across calls.\n\n"
+            "**Event types and payloads:**\n"
+            "- `request_accepted` — emitted when the mentor accepts the request; "
+            "payload: `request_id`, `initial_session_start_at`, `initial_session_end_at`.\n"
+            "- `session_scheduled` — emitted when a MeetingSession is created in SCHEDULED; "
+            "payload: `session_id`, `scheduled_start_at_utc`, `scheduled_end_at_utc`.\n"
+            "- `session_rescheduled` — emitted when a session is moved to a new slot; "
+            "payload: `session_id`, `scheduled_start_at_utc`, `scheduled_end_at_utc`.\n"
+            "- `session_canceled` — emitted when a session is canceled; "
+            "payload adds `cancel_reason` to the standard session fields.\n"
+            "- `session_completed` — emitted when a session transitions to COMPLETED; "
+            "payload: `session_id`, `scheduled_start_at_utc`, `scheduled_end_at_utc`.\n"
+            "- `mentorship_ended` — emitted when the match is deactivated; "
+            "payload: `match_id`, `notification_id`."
         ),
         tags=["Mentorship"],
     )

--- a/backend/mentorship/views.py
+++ b/backend/mentorship/views.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 from django.db import IntegrityError
 from django.db.models import Q
 from django.utils import timezone
-from drf_spectacular.utils import OpenApiResponse, extend_schema
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, OpenApiTypes, extend_schema
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -27,6 +27,8 @@ from .models import Feedback, Match, MeetingSession, MentorshipRequest
 from .serializers import (
     FeedbackCreateSerializer,
     FeedbackSerializer,
+    JourneyFeedSerializer,
+    JourneyQueryParamsSerializer,
     MatchSerializer,
     MeetingSessionSerializer,
     MentorshipRequestCreateSerializer,
@@ -42,6 +44,7 @@ from .services import (
     create_match_feedback,
     create_mentorship_request,
     deactivate_match,
+    list_match_journey_events,
     delete_match_feedback,
     reschedule_match_session,
     respond_to_mentorship_request,
@@ -519,6 +522,67 @@ class DeactivateMatchAPIView(APIView):
         match = deactivate_match(match=match, actor_profile=profile)
 
         return Response(MatchSerializer(match).data, status=status.HTTP_200_OK)
+
+
+class MatchJourneyAPIView(APIView):
+    """Read-only timeline endpoint that merges match lifecycle events across source tables."""
+
+    permission_classes = [IsUser]
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="offset",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=OpenApiTypes.INT,
+                description="Zero-based index of the first item to include. Default: 0.",
+            ),
+            OpenApiParameter(
+                name="limit",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=OpenApiTypes.INT,
+                description="Maximum number of items to return. Default: 50. Maximum: 200.",
+            ),
+        ],
+        responses={
+            200: JourneyFeedSerializer,
+            400: OpenApiResponse(description="Invalid offset/limit query params."),
+            401: OpenApiResponse(description="Authentication required."),
+            404: OpenApiResponse(description="Match not found."),
+        },
+        description=(
+            "Return the journey timeline for a single match, merged server-side from "
+            "MentorshipRequest acceptance, MeetingSession lifecycle rows, and match "
+            "deactivation notification signals. Results are globally sorted newest-first. "
+            "Pagination uses offset/limit after merge ordering, so clients should call with "
+            "offset=N and limit=M to read additional pages without re-merging multiple endpoints. "
+            "Event types: request_accepted, session_scheduled, session_rescheduled, "
+            "session_canceled, session_completed, mentorship_ended. Payload notes: "
+            "request_accepted includes request_id and optional initial session snapshot; "
+            "session_* includes session_id and scheduled window, with cancel_reason on "
+            "session_canceled; mentorship_ended includes match_id and notification_id."
+        ),
+        tags=["Mentorship"],
+    )
+    def get(self, request: Request, match_id: str) -> Response:
+        """Return a paginated cross-source journey feed for the identified match."""
+        params_serializer = JourneyQueryParamsSerializer(data=request.query_params)
+        params_serializer.is_valid(raise_exception=True)
+        params = cast(dict[str, int], params_serializer.validated_data)
+
+        try:
+            match = Match.objects.select_related("mentor", "mentee", "request").get(id=match_id)
+        except Match.DoesNotExist:
+            return Response(_NOT_FOUND, status=status.HTTP_404_NOT_FOUND)
+
+        payload = list_match_journey_events(
+            match=match,
+            offset=params["offset"],
+            limit=params["limit"],
+        )
+        return Response(JourneyFeedSerializer(payload).data, status=status.HTTP_200_OK)
 
 
 class MatchFeedbackListCreateAPIView(APIView):


### PR DESCRIPTION
## Related Issue

Closes #441 

## Description

This PR adds a timeline to allow a mentor to track and display a mentee's journey.

Added READ-ONLY endpoint `GET /api/mentorship/matches/<match_id>/journey/`

Ordering: All events are sorted newest-first (descending by timestamp) across all source types before pagination is applied.

Pagination: Use offset (zero-based start index, default 0) and limit (page size, default 50, max 200). Slicing is applied after the global merge-sort, so page boundaries are stable across calls.

Event types and payloads:

 - request_accepted — emitted when the mentor accepts the request; payload: request_id, initial_session_start_at, initial_session_end_at.
 - session_scheduled — emitted when a MeetingSession is created in SCHEDULED; payload: session_id, scheduled_start_at_utc, scheduled_end_at_utc.
 - session_rescheduled — emitted when a session is moved to a new slot; payload: session_id, scheduled_start_at_utc, scheduled_end_at_utc.
 - session_canceled — emitted when a session is canceled; payload adds cancel_reason to the standard session fields.
 - session_completed — emitted when a session transitions to COMPLETED; payload: session_id, scheduled_start_at_utc, scheduled_end_at_utc.
 - mentorship_ended — emitted when the match is deactivated; payload: match_id, notification_id.


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or configuration

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code

## Notes

(Any additional information or considerations.)
