### PR TITLE
test: add mentor discovery e2e coverage (AT-007)

### DIFF
--- a/web/e2e/api/TestDataApi.ts
+++ b/web/e2e/api/TestDataApi.ts
@@ -1,0 +1,129 @@
+import { expect, type APIRequestContext, type Page } from '@playwright/test';
+
+export const API_BASE_URL = 'http://localhost:8000/api';
+const PASSWORD = 'DiscoveryPass123!';
+
+export type AuthResponse = {
+  access_token: string;
+  refresh_token: string;
+  user: {
+    id: string;
+    username: string;
+    app_usage_mode: 'MENTEE' | 'MENTOR';
+  };
+};
+
+export type UserSeed = {
+  email: string;
+  username: string;
+  displayName: string;
+  title: string;
+  bio: string;
+  skills: string[];
+};
+
+export type PublicMentorProfile = {
+  username: string;
+  full_name: string;
+  bio: string;
+  skills: string[];
+  rating?: number;
+  average_rating?: string | number;
+  total_mentee_count: number;
+};
+
+export class TestDataApi {
+  readonly request: APIRequestContext;
+
+  constructor(request: APIRequestContext) {
+    this.request = request;
+  }
+
+  async seedUser(seed: UserSeed, appUsageMode: 'MENTEE' | 'MENTOR') {
+    const auth = await this.registerOrLogin(seed.email);
+    await this.setUsageMode(auth.access_token, appUsageMode);
+    await this.updateProfile(auth.access_token, seed);
+    return auth;
+  }
+
+  async loginInBrowser(page: Page, auth: AuthResponse) {
+    await page.goto('/');
+    await page.evaluate((tokens) => {
+      localStorage.setItem('access_token', tokens.accessToken);
+      localStorage.setItem('refresh_token', tokens.refreshToken);
+      localStorage.setItem('id', tokens.userId);
+    }, {
+      accessToken: auth.access_token,
+      refreshToken: auth.refresh_token,
+      userId: auth.user.id,
+    });
+  }
+
+  async fetchMentors(query = '') {
+    const response = await this.request.get(`${API_BASE_URL}/profiles/${query}`);
+    expect(response.ok()).toBeTruthy();
+    return response.json() as Promise<{ results: PublicMentorProfile[] }>;
+  }
+
+  async fetchPopularMentors(limit = 6) {
+    const response = await this.request.get(`${API_BASE_URL}/profiles/popular/?limit=${limit}`);
+    expect(response.ok()).toBeTruthy();
+    return response.json() as Promise<{ results: PublicMentorProfile[] }>;
+  }
+
+  async fetchRecentlyAddedMentors(limit = 6) {
+    const response = await this.request.get(`${API_BASE_URL}/profiles/recently-added/?limit=${limit}`);
+    expect(response.ok()).toBeTruthy();
+    return response.json() as Promise<{ results: PublicMentorProfile[] }>;
+  }
+
+  private async registerOrLogin(email: string): Promise<AuthResponse> {
+    const payload = {
+      email,
+      password: PASSWORD,
+      confirm_password: PASSWORD,
+    };
+
+    const register = await this.request.post(`${API_BASE_URL}/auth/register/`, { data: payload });
+    if (register.ok()) {
+      return register.json();
+    }
+
+    const login = await this.request.post(`${API_BASE_URL}/auth/login/`, {
+      data: { email, password: PASSWORD },
+    });
+    expect(login.ok()).toBeTruthy();
+    return login.json();
+  }
+
+  private async patchWithAuth(
+    token: string,
+    url: string,
+    data: Record<string, unknown>,
+  ) {
+    const response = await this.request.patch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+      data,
+    });
+    expect(response.ok()).toBeTruthy();
+    return response.json().catch(() => null);
+  }
+
+  private async setUsageMode(token: string, appUsageMode: 'MENTEE' | 'MENTOR') {
+    await this.patchWithAuth(token, `${API_BASE_URL}/auth/me/role/`, {
+      app_usage_mode: appUsageMode,
+    });
+  }
+
+  private async updateProfile(token: string, profile: UserSeed) {
+    await this.patchWithAuth(token, `${API_BASE_URL}/profiles/me/`, {
+      username: profile.username,
+      display_name: profile.displayName,
+      bio: profile.bio,
+      title: profile.title,
+      is_visible: true,
+      show_initials_only: false,
+      skills: profile.skills,
+    });
+  }
+}

--- a/web/e2e/mentor-discovery.spec.ts
+++ b/web/e2e/mentor-discovery.spec.ts
@@ -1,0 +1,172 @@
+import { expect, test } from '@playwright/test';
+import { TestDataApi, type UserSeed } from './api/TestDataApi';
+import { DiscoverPage } from './pages/DiscoverPage';
+import { ProfilePage } from './pages/ProfilePage';
+
+test.describe('AT-007: Mentor Discovery', () => {
+  test('mentee finds mentors by skill, popularity, recency, profile drill-down, and case-insensitive search', async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(90_000);
+
+    const runId = Date.now();
+    const testDataApi = new TestDataApi(request);
+    const discoverPage = new DiscoverPage(page);
+    const profilePage = new ProfilePage(page);
+    const mentors: UserSeed[] = [
+      {
+        email: `atlas.python.${runId}@example.com`,
+        username: `atlas_python_${runId}`,
+        displayName: `Atlas Python ${runId}`,
+        title: 'Python Systems Mentor',
+        bio: 'Helps students learn Python, backend design, and practical debugging habits.',
+        skills: ['Python/Django', 'System Design', 'Testing'],
+      },
+      {
+        email: `bianca.data.${runId}@example.com`,
+        username: `bianca_data_${runId}`,
+        displayName: `Bianca Data ${runId}`,
+        title: 'Data Science Mentor',
+        bio: 'Guides learners through Python notebooks, statistics, and model evaluation.',
+        skills: ['Python/Django', 'Machine Learning', 'Database Design'],
+      },
+      {
+        email: `cem.frontend.${runId}@example.com`,
+        username: `cem_frontend_${runId}`,
+        displayName: `Cem Frontend ${runId}`,
+        title: 'Frontend Mentor',
+        bio: 'Focuses on React, accessibility, interface quality, and TypeScript workflows.',
+        skills: ['React', 'TypeScript', 'JavaScript'],
+      },
+      {
+        email: `darya.django.${runId}@example.com`,
+        username: `darya_django_${runId}`,
+        displayName: `Darya Django ${runId}`,
+        title: 'Django Mentor',
+        bio: 'Works with students on Django APIs, database modeling, and deployment.',
+        skills: ['Python/Django', 'DevOps', 'Database Design'],
+      },
+      {
+        email: `ekin.mobile.${runId}@example.com`,
+        username: `ekin_mobile_${runId}`,
+        displayName: `Ekin Mobile ${runId}`,
+        title: 'Mobile Mentor',
+        bio: 'Mentors mobile teams on React Native, release hygiene, and product iteration.',
+        skills: ['React Native', 'TypeScript', 'System Design'],
+      },
+      {
+        email: `funda.product.${runId}@example.com`,
+        username: `funda_product_${runId}`,
+        displayName: `Funda Product ${runId}`,
+        title: 'Product Mentor',
+        bio: 'Supports students with interview practice, public speaking, and career planning.',
+        skills: ['Public Speaking', 'Interview Practice', 'Communication'],
+      },
+    ];
+
+    await Promise.all(mentors.map((mentor) => testDataApi.seedUser(mentor, 'MENTOR')));
+    const mentee = await testDataApi.seedUser(
+      {
+        email: `mira.mentee.${runId}@example.com`,
+        username: `mira_mentee_${runId}`,
+        displayName: `Mira Mentee ${runId}`,
+        title: 'Computer Science Student',
+        bio: 'Looking for mentors who can help with Python, Django, and reliable software delivery.',
+        skills: ['Python/Django', 'Testing'],
+      },
+      'MENTEE',
+    );
+
+    await testDataApi.loginInBrowser(page, mentee);
+
+    await test.step('Open mentor discovery and verify the default mentor list', async () => {
+      await discoverPage.goto();
+      await discoverPage.expectLoaded();
+
+      for (const mentor of mentors.slice(0, 3)) {
+        await discoverPage.expectMentorVisible(mentor.displayName);
+      }
+    });
+
+    await test.step('Filter by Python/Django and verify only relevant mentors are shown', async () => {
+      await discoverPage.openSkillFilter();
+      await discoverPage.selectSkill('Python/Django');
+      await discoverPage.expectSelectedSkillCount(1);
+
+      await discoverPage.expectMentorVisible(mentors[0].displayName);
+      await discoverPage.expectMentorHidden(mentors[2].displayName);
+
+      const filtered = await testDataApi.fetchMentors('?skill=Python%2FDjango&pageSize=50');
+      expect(filtered.results.length).toBeGreaterThanOrEqual(2);
+      expect(filtered.results.every((mentor) => mentor.skills.includes('Python/Django'))).toBeTruthy();
+    });
+
+    await test.step('Add Machine Learning as a second skill and keep active filter context visible', async () => {
+      await discoverPage.selectSkill('Machine Learning');
+      await discoverPage.expectSelectedSkillCount(2);
+      await discoverPage.expectMentorVisible(mentors[0].displayName);
+
+      const filtered = await testDataApi.fetchMentors('?skill=Python%2FDjango&skill=Machine%20Learning&pageSize=50');
+      expect(filtered.results.length).toBeGreaterThanOrEqual(3);
+      expect(
+        filtered.results.every((mentor) =>
+          mentor.skills.some((skill) => ['Python/Django', 'Machine Learning'].includes(skill)),
+        ),
+      ).toBeTruthy();
+    });
+
+    await test.step('Clear selected skill filters and return to the broad mentor list', async () => {
+      await discoverPage.clearFilters();
+      await discoverPage.expectLoaded();
+      await discoverPage.expectMentorVisible(mentors[2].displayName);
+    });
+
+    await test.step('Verify popular mentor ordering from the Popular Mentors section data source', async () => {
+      await discoverPage.expectPopularSectionVisible();
+
+      const popular = await testDataApi.fetchPopularMentors(6);
+      expect(popular.results.length).toBeGreaterThanOrEqual(2);
+
+      for (let index = 1; index < popular.results.length; index += 1) {
+        const previous = popular.results[index - 1];
+        const current = popular.results[index];
+        const previousRating = Number(previous.average_rating ?? previous.rating ?? 0);
+        const currentRating = Number(current.average_rating ?? current.rating ?? 0);
+        expect(previousRating).toBeGreaterThanOrEqual(currentRating);
+        if (previousRating === currentRating) {
+          expect(previous.total_mentee_count).toBeGreaterThanOrEqual(current.total_mentee_count);
+        }
+      }
+    });
+
+    await test.step('Open a recently joined mentor profile and return to discovery', async () => {
+      await discoverPage.expectRecentlyJoinedSectionVisible();
+
+      const recent = await testDataApi.fetchRecentlyAddedMentors(6);
+      expect(recent.results.length).toBeGreaterThan(0);
+
+      const topRecent = recent.results[0];
+      await discoverPage.openMentorProfile(topRecent.full_name);
+      await profilePage.expectLoaded(topRecent.username, topRecent.full_name);
+
+      await profilePage.goBackToDiscover();
+      await discoverPage.expectRecentlyJoinedSectionVisible();
+    });
+
+    await test.step('Search by skill keyword with different casing', async () => {
+      await discoverPage.search('pYtHoN');
+      await discoverPage.expectMentorHidden(mentors[5].displayName);
+
+      const search = await testDataApi.fetchMentors('?q=pYtHoN&pageSize=50');
+      expect(search.results.length).toBeGreaterThanOrEqual(2);
+      expect(
+        search.results.every((mentor) =>
+          mentor.skills.some((skill) => skill.toLowerCase().includes('python')) ||
+          mentor.full_name.toLowerCase().includes('python') ||
+          mentor.bio.toLowerCase().includes('python'),
+        ),
+      ).toBeTruthy();
+    });
+  });
+});

--- a/web/e2e/pages/DiscoverPage.ts
+++ b/web/e2e/pages/DiscoverPage.ts
@@ -1,0 +1,68 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+export class DiscoverPage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async goto() {
+    await this.page.goto('/discover');
+  }
+
+  async expectLoaded() {
+    await expect(this.page.getByRole('heading', { name: /Discover the Curated Network/i })).toBeVisible();
+    await expect(this.page.getByText('All Mentors')).toBeVisible();
+  }
+
+  mentorCard(mentorName: string): Locator {
+    return this.page.locator('.island-shell', {
+      has: this.page.getByRole('heading', { name: mentorName }),
+    }).first();
+  }
+
+  async expectMentorVisible(mentorName: string) {
+    await expect(this.mentorCard(mentorName)).toBeVisible();
+  }
+
+  async expectMentorHidden(mentorName: string) {
+    await expect(this.mentorCard(mentorName)).toHaveCount(0);
+  }
+
+  async openSkillFilter() {
+    await this.page.getByRole('button', { name: /Filter by skill/i }).click();
+  }
+
+  async selectSkill(skill: string) {
+    await this.page.getByRole('button', { name: new RegExp(`^${escapeRegExp(skill)}$`) }).click();
+  }
+
+  async expectSelectedSkillCount(count: number) {
+    await expect(this.page.getByText(`${count} selected ${count === 1 ? 'skill' : 'skills'}`)).toBeVisible();
+  }
+
+  async clearFilters() {
+    await this.page.getByRole('button', { name: /Clear all/i }).click();
+  }
+
+  async expectPopularSectionVisible() {
+    await expect(this.page.getByRole('heading', { name: 'Popular Mentors' })).toBeVisible();
+  }
+
+  async expectRecentlyJoinedSectionVisible() {
+    await expect(this.page.getByRole('heading', { name: 'Recently Joined' })).toBeVisible();
+  }
+
+  async openMentorProfile(mentorName: string) {
+    await this.mentorCard(mentorName).getByRole('button', { name: /View Profile/i }).click();
+  }
+
+  async search(value: string) {
+    await this.page.getByLabel('Search profiles, skills, or projects...').fill(value);
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/web/e2e/pages/ProfilePage.ts
+++ b/web/e2e/pages/ProfilePage.ts
@@ -1,0 +1,19 @@
+import { expect, type Page } from '@playwright/test';
+
+export class ProfilePage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async expectLoaded(username: string, displayName: string) {
+    await expect(this.page).toHaveURL(new RegExp(`/profiles/${username}`));
+    await expect(this.page.getByRole('heading', { name: displayName })).toBeVisible();
+  }
+
+  async goBackToDiscover() {
+    await this.page.goBack();
+    await expect(this.page).toHaveURL(/\/discover/);
+  }
+}


### PR DESCRIPTION
## Related Issue

Closes #490 

## Description

This PR adds Playwright E2E coverage for the Mentor Discovery acceptance scenario (`AT-007`).

Key changes:
- Adds a POM-based Mentor Discovery E2E test.
- Adds `DiscoverPage` and `ProfilePage` page objects.
- Adds `TestDataApi` for synthetic user setup, browser login, and discovery API verification.
- Covers browsing mentors, skill filtering, multi-skill filtering, clearing filters, popular mentor ordering, recently joined profile drill-down, and case-insensitive search.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [x] CI/CD or configuration

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code

## Notes

This branch is stacked on top of the Playwright setup branch. The test is web-only and follows the POM direction used by the authentication E2E work.
