### PR TITLE
fix: fixed migration conflict

### DIFF
--- a/backend/profiles/migrations/0015_backfill_total_mentee_count_from_matches.py
+++ b/backend/profiles/migrations/0015_backfill_total_mentee_count_from_matches.py
@@ -32,7 +32,7 @@ def noop_reverse(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("profiles", "0012_remove_profile_rating"),
+        ("profiles", "0014_seed_starter_community_tags"),
         (
             "mentorship",
             "0009_rename_meeting_ses_mentor__73f9cd_idx_meeting_ses_mentor__62e580_idx_and_more",


### PR DESCRIPTION
## Related Issue

Closes #453 

## Description

This PR resolves the `CommandError: Conflicting migrations detected` in the `profiles` app that was blocking CI tests on the `dev` branch.

It renames `0013_backfill_total_mentee_count_from_matches.py` to `0015_backfill_total_mentee_count_from_matches.py` and updates its internal `dependencies` list to point to `0014_seed_starter_community_tags` instead of `0012_remove_profile_rating`. This linearizes the migration graph in the `profiles` app so Django can properly apply migrations.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or configuration

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code

## Notes

The backend tests should now pass in CI without migration conflicts.
