### PR TITLE
feat: Community Posts Endpoints

### DIFF
--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -726,6 +726,18 @@ class AdminUserUpdateAPIView(APIView):
         )
 
     # Support PUT as well for backward compatibility with E2E tests
+    @extend_schema(
+        request=AdminUserUpdateSerializer,
+        responses={
+            200: UserResponseSerializer,
+            400: OpenApiResponse(description="Validation error."),
+            401: OpenApiResponse(description="Authentication required."),
+            403: OpenApiResponse(description="Admin access required."),
+            404: OpenApiResponse(description="User not found."),
+        },
+        description="Admin only: update a user's ban status.",
+        tags=["Admin"],
+    )
     def put(self, request: Request, user_id: str) -> Response:
         return self.patch(request, user_id)
 

--- a/backend/profiles/serializers.py
+++ b/backend/profiles/serializers.py
@@ -668,7 +668,12 @@ class ProfilePostListQueryParamsSerializer(serializers.Serializer):
 
 
 class ProfilePostSerializer(serializers.Serializer):
-    """Read serializer for profile feed items (PrP + visible MCTE)."""
+    """Read serializer for profile feed items (PrP, visible MCTE, and visible CoP).
+
+    ``community_id`` is populated only for CoP posts and is ``null`` for PrP and MCTE.
+    Clients can use it to navigate to ``/api/profiles/tags/{community_id}/`` or link
+    to the community feed at ``/api/profiles/tags/{community_id}/posts/``.
+    """
 
     id = serializers.UUIDField(read_only=True)
     source_id = serializers.CharField(read_only=True)

--- a/backend/profiles/serializers.py
+++ b/backend/profiles/serializers.py
@@ -589,7 +589,7 @@ class PublicMentorProfileSearchListResponseSerializer(serializers.Serializer):
 
 
 _PROFILE_POST_EVENT_TYPE_CHOICES = ["achievement", "social", "progress"]
-_PROFILE_POST_CATEGORY_CHOICES = ["PrP", "MCTE"]
+_PROFILE_POST_CATEGORY_CHOICES = ["PrP", "MCTE", "CoP"]
 
 
 class ProfilePostAuthorSerializer(serializers.ModelSerializer):

--- a/backend/profiles/serializers.py
+++ b/backend/profiles/serializers.py
@@ -11,9 +11,8 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from core.utils.image import resize_image
-from core.utils.validators import validate_file_size, validate_image_content_type
-
 from core.utils.timezone import get_project_timezone, to_local_time
+from core.utils.validators import validate_file_size, validate_image_content_type
 from mentorship.models import MeetingSession
 
 from .models import AvailabilitySlot, CommunityTag, Profile, Skill
@@ -35,6 +34,7 @@ def resolve_picture_url(profile: Profile) -> str:
         except ValueError:
             pass
     return profile.picture_url or ""
+
 
 @extend_schema_field(
     {
@@ -133,6 +133,7 @@ class PostMediaUploadSerializer(serializers.Serializer):
     def validate_file(self, file):
         """Validate content-type (image or PDF) and enforce a size limit."""
         from django.conf import settings
+
         from core.utils.validators import validate_media_content_type
 
         validate_media_content_type(file)
@@ -147,6 +148,7 @@ class PostMediaUploadSerializer(serializers.Serializer):
         """Resize (if image) and persist the file, returning the public URL."""
         from django.conf import settings
         from django.core.files.storage import default_storage
+
         from core.utils.validators import IMAGE_CONTENT_TYPES
 
         uploaded = self.validated_data["file"]
@@ -162,14 +164,12 @@ class PostMediaUploadSerializer(serializers.Serializer):
             processed = uploaded
 
         import uuid as _uuid
+
         from django.utils import timezone as _tz
 
         now = _tz.now()
         filename = f"{_uuid.uuid4().hex}_{processed.name}"
-        path = (
-            f"post_media/{now.year}/{now.month:02d}"
-            f"/{now.day:02d}/{filename}"
-        )
+        path = f"post_media/{now.year}/{now.month:02d}" f"/{now.day:02d}/{filename}"
         saved_path = default_storage.save(path, processed)
         return default_storage.url(saved_path)
 
@@ -680,6 +680,7 @@ class ProfilePostSerializer(serializers.Serializer):
     created_at = serializers.DateTimeField(read_only=True)
     last_edited = serializers.DateTimeField(read_only=True, allow_null=True)
     show_on_profile = serializers.BooleanField(read_only=True)
+    community_id = serializers.UUIDField(read_only=True, allow_null=True)
     actor_role = serializers.CharField(read_only=True)
     author = ProfilePostAuthorSerializer(read_only=True)
 

--- a/backend/profiles/serializers.py
+++ b/backend/profiles/serializers.py
@@ -799,3 +799,90 @@ class CommunityTagListResponseSerializer(serializers.Serializer):
     page = serializers.IntegerField()
     pageSize = serializers.IntegerField()
     results = CommunityTagListSerializer(many=True)
+
+
+# ---------------------------------------------------------------------------
+# Community Posts (CoP)
+# ---------------------------------------------------------------------------
+
+
+class CoPCreateSerializer(serializers.Serializer):
+    """Write serializer for creating a community post (CoP)."""
+
+    event_type = serializers.ChoiceField(choices=_PROFILE_POST_EVENT_TYPE_CHOICES)
+    content = serializers.CharField(required=True, max_length=2000)
+    media_url = serializers.URLField(required=False, allow_null=True, default=None)
+    show_on_profile = serializers.BooleanField(required=False, default=False)
+    timestamp = serializers.DateTimeField(required=False, allow_null=True, default=None)
+
+    def to_internal_value(self, data: Any) -> dict:
+        """Normalize empty timestamp values to null so fallback logic can be applied."""
+        if isinstance(data, dict) and data.get("timestamp") == "":
+            data = {**data, "timestamp": None}
+        return super().to_internal_value(data)
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        """Reject timestamps more than 1 day in the future when provided."""
+        timestamp = attrs.get("timestamp")
+        if timestamp is not None and timestamp > timezone.now() + timedelta(days=1):
+            raise serializers.ValidationError(
+                {"timestamp": "Timestamp cannot be more than 1 day in the future."}
+            )
+        return attrs
+
+
+class CoPUpdateSerializer(serializers.Serializer):
+    """Write serializer for partially updating a community post."""
+
+    content = serializers.CharField(required=False, allow_blank=True, max_length=2000)
+    event_type = serializers.ChoiceField(choices=_PROFILE_POST_EVENT_TYPE_CHOICES, required=False)
+    media_url = serializers.URLField(required=False, allow_null=True)
+    show_on_profile = serializers.BooleanField(required=False)
+
+    def validate(self, attrs: dict) -> dict:
+        """Require at least one editable field to be provided."""
+        if not attrs:
+            raise serializers.ValidationError(
+                "At least one of 'content', 'event_type', 'media_url', or "
+                "'show_on_profile' must be provided."
+            )
+        return attrs
+
+
+class CommunityPostListQueryParamsSerializer(serializers.Serializer):
+    """Validate query parameters for community post listing endpoint."""
+
+    event_type = serializers.ChoiceField(
+        choices=_PROFILE_POST_EVENT_TYPE_CHOICES,
+        required=False,
+        allow_null=True,
+        default=None,
+    )
+    offset = serializers.IntegerField(required=False, min_value=0, default=0)
+    limit = serializers.IntegerField(required=False, min_value=1, max_value=200, default=50)
+
+
+class CommunityPostSerializer(serializers.Serializer):
+    """Read serializer for community feed items (CoP)."""
+
+    id = serializers.UUIDField(read_only=True)
+    source_id = serializers.CharField(read_only=True)
+    category = serializers.CharField(read_only=True)
+    event_type = serializers.CharField(read_only=True)
+    content = serializers.CharField(read_only=True)
+    media_url = serializers.URLField(read_only=True, allow_null=True)
+    timestamp = serializers.DateTimeField(read_only=True)
+    created_at = serializers.DateTimeField(read_only=True)
+    last_edited = serializers.DateTimeField(read_only=True, allow_null=True)
+    show_on_profile = serializers.BooleanField(read_only=True)
+    community_id = serializers.UUIDField(read_only=True)
+    author = ProfilePostAuthorSerializer(read_only=True)
+
+
+class CommunityPostFeedSerializer(serializers.Serializer):
+    """Paginated response wrapper for community posts feed."""
+
+    count = serializers.IntegerField(read_only=True)
+    offset = serializers.IntegerField(read_only=True)
+    limit = serializers.IntegerField(read_only=True)
+    results = CommunityPostSerializer(many=True, read_only=True)

--- a/backend/profiles/services.py
+++ b/backend/profiles/services.py
@@ -41,6 +41,10 @@ class InvalidPrPEventTypeError(Exception):
     """Raised when an unsupported event_type is supplied for a profile post."""
 
 
+class InvalidCoPEventTypeError(Exception):
+    """Raised when an unsupported event_type is supplied for a community post."""
+
+
 def book_availability_slot(*, profile: Profile, slot_id, actor) -> AvailabilitySlot:
     """Book one slot with row-level locking to prevent race conditions."""
     with transaction.atomic():
@@ -232,5 +236,132 @@ def edit_prp_event(
 
 def soft_delete_prp_event(*, event: Any) -> None:
     """Soft-delete a profile post by setting is_deleted=True."""
+    event.is_deleted = True
+    event.save(update_fields=["is_deleted"])
+
+
+def list_community_feed_events(
+    *,
+    community_tag: Any,
+    offset: int,
+    limit: int,
+    event_type: str | None = None,
+) -> dict[str, Any]:
+    """Return paginated community feed events for a community tag.
+
+    Feed includes all non-deleted CoP events scoped to the given community_id,
+    ordered newest-first by created_at then effective last update tie-breaker.
+    """
+    from timeline.models import TimelineEvent
+
+    queryset = (
+        TimelineEvent.objects.filter(
+            community_id=community_tag.id,
+            category=TimelineEvent.Category.COP,
+            is_deleted=False,
+        )
+        .select_related("author")
+        .annotate(effective_last_update=Coalesce("last_edited", "created_at"))
+        .order_by("-created_at", "-effective_last_update", "-source_id")
+    )
+
+    if event_type is not None:
+        queryset = queryset.filter(event_type=event_type)
+
+    total_count = queryset.count()
+    events = list(queryset[offset : offset + limit])
+
+    return {
+        "count": total_count,
+        "offset": offset,
+        "limit": limit,
+        "results": events,
+    }
+
+
+def create_cop_event(
+    *,
+    author_profile: Profile,
+    community_tag: Any,
+    event_type: str,
+    content: str = "",
+    media_url: str | None = None,
+    show_on_profile: bool = False,
+    timestamp: Any | None = None,
+) -> Any:
+    """Create and persist a community post (CoP).
+
+    If timestamp is omitted, event timestamp is aligned with created_at.
+    """
+    from timeline.models import TimelineEvent
+
+    if event_type not in TimelineEvent.MCTEEventType.values:
+        raise InvalidCoPEventTypeError(
+            f"Invalid CoP event_type: '{event_type}'. "
+            f"Must be one of {TimelineEvent.MCTEEventType.values}."
+        )
+
+    event = TimelineEvent.objects.create(
+        source_id=f"cop:{uuid.uuid4()}",
+        category=TimelineEvent.Category.COP,
+        event_type=event_type,
+        author=author_profile,
+        community_id=community_tag.id,
+        content=content,
+        media_url=media_url,
+        show_on_profile=show_on_profile,
+        timestamp=timestamp if timestamp is not None else timezone.now(),
+    )
+
+    if timestamp is None:
+        event.timestamp = event.created_at
+        event.save(update_fields=["timestamp"])
+
+    return event
+
+
+def edit_cop_event(
+    *,
+    event: Any,
+    content: str | None = None,
+    event_type: str | None = None,
+    media_url: str | None = None,
+    show_on_profile: bool | None = None,
+    update_media_url: bool = False,
+) -> Any:
+    """Partially update a community post and set last_edited."""
+    from timeline.models import TimelineEvent
+
+    if event_type is not None and event_type not in TimelineEvent.MCTEEventType.values:
+        raise InvalidCoPEventTypeError(
+            f"Invalid CoP event_type: '{event_type}'. "
+            f"Must be one of {TimelineEvent.MCTEEventType.values}."
+        )
+
+    update_fields: list[str] = ["last_edited"]
+
+    if content is not None:
+        event.content = content
+        update_fields.append("content")
+
+    if event_type is not None:
+        event.event_type = event_type
+        update_fields.append("event_type")
+
+    if update_media_url:
+        event.media_url = media_url
+        update_fields.append("media_url")
+
+    if show_on_profile is not None:
+        event.show_on_profile = show_on_profile
+        update_fields.append("show_on_profile")
+
+    event.last_edited = timezone.now()
+    event.save(update_fields=update_fields)
+    return event
+
+
+def soft_delete_cop_event(*, event: Any) -> None:
+    """Soft-delete a community post by setting is_deleted=True."""
     event.is_deleted = True
     event.save(update_fields=["is_deleted"])

--- a/backend/profiles/services.py
+++ b/backend/profiles/services.py
@@ -123,6 +123,7 @@ def list_profile_feed_events(
     Feed includes:
     - Profile posts (PrP) authored by the profile.
     - MCTE events authored by the profile where show_on_profile=True.
+    - CoP events authored by the profile where show_on_profile=True.
     """
     from timeline.models import TimelineEvent
 
@@ -131,6 +132,7 @@ def list_profile_feed_events(
         .filter(
             Q(category=TimelineEvent.Category.PRP)
             | Q(category=TimelineEvent.Category.MCTE, show_on_profile=True)
+            | Q(category=TimelineEvent.Category.COP, show_on_profile=True)
         )
         .select_related("author")
         .annotate(effective_last_update=Coalesce("last_edited", "created_at"))

--- a/backend/profiles/tests.py
+++ b/backend/profiles/tests.py
@@ -1006,6 +1006,324 @@ class ProfilePostsAPITests(TestCase):
         )
 
 
+class CommunityTagPostsAPITests(TestCase):
+    """Integration tests for community tag posts endpoints (CoP)."""
+
+    def setUp(self) -> None:
+        self.api_client: Any = APIClient()
+
+        self.member_user = User.objects.create_user(
+            email="cop-member@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTOR,
+        )
+        self.member_profile = Profile.objects.create(
+            user=self.member_user,
+            username="cop_member",
+            display_name="CoP Member",
+        )
+
+        self.outsider_user = User.objects.create_user(
+            email="cop-outsider@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTEE,
+        )
+        self.outsider_profile = Profile.objects.create(
+            user=self.outsider_user,
+            username="cop_outsider",
+            display_name="CoP Outsider",
+        )
+
+        self.tag = CommunityTag.objects.create(
+            name="Test Community",
+            description="A test community",
+            created_by=self.member_profile,
+        )
+        CommunityTagMembership.objects.create(
+            profile=self.member_profile,
+            tag=self.tag,
+        )
+
+        self.member_token = str(RefreshToken.for_user(self.member_user).access_token)
+        self.outsider_token = str(RefreshToken.for_user(self.outsider_user).access_token)
+
+        self.list_create_url = f"/api/profiles/tags/{self.tag.id}/posts/"
+
+    def _auth_member(self) -> None:
+        self.api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.member_token}")
+
+    def _auth_outsider(self) -> None:
+        self.api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.outsider_token}")
+
+    def _detail_url(self, event_id: str) -> str:
+        return f"/api/profiles/tags/{self.tag.id}/posts/{event_id}/"
+
+    # ------------------------------------------------------------------ list
+
+    def test_list_community_posts_unauthenticated_returns_401(self) -> None:
+        response = self.api_client.get(self.list_create_url)
+        self.assertEqual(response.status_code, 401)
+
+    def test_list_community_posts_empty_tag_returns_empty_feed(self) -> None:
+        self._auth_member()
+        response = self.api_client.get(self.list_create_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 0)
+        self.assertEqual(response.data["results"], [])
+
+    def test_list_community_posts_returns_cop_events(self) -> None:
+        from timeline.models import TimelineEvent
+
+        event = TimelineEvent.objects.create(
+            source_id=f"cop:{uuid.uuid4()}",
+            category=TimelineEvent.Category.COP,
+            event_type="social",
+            author=self.member_profile,
+            community_id=self.tag.id,
+            content="Hello community",
+            timestamp=timezone.now() - timedelta(minutes=5),
+        )
+
+        self._auth_member()
+        response = self.api_client.get(self.list_create_url)
+
+        self.assertEqual(response.status_code, 200)
+        source_ids = {item["source_id"] for item in response.data["results"]}
+        self.assertIn(event.source_id, source_ids)
+        result = next(i for i in response.data["results"] if i["source_id"] == event.source_id)
+        self.assertEqual(result["category"], "CoP")
+        self.assertIn("community_id", result)
+
+    def test_list_community_posts_excludes_deleted(self) -> None:
+        from timeline.models import TimelineEvent
+
+        deleted = TimelineEvent.objects.create(
+            source_id=f"cop:{uuid.uuid4()}",
+            category=TimelineEvent.Category.COP,
+            event_type="social",
+            author=self.member_profile,
+            community_id=self.tag.id,
+            content="Deleted post",
+            is_deleted=True,
+            timestamp=timezone.now() - timedelta(minutes=5),
+        )
+
+        self._auth_member()
+        response = self.api_client.get(self.list_create_url)
+
+        self.assertEqual(response.status_code, 200)
+        source_ids = {item["source_id"] for item in response.data["results"]}
+        self.assertNotIn(deleted.source_id, source_ids)
+
+    def test_list_community_posts_filter_by_event_type(self) -> None:
+        from timeline.models import TimelineEvent
+
+        social = TimelineEvent.objects.create(
+            source_id=f"cop:{uuid.uuid4()}",
+            category=TimelineEvent.Category.COP,
+            event_type="social",
+            author=self.member_profile,
+            community_id=self.tag.id,
+            content="Social post",
+            timestamp=timezone.now() - timedelta(minutes=10),
+        )
+        TimelineEvent.objects.create(
+            source_id=f"cop:{uuid.uuid4()}",
+            category=TimelineEvent.Category.COP,
+            event_type="achievement",
+            author=self.member_profile,
+            community_id=self.tag.id,
+            content="Achievement post",
+            timestamp=timezone.now() - timedelta(minutes=5),
+        )
+
+        self._auth_member()
+        response = self.api_client.get(self.list_create_url + "?event_type=social")
+
+        self.assertEqual(response.status_code, 200)
+        results = response.data["results"]
+        self.assertTrue(all(item["event_type"] == "social" for item in results))
+        self.assertIn(social.source_id, {item["source_id"] for item in results})
+
+    def test_list_community_posts_tag_not_found_returns_404(self) -> None:
+        self._auth_member()
+        response = self.api_client.get(f"/api/profiles/tags/{uuid.uuid4()}/posts/")
+        self.assertEqual(response.status_code, 404)
+
+    # ------------------------------------------------------------------ create
+
+    def test_create_community_post_by_member_returns_201(self) -> None:
+        self._auth_member()
+        response = self.api_client.post(
+            self.list_create_url,
+            {"event_type": "achievement", "content": "We did it!"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data["category"], "CoP")
+        self.assertEqual(response.data["event_type"], "achievement")
+        self.assertEqual(response.data["content"], "We did it!")
+        self.assertFalse(response.data["show_on_profile"])
+        self.assertIsNotNone(response.data["community_id"])
+
+    def test_create_community_post_with_show_on_profile_true(self) -> None:
+        self._auth_member()
+        response = self.api_client.post(
+            self.list_create_url,
+            {"event_type": "social", "content": "Shared!", "show_on_profile": True},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(response.data["show_on_profile"])
+
+    def test_create_community_post_by_non_member_returns_403(self) -> None:
+        self._auth_outsider()
+        response = self.api_client.post(
+            self.list_create_url,
+            {"event_type": "social", "content": "Uninvited post"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_create_community_post_unauthenticated_returns_401(self) -> None:
+        response = self.api_client.post(
+            self.list_create_url,
+            {"event_type": "social", "content": "No auth"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_create_community_post_missing_content_returns_400(self) -> None:
+        self._auth_member()
+        response = self.api_client.post(
+            self.list_create_url,
+            {"event_type": "social"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_create_community_post_invalid_event_type_returns_400(self) -> None:
+        self._auth_member()
+        response = self.api_client.post(
+            self.list_create_url,
+            {"event_type": "invalid_type", "content": "Bad post"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_create_community_post_far_future_timestamp_returns_400(self) -> None:
+        self._auth_member()
+        future_ts = (timezone.now() + timedelta(days=5)).isoformat()
+        response = self.api_client.post(
+            self.list_create_url,
+            {"event_type": "progress", "content": "Future post", "timestamp": future_ts},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_create_community_post_appears_in_community_feed(self) -> None:
+        self._auth_member()
+        create_response = self.api_client.post(
+            self.list_create_url,
+            {"event_type": "social", "content": "Feed entry"},
+            format="json",
+        )
+        self.assertEqual(create_response.status_code, 201)
+        source_id = create_response.data["source_id"]
+
+        list_response = self.api_client.get(self.list_create_url)
+        self.assertEqual(list_response.status_code, 200)
+        feed_ids = {item["source_id"] for item in list_response.data["results"]}
+        self.assertIn(source_id, feed_ids)
+
+    # ------------------------------------------------------------------ patch
+
+    def test_patch_community_post_by_author_returns_200(self) -> None:
+        self._auth_member()
+        create_response = self.api_client.post(
+            self.list_create_url,
+            {"event_type": "social", "content": "Original"},
+            format="json",
+        )
+        event_id = create_response.data["id"]
+
+        patch_response = self.api_client.patch(
+            self._detail_url(event_id),
+            {"content": "Edited", "event_type": "progress", "show_on_profile": True},
+            format="json",
+        )
+        self.assertEqual(patch_response.status_code, 200)
+        self.assertEqual(patch_response.data["content"], "Edited")
+        self.assertEqual(patch_response.data["event_type"], "progress")
+        self.assertTrue(patch_response.data["show_on_profile"])
+        self.assertIsNotNone(patch_response.data["last_edited"])
+
+    def test_patch_community_post_by_non_author_returns_404(self) -> None:
+        self._auth_member()
+        create_response = self.api_client.post(
+            self.list_create_url,
+            {"event_type": "social", "content": "Original"},
+            format="json",
+        )
+        event_id = create_response.data["id"]
+
+        self._auth_outsider()
+        response = self.api_client.patch(
+            self._detail_url(event_id),
+            {"content": "Hacked"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_patch_community_post_empty_body_returns_400(self) -> None:
+        self._auth_member()
+        create_response = self.api_client.post(
+            self.list_create_url,
+            {"event_type": "social", "content": "Original"},
+            format="json",
+        )
+        event_id = create_response.data["id"]
+
+        patch_response = self.api_client.patch(
+            self._detail_url(event_id),
+            {},
+            format="json",
+        )
+        self.assertEqual(patch_response.status_code, 400)
+
+    # ------------------------------------------------------------------ delete
+
+    def test_delete_community_post_by_author_returns_204(self) -> None:
+        self._auth_member()
+        create_response = self.api_client.post(
+            self.list_create_url,
+            {"event_type": "social", "content": "Delete me"},
+            format="json",
+        )
+        event_id = create_response.data["id"]
+        source_id = create_response.data["source_id"]
+
+        delete_response = self.api_client.delete(self._detail_url(event_id))
+        self.assertEqual(delete_response.status_code, 204)
+
+        list_response = self.api_client.get(self.list_create_url)
+        feed_ids = {item["source_id"] for item in list_response.data["results"]}
+        self.assertNotIn(source_id, feed_ids)
+
+    def test_delete_community_post_by_non_author_returns_404(self) -> None:
+        self._auth_member()
+        create_response = self.api_client.post(
+            self.list_create_url,
+            {"event_type": "social", "content": "Mine"},
+            format="json",
+        )
+        event_id = create_response.data["id"]
+
+        self._auth_outsider()
+        response = self.api_client.delete(self._detail_url(event_id))
+        self.assertEqual(response.status_code, 404)
+
+
 class SkillListAPIViewTests(TestCase):
     """Tests for GET /api/profiles/skills/ endpoint."""
 

--- a/backend/profiles/tests.py
+++ b/backend/profiles/tests.py
@@ -844,6 +844,43 @@ class ProfilePostsAPITests(TestCase):
         self.assertIn(visible_cop.source_id, source_ids)
         self.assertNotIn(prp_event.source_id, source_ids)
 
+    def test_profile_feed_cop_post_includes_community_id(self) -> None:
+        visible_cop = self._create_cop_for_owner(
+            content="Community post with tag link",
+            show_on_profile=True,
+            timestamp=timezone.now() - timedelta(minutes=5),
+        )
+
+        self._auth_viewer()
+        response = self.api_client.get(self.owner_feed_url + "?category=CoP")
+
+        self.assertEqual(response.status_code, 200)
+        cop_result = next(
+            item for item in response.data["results"]
+            if item["source_id"] == visible_cop.source_id
+        )
+        self.assertIn("community_id", cop_result)
+        self.assertEqual(str(cop_result["community_id"]), str(visible_cop.community_id))
+
+    def test_profile_feed_prp_post_has_null_community_id(self) -> None:
+        prp_event = create_prp_event(
+            author_profile=self.owner_profile,
+            event_type="achievement",
+            content="PrP post",
+            timestamp=timezone.now() - timedelta(minutes=5),
+        )
+
+        self._auth_viewer()
+        response = self.api_client.get(self.owner_feed_url + "?category=PrP")
+
+        self.assertEqual(response.status_code, 200)
+        prp_result = next(
+            item for item in response.data["results"]
+            if item["source_id"] == prp_event.source_id
+        )
+        self.assertIn("community_id", prp_result)
+        self.assertIsNone(prp_result["community_id"])
+
     def test_list_profile_posts_filter_by_event_type_returns_matching_items(self) -> None:
         progress_prp = create_prp_event(
             author_profile=self.owner_profile,

--- a/backend/profiles/tests.py
+++ b/backend/profiles/tests.py
@@ -628,6 +628,25 @@ class ProfilePostsAPITests(TestCase):
         )
         return ensure_match_and_initial_session(mentorship_request=request_obj)
 
+    def _create_cop_for_owner(
+        self,
+        *,
+        content: str,
+        show_on_profile: bool,
+        timestamp: datetime | None = None,
+    ) -> TimelineEvent:
+        effective_timestamp = timestamp if timestamp is not None else timezone.now()
+        return TimelineEvent.objects.create(
+            source_id=f"cop:{uuid.uuid4()}",
+            category=TimelineEvent.Category.COP,
+            event_type="social",
+            author=self.owner_profile,
+            community_id=uuid.uuid4(),
+            show_on_profile=show_on_profile,
+            content=content,
+            timestamp=effective_timestamp,
+        )
+
     def test_create_prp_missing_timestamp_returns_201(self) -> None:
         self._auth_owner()
 
@@ -775,6 +794,55 @@ class ProfilePostsAPITests(TestCase):
         source_ids = {item["source_id"] for item in results}
         self.assertIn(prp_event.source_id, source_ids)
         self.assertNotIn(visible_mcte.source_id, source_ids)
+
+    def test_list_profile_posts_includes_visible_cop_and_excludes_hidden_cop(self) -> None:
+        visible_cop = self._create_cop_for_owner(
+            content="Visible community post",
+            show_on_profile=True,
+            timestamp=timezone.now() - timedelta(minutes=20),
+        )
+        hidden_cop = self._create_cop_for_owner(
+            content="Hidden community post",
+            show_on_profile=False,
+            timestamp=timezone.now() - timedelta(minutes=10),
+        )
+
+        self._auth_viewer()
+        response = self.api_client.get(self.owner_feed_url)
+
+        self.assertEqual(response.status_code, 200)
+        source_ids = {item["source_id"] for item in response.data["results"]}
+        self.assertIn(visible_cop.source_id, source_ids)
+        self.assertNotIn(hidden_cop.source_id, source_ids)
+        self.assertTrue(any(item["category"] == "CoP" for item in response.data["results"]))
+
+    def test_list_profile_posts_filter_by_category_cop_returns_matching_items(self) -> None:
+        visible_cop = self._create_cop_for_owner(
+            content="Visible community post",
+            show_on_profile=True,
+            timestamp=timezone.now() - timedelta(minutes=20),
+        )
+        self._create_cop_for_owner(
+            content="Hidden community post",
+            show_on_profile=False,
+            timestamp=timezone.now() - timedelta(minutes=10),
+        )
+        prp_event = create_prp_event(
+            author_profile=self.owner_profile,
+            event_type="achievement",
+            content="PrP entry",
+            timestamp=timezone.now() - timedelta(hours=1),
+        )
+
+        self._auth_viewer()
+        response = self.api_client.get(self.owner_feed_url + "?category=CoP")
+
+        self.assertEqual(response.status_code, 200)
+        results = response.data["results"]
+        self.assertTrue(all(item["category"] == "CoP" for item in results))
+        source_ids = {item["source_id"] for item in results}
+        self.assertIn(visible_cop.source_id, source_ids)
+        self.assertNotIn(prp_event.source_id, source_ids)
 
     def test_list_profile_posts_filter_by_event_type_returns_matching_items(self) -> None:
         progress_prp = create_prp_event(

--- a/backend/profiles/tests.py
+++ b/backend/profiles/tests.py
@@ -856,8 +856,7 @@ class ProfilePostsAPITests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         cop_result = next(
-            item for item in response.data["results"]
-            if item["source_id"] == visible_cop.source_id
+            item for item in response.data["results"] if item["source_id"] == visible_cop.source_id
         )
         self.assertIn("community_id", cop_result)
         self.assertEqual(str(cop_result["community_id"]), str(visible_cop.community_id))
@@ -875,8 +874,7 @@ class ProfilePostsAPITests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         prp_result = next(
-            item for item in response.data["results"]
-            if item["source_id"] == prp_event.source_id
+            item for item in response.data["results"] if item["source_id"] == prp_event.source_id
         )
         self.assertIn("community_id", prp_result)
         self.assertIsNone(prp_result["community_id"])
@@ -4423,14 +4421,20 @@ class ProfilePictureUploadTests(TestCase):
     def _make_image_file(self, name: str = "test.jpg", size: tuple = (100, 100), fmt: str = "JPEG"):
         """Create an in-memory image file for testing."""
         from io import BytesIO
-        from PIL import Image as PILImage
+
         from django.core.files.uploadedfile import SimpleUploadedFile
+        from PIL import Image as PILImage
 
         img = PILImage.new("RGB", size, color="red")
         buf = BytesIO()
         img.save(buf, format=fmt)
         buf.seek(0)
-        content_type = {"JPEG": "image/jpeg", "PNG": "image/png", "GIF": "image/gif", "WEBP": "image/webp"}.get(fmt, "image/jpeg")
+        content_type = {
+            "JPEG": "image/jpeg",
+            "PNG": "image/png",
+            "GIF": "image/gif",
+            "WEBP": "image/webp",
+        }.get(fmt, "image/jpeg")
         return SimpleUploadedFile(name=name, content=buf.read(), content_type=content_type)
 
     def test_upload_valid_jpeg_returns_200(self) -> None:
@@ -4448,8 +4452,9 @@ class ProfilePictureUploadTests(TestCase):
     def test_upload_oversized_file_returns_400(self) -> None:
         """Files exceeding 5 MB should be rejected."""
         from io import BytesIO
-        from PIL import Image as PILImage
+
         from django.core.files.uploadedfile import SimpleUploadedFile
+        from PIL import Image as PILImage
 
         # Create a large image (uncompressed)
         img = PILImage.new("RGB", (4000, 4000), color="blue")
@@ -4503,7 +4508,9 @@ class ProfilePictureUploadTests(TestCase):
         self.assertEqual(response.status_code, 200)
 
         # The returned URL should NOT be the Google one
-        self.assertNotEqual(response.data["picture_url"], "https://lh3.googleusercontent.com/photo.jpg")
+        self.assertNotEqual(
+            response.data["picture_url"], "https://lh3.googleusercontent.com/photo.jpg"
+        )
 
     def test_after_delete_falls_back_to_oauth_url(self) -> None:
         """After deleting the uploaded picture, picture_url falls back to OAuth."""
@@ -4515,7 +4522,9 @@ class ProfilePictureUploadTests(TestCase):
 
         response = self.client.delete(self.PICTURE_URL)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["picture_url"], "https://lh3.googleusercontent.com/photo.jpg")
+        self.assertEqual(
+            response.data["picture_url"], "https://lh3.googleusercontent.com/photo.jpg"
+        )
 
     def test_unauthenticated_upload_returns_401(self) -> None:
         self.client.credentials()
@@ -4569,8 +4578,9 @@ class PostMediaUploadTests(TestCase):
     def _make_image_file(self, name: str = "post.jpg"):
         """Create an in-memory image file for testing."""
         from io import BytesIO
-        from PIL import Image as PILImage
+
         from django.core.files.uploadedfile import SimpleUploadedFile
+        from PIL import Image as PILImage
 
         img = PILImage.new("RGB", (200, 200), color="green")
         buf = BytesIO()
@@ -4596,7 +4606,9 @@ class PostMediaUploadTests(TestCase):
     def test_upload_unsupported_type_returns_400(self) -> None:
         from django.core.files.uploadedfile import SimpleUploadedFile
 
-        file = SimpleUploadedFile("script.exe", b"MZ\x90\x00", content_type="application/x-msdownload")
+        file = SimpleUploadedFile(
+            "script.exe", b"MZ\x90\x00", content_type="application/x-msdownload"
+        )
         response = self.client.post(self.UPLOAD_URL, {"file": file}, format="multipart")
         self.assertEqual(response.status_code, 400)
 

--- a/backend/profiles/urls.py
+++ b/backend/profiles/urls.py
@@ -10,6 +10,8 @@ from .views import (
     CommunityTagLeaveAPIView,
     CommunityTagListCreateAPIView,
     CommunityTagMembersListAPIView,
+    CommunityTagPostDetailAPIView,
+    CommunityTagPostsListCreateAPIView,
     MentorPublicAverageRatingAPIView,
     MyAvailabilitySlotDetailAPIView,
     MyAvailabilitySlotListCreateAPIView,
@@ -102,6 +104,16 @@ urlpatterns = [
         "tags/<uuid:tag_id>/members/",
         CommunityTagMembersListAPIView.as_view(),
         name="community-tag-members",
+    ),
+    path(
+        "tags/<uuid:tag_id>/posts/",
+        CommunityTagPostsListCreateAPIView.as_view(),
+        name="community-tag-posts-list-create",
+    ),
+    path(
+        "tags/<uuid:tag_id>/posts/<uuid:event_id>/",
+        CommunityTagPostDetailAPIView.as_view(),
+        name="community-tag-posts-detail",
     ),
     path("me/tags/", MyTagsListAPIView.as_view(), name="my-tags-list"),
     # Catch-all username route (must stay last)

--- a/backend/profiles/views.py
+++ b/backend/profiles/views.py
@@ -255,13 +255,16 @@ class ProfilePostsListAPIView(ProfileLookupMixin, APIView):
             404: OpenApiResponse(description="Profile not found."),
         },
         description=(
-            "Return profile posts for a username. Includes both PrP posts authored by the "
+            "Return profile posts for a username. Includes PrP posts authored by the "
             "profile, MCTE events authored by the profile where `show_on_profile=true`, and "
             "CoP events authored by the profile where `show_on_profile=true`. "
-            "If profile is private, only the owner can access this feed. "
+            "If the profile is private, only the owner can access this feed. "
             "Supports optional filtering by `category` and `event_type`. "
             "Results are ordered newest-first by action metadata: `created_at`, then "
-            "`last_edited` as a tie-breaker."
+            "`last_edited` as a tie-breaker. "
+            "Each result includes a `community_id` field: populated with the community tag "
+            "UUID for CoP posts (use it to link to `GET /api/profiles/tags/{community_id}/` "
+            "or `GET /api/profiles/tags/{community_id}/posts/`), and `null` for PrP and MCTE."
         ),
         tags=["Profiles"],
     )

--- a/backend/profiles/views.py
+++ b/backend/profiles/views.py
@@ -212,7 +212,7 @@ class ProfilePostsListAPIView(ProfileLookupMixin, APIView):
                 location=OpenApiParameter.QUERY,
                 required=False,
                 type=OpenApiTypes.STR,
-                enum=["PrP", "MCTE"],
+                enum=["PrP", "MCTE", "CoP"],
                 description="Filter by event category.",
             ),
             OpenApiParameter(
@@ -246,7 +246,8 @@ class ProfilePostsListAPIView(ProfileLookupMixin, APIView):
         },
         description=(
             "Return profile posts for a username. Includes both PrP posts authored by the "
-            "profile and MCTE events authored by the profile where `show_on_profile=true`. "
+            "profile, MCTE events authored by the profile where `show_on_profile=true`, and "
+            "CoP events authored by the profile where `show_on_profile=true`. "
             "If profile is private, only the owner can access this feed. "
             "Supports optional filtering by `category` and `event_type`. "
             "Results are ordered newest-first by action metadata: `created_at`, then "
@@ -308,7 +309,6 @@ class MyProfilePostsCollectionAPIView(ProfileLookupMixin, APIView):
         serializer = PrPCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         validated = serializer.validated_data
-
         try:
             event = create_prp_event(
                 author_profile=profile,

--- a/backend/profiles/views.py
+++ b/backend/profiles/views.py
@@ -26,12 +26,17 @@ from .models import AvailabilitySlot, CommunityTag, CommunityTagMembership, Prof
 from .serializers import (
     AvailabilitySlotSerializer,
     AvailabilitySlotWriteSerializer,
+    CommunityPostFeedSerializer,
+    CommunityPostListQueryParamsSerializer,
+    CommunityPostSerializer,
     CommunityTagCreateSerializer,
     CommunityTagDetailSerializer,
     CommunityTagListResponseSerializer,
     CommunityTagListSerializer,
     CommunityTagMembershipSerializer,
     CommunityTagUpdateSerializer,
+    CoPCreateSerializer,
+    CoPUpdateSerializer,
     MenteeProfileResponseSerializer,
     MentorProfileResponseSerializer,
     PostMediaUploadSerializer,
@@ -50,13 +55,18 @@ from .serializers import (
     resolve_picture_url,
 )
 from .services import (
+    InvalidCoPEventTypeError,
     InvalidPrPEventTypeError,
     OwnSlotBookingError,
     SlotAlreadyBookedError,
     SlotInPastError,
+    create_cop_event,
     create_prp_event,
+    edit_cop_event,
     edit_prp_event,
+    list_community_feed_events,
     list_profile_feed_events,
+    soft_delete_cop_event,
     soft_delete_prp_event,
 )
 
@@ -1503,6 +1513,211 @@ class MyTagsListAPIView(ProfileLookupMixin, APIView):
             CommunityTagListSerializer(tags, many=True).data,
             status=status.HTTP_200_OK,
         )
+
+
+class CommunityTagPostsListCreateAPIView(ProfileLookupMixin, APIView):
+    """List and create community posts (CoP) for a community tag."""
+
+    permission_classes = [IsUser]
+
+    @extend_schema(
+        operation_id="community_tag_posts_list",
+        parameters=[
+            OpenApiParameter(
+                name="event_type",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=OpenApiTypes.STR,
+                enum=["achievement", "social", "progress"],
+                description="Filter by event type.",
+            ),
+            OpenApiParameter(
+                name="offset",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=OpenApiTypes.INT,
+                description="Zero-based index of the first item to include. Default: 0.",
+            ),
+            OpenApiParameter(
+                name="limit",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=OpenApiTypes.INT,
+                description="Maximum number of items to return. Default: 50. Maximum: 200.",
+            ),
+        ],
+        responses={
+            200: CommunityPostFeedSerializer,
+            400: OpenApiResponse(description="Invalid query parameters."),
+            401: OpenApiResponse(description="Authentication required."),
+            404: OpenApiResponse(description="Community tag not found."),
+        },
+        description=(
+            "List community posts for a tag, ordered newest-first. "
+            "Authenticated users can view all non-deleted posts. "
+            "Supports filtering by `event_type`. Pagination via `offset` and `limit`."
+        ),
+        tags=["Community Tags"],
+    )
+    def get(self, request: Request, tag_id: str) -> Response:
+        """Return paginated community feed events for a tag."""
+        tag = CommunityTag.objects.filter(id=tag_id).first()
+        if tag is None:
+            return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
+
+        params_serializer = CommunityPostListQueryParamsSerializer(data=request.query_params)
+        params_serializer.is_valid(raise_exception=True)
+        params = params_serializer.validated_data
+
+        payload = list_community_feed_events(
+            community_tag=tag,
+            offset=params["offset"],
+            limit=params["limit"],
+            event_type=params.get("event_type"),
+        )
+        return Response(CommunityPostFeedSerializer(payload).data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        operation_id="community_tag_posts_create",
+        request=CoPCreateSerializer,
+        responses={
+            201: CommunityPostSerializer,
+            400: OpenApiResponse(description="Validation error."),
+            401: OpenApiResponse(description="Authentication required."),
+            403: OpenApiResponse(description="Not a member of this community."),
+            404: OpenApiResponse(description="Community tag not found."),
+        },
+        description=(
+            "Create a community post (CoP) in a tag. Requester must be a member. "
+            "`show_on_profile` defaults to `false`; set to `true` to also display "
+            "this post on the author's profile feed. "
+            "`timestamp` is optional; defaults to creation time."
+        ),
+        tags=["Community Tags"],
+    )
+    def post(self, request: Request, tag_id: str) -> Response:
+        """Create a new community post authored by request.user's profile."""
+        tag = CommunityTag.objects.filter(id=tag_id).first()
+        if tag is None:
+            return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
+
+        profile = self._get_request_profile_or_404(request)
+        if profile is None:
+            return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
+
+        is_member = CommunityTagMembership.objects.filter(profile=profile, tag=tag).exists()
+        if not is_member:
+            return Response(
+                {"detail": "You must be a member of this community to post."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        serializer = CoPCreateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        validated = serializer.validated_data
+
+        try:
+            event = create_cop_event(
+                author_profile=profile,
+                community_tag=tag,
+                event_type=validated["event_type"],
+                content=validated.get("content", ""),
+                media_url=validated.get("media_url"),
+                show_on_profile=validated.get("show_on_profile", False),
+                timestamp=validated.get("timestamp"),
+            )
+        except InvalidCoPEventTypeError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+
+        event.author = profile
+        return Response(CommunityPostSerializer(event).data, status=status.HTTP_201_CREATED)
+
+
+class CommunityTagPostDetailAPIView(ProfileLookupMixin, APIView):
+    """Update or soft-delete a community post owned by the authenticated user."""
+
+    permission_classes = [IsUser]
+
+    def _resolve_owned_post(self, request: Request, tag_id: str, event_id: str):
+        """Return (profile, event) for an owned CoP, or a 404 Response."""
+        from timeline.models import TimelineEvent
+
+        profile = self._get_request_profile_or_404(request)
+        if profile is None:
+            return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
+
+        try:
+            event = TimelineEvent.objects.select_related("author").get(
+                id=event_id,
+                author=profile,
+                community_id=tag_id,
+                category=TimelineEvent.Category.COP,
+                is_deleted=False,
+            )
+        except TimelineEvent.DoesNotExist:
+            return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
+
+        return profile, event
+
+    @extend_schema(
+        operation_id="community_tag_posts_update",
+        request=CoPUpdateSerializer,
+        responses={
+            200: CommunityPostSerializer,
+            400: OpenApiResponse(description="Validation error."),
+            401: OpenApiResponse(description="Authentication required."),
+            404: OpenApiResponse(description="Post not found."),
+        },
+        description=(
+            "Partially update a community post. Only the original author can edit. "
+            "Editable fields: `content`, `event_type`, `media_url`, `show_on_profile`."
+        ),
+        tags=["Community Tags"],
+    )
+    def patch(self, request: Request, tag_id: str, event_id: str) -> Response:
+        """Partially update an owned community post."""
+        result = self._resolve_owned_post(request, tag_id, event_id)
+        if isinstance(result, Response):
+            return result
+        _profile, event = result
+
+        serializer = CoPUpdateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        validated = serializer.validated_data
+
+        try:
+            updated_event = edit_cop_event(
+                event=event,
+                content=validated.get("content"),
+                event_type=validated.get("event_type"),
+                media_url=validated.get("media_url"),
+                show_on_profile=validated.get("show_on_profile"),
+                update_media_url="media_url" in validated,
+            )
+        except InvalidCoPEventTypeError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(CommunityPostSerializer(updated_event).data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        operation_id="community_tag_posts_delete",
+        responses={
+            204: OpenApiResponse(description="Post deleted."),
+            401: OpenApiResponse(description="Authentication required."),
+            404: OpenApiResponse(description="Post not found."),
+        },
+        description="Soft-delete a community post. Only the original author can delete.",
+        tags=["Community Tags"],
+    )
+    def delete(self, request: Request, tag_id: str, event_id: str) -> Response:
+        """Soft-delete an owned community post."""
+        result = self._resolve_owned_post(request, tag_id, event_id)
+        if isinstance(result, Response):
+            return result
+        _profile, event = result
+
+        soft_delete_cop_event(event=event)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 POPULAR_TAGS_WINDOWS = {"all": None, "7d": 7, "30d": 30}


### PR DESCRIPTION
## Related Issue

Closes #505.

## Description

This PR adds the CoP endpoints outlined in the issue. Allows for creation, deletion, editing of the posts.

Posts with show_on_profile field TRUE are shown in the profile feed.

Returns community information within the community_id field for the profile feed.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or configuration

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code

## Notes

(Any additional information or considerations.)
