### PR TITLE
feat: auto membership of community upon creating

### DIFF
--- a/backend/profiles/tests.py
+++ b/backend/profiles/tests.py
@@ -2990,7 +2990,7 @@ class CommunityTagsAPITests(TestCase):
         data = response.json()
         self.assertEqual(data["name"], "Python Devs")
         self.assertEqual(data["slug"], "python-devs")
-        self.assertEqual(data["member_count"], 0)
+        self.assertEqual(data["member_count"], 1)
         self.assertEqual(data["created_by_username"], self.profile.username)
 
     def test_create_tag_unauthenticated_returns_401(self) -> None:
@@ -3079,6 +3079,7 @@ class CommunityTagsAPITests(TestCase):
         tag_id = create_resp.json()["id"]
 
         self._auth()
+        self.client.delete(f"/api/profiles/tags/{tag_id}/leave/")
         response = self.client.delete(f"/api/profiles/tags/{tag_id}/")
 
         self.assertEqual(response.status_code, 204)
@@ -3131,7 +3132,7 @@ class CommunityTagsAPITests(TestCase):
         create_resp = self._create_tag("Joinable Tag")
         tag_id = create_resp.json()["id"]
 
-        self._auth()
+        self._auth(self.access_token2)
         response = self.client.post(f"/api/profiles/tags/{tag_id}/join/")
 
         self.assertEqual(response.status_code, 200)
@@ -3146,9 +3147,6 @@ class CommunityTagsAPITests(TestCase):
         create_resp = self._create_tag("Count Tag")
         tag_id = create_resp.json()["id"]
 
-        self._auth()
-        self.client.post(f"/api/profiles/tags/{tag_id}/join/")
-
         self._auth(self.access_token2)
         self.client.post(f"/api/profiles/tags/{tag_id}/join/")
 
@@ -3160,7 +3158,7 @@ class CommunityTagsAPITests(TestCase):
         create_resp = self._create_tag("Dup Join Tag")
         tag_id = create_resp.json()["id"]
 
-        self._auth()
+        self._auth(self.access_token2)
         self.client.post(f"/api/profiles/tags/{tag_id}/join/")
         response = self.client.post(f"/api/profiles/tags/{tag_id}/join/")
 
@@ -3183,7 +3181,6 @@ class CommunityTagsAPITests(TestCase):
         tag_id = create_resp.json()["id"]
 
         self._auth()
-        self.client.post(f"/api/profiles/tags/{tag_id}/join/")
         response = self.client.delete(f"/api/profiles/tags/{tag_id}/leave/")
 
         self.assertEqual(response.status_code, 200)
@@ -3196,9 +3193,6 @@ class CommunityTagsAPITests(TestCase):
 
         create_resp = self._create_tag("Decrement Tag")
         tag_id = create_resp.json()["id"]
-
-        self._auth()
-        self.client.post(f"/api/profiles/tags/{tag_id}/join/")
 
         self._auth(self.access_token2)
         self.client.post(f"/api/profiles/tags/{tag_id}/join/")
@@ -3214,7 +3208,7 @@ class CommunityTagsAPITests(TestCase):
         create_resp = self._create_tag("No Membership Tag")
         tag_id = create_resp.json()["id"]
 
-        self._auth()
+        self._auth(self.access_token2)
         response = self.client.delete(f"/api/profiles/tags/{tag_id}/leave/")
 
         self.assertEqual(response.status_code, 400)
@@ -3226,12 +3220,9 @@ class CommunityTagsAPITests(TestCase):
         """My tags endpoint returns only tags the user has joined."""
         resp1 = self._create_tag("My Tag 1")
         resp2 = self._create_tag("My Tag 2")
-        self._create_tag("Not Joined Tag")
+        self._create_tag("Not Joined Tag", token=self.access_token2)
 
         self._auth()
-        self.client.post(f"/api/profiles/tags/{resp1.json()['id']}/join/")
-        self.client.post(f"/api/profiles/tags/{resp2.json()['id']}/join/")
-
         response = self.client.get(self.my_tags_url)
 
         self.assertEqual(response.status_code, 200)
@@ -3476,7 +3467,7 @@ class CommunityTagsAPITests(TestCase):
     def test_popular_excludes_zero_member_tags(self) -> None:
         """Tags with no members are not included in the popular list."""
         self._seed_tag_with_members("Has Members", 2)
-        self._create_tag("Empty Tag")  # zero members
+        CommunityTag.objects.create(name="Empty Tag", slug="empty-tag")  # zero members
 
         self.client.credentials()
         response = self.client.get("/api/profiles/tags/popular/")
@@ -3688,6 +3679,9 @@ class CommunityTagsAPITests(TestCase):
         """An empty tag returns an empty results array with count zero."""
         create_resp = self._create_tag("Empty Tag")
         tag_id = create_resp.json()["id"]
+
+        self._auth()
+        self.client.delete(f"/api/profiles/tags/{tag_id}/leave/")
 
         self.client.credentials()
         response = self.client.get(f"/api/profiles/tags/{tag_id}/members/")

--- a/backend/profiles/views.py
+++ b/backend/profiles/views.py
@@ -1237,7 +1237,12 @@ class CommunityTagListCreateAPIView(APIView):
             context={"profile": profile},
         )
         serializer.is_valid(raise_exception=True)
-        tag = serializer.save()
+
+        with transaction.atomic():
+            tag = serializer.save()
+            CommunityTagMembership.objects.create(profile=profile, tag=tag)
+            CommunityTag.objects.filter(id=tag.id).update(member_count=models.F("member_count") + 1)
+            tag.refresh_from_db()
 
         return Response(
             CommunityTagDetailSerializer(tag, context={"request": request}).data,


### PR DESCRIPTION
## Related Issue

Closes #480 

## Description

Automate membership logic for community creators. Previously, when a user created a community tag, they were not automatically enrolled as a member. This PR updates the creation flow to:
- Automatically create a `CommunityTagMembership` for the creator upon successful community creation.
- Increment the `member_count` to reflect the creator's membership.
- Ensure the tag instance is refreshed before being returned in the API response.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or configuration

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [ ] I have written or updated tests where applicable
- [x] I have performed a self-review of my code

## Notes

The implementation uses an atomic transaction to ensure data integrity between tag creation and membership enrollment.
