### PR TITLE
task: Enhance Post Returns

### DIFF
--- a/backend/mentorship/services.py
+++ b/backend/mentorship/services.py
@@ -106,9 +106,6 @@ def create_mcte_event(
     The author must be a participant (mentor or mentee) of the match.
     ``timestamp`` must be a timezone-aware datetime; far-future dates
     (more than 1 day ahead of now) are rejected at the serializer layer.
-
-    Stores partner profile ID in payload to preserve it even if the match is deleted
-    or if the partner's username changes.
     """
     if event_type not in TimelineEvent.MCTEEventType.values:
         raise InvalidMCTEEventTypeError(
@@ -120,14 +117,7 @@ def create_mcte_event(
     source_id = f"mcte:{uuid.uuid4()}"
 
     effective_timestamp = timestamp if timestamp is not None else timezone.now()
-    
-    # Store partner profile ID in payload as fallback for deleted mentorships
-    # (usernames can change, so we use stable profile ID)
-    if actor_role == "mentor":
-        partner_id = str(match.mentee.id)
-    else:
-        partner_id = str(match.mentor.id)
-    
+
     event = TimelineEvent.objects.create(
         source_id=source_id,
         category=TimelineEvent.Category.MCTE,
@@ -139,7 +129,6 @@ def create_mcte_event(
         actor_role=actor_role,
         timestamp=effective_timestamp,
         show_on_profile=show_on_profile,
-        payload={"mentorship_partner_id": partner_id},
     )
 
     # Keep fallback semantics explicit: omitted timestamp should match created_at.

--- a/backend/mentorship/services.py
+++ b/backend/mentorship/services.py
@@ -106,6 +106,9 @@ def create_mcte_event(
     The author must be a participant (mentor or mentee) of the match.
     ``timestamp`` must be a timezone-aware datetime; far-future dates
     (more than 1 day ahead of now) are rejected at the serializer layer.
+
+    Stores partner profile ID in payload to preserve it even if the match is deleted
+    or if the partner's username changes.
     """
     if event_type not in TimelineEvent.MCTEEventType.values:
         raise InvalidMCTEEventTypeError(
@@ -117,6 +120,14 @@ def create_mcte_event(
     source_id = f"mcte:{uuid.uuid4()}"
 
     effective_timestamp = timestamp if timestamp is not None else timezone.now()
+    
+    # Store partner profile ID in payload as fallback for deleted mentorships
+    # (usernames can change, so we use stable profile ID)
+    if actor_role == "mentor":
+        partner_id = str(match.mentee.id)
+    else:
+        partner_id = str(match.mentor.id)
+    
     event = TimelineEvent.objects.create(
         source_id=source_id,
         category=TimelineEvent.Category.MCTE,
@@ -128,6 +139,7 @@ def create_mcte_event(
         actor_role=actor_role,
         timestamp=effective_timestamp,
         show_on_profile=show_on_profile,
+        payload={"mentorship_partner_id": partner_id},
     )
 
     # Keep fallback semantics explicit: omitted timestamp should match created_at.

--- a/backend/profiles/serializers.py
+++ b/backend/profiles/serializers.py
@@ -14,6 +14,7 @@ from core.utils.image import resize_image
 from core.utils.timezone import get_project_timezone, to_local_time
 from core.utils.validators import validate_file_size, validate_image_content_type
 from mentorship.models import MeetingSession
+from timeline.models import TimelineEvent
 
 from .models import AvailabilitySlot, CommunityTag, Profile, Skill
 
@@ -670,8 +671,12 @@ class ProfilePostListQueryParamsSerializer(serializers.Serializer):
 class ProfilePostSerializer(serializers.Serializer):
     """Read serializer for profile feed items (PrP, visible MCTE, and visible CoP).
 
-    ``community_id`` is populated only for CoP posts and is ``null`` for PrP and MCTE.
-    Clients can use it to navigate to ``/api/profiles/tags/{community_id}/`` or link
+    ``community_id`` and ``community_name`` are populated only for CoP posts.
+    ``community_name`` is fetched live; if the community has been deleted it falls back
+    to the name snapshotted in ``payload`` at creation time.
+    ``mentorship_partner`` is populated only for MCTE posts and contains the username of
+    the mentorship partner (mentor or mentee, depending on the author's role).
+    Clients can use ``community_id`` to navigate to ``/api/profiles/tags/{community_id}/`` or link
     to the community feed at ``/api/profiles/tags/{community_id}/posts/``.
     """
 
@@ -686,8 +691,69 @@ class ProfilePostSerializer(serializers.Serializer):
     last_edited = serializers.DateTimeField(read_only=True, allow_null=True)
     show_on_profile = serializers.BooleanField(read_only=True)
     community_id = serializers.UUIDField(read_only=True, allow_null=True)
+    community_name = serializers.SerializerMethodField()
     actor_role = serializers.CharField(read_only=True)
+    mentorship_partner = serializers.SerializerMethodField()
     author = ProfilePostAuthorSerializer(read_only=True)
+
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_community_name(self, obj: TimelineEvent) -> str | None:
+        """Return the community name for CoP events.
+
+        First tries to fetch the live name from the database. Falls back to the
+        name stored in payload at creation time if the community has been deleted.
+        """
+        if obj.category != TimelineEvent.Category.COP or obj.community_id is None:
+            return None
+
+        community = CommunityTag.objects.filter(id=obj.community_id).values("name").first()
+        if community is not None:
+            return community["name"]
+
+        # Community was deleted — fall back to snapshot stored at creation time
+        payload = obj.payload or {}
+        return payload.get("community_name")
+
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_mentorship_partner(self, obj: TimelineEvent) -> str | None:
+        """Return the username of the mentorship partner for MCTE events.
+
+        For MCTE events, returns the username of the mentee or mentor (whichever is not
+        the author). For other event types, returns None.
+
+        Handles edge cases gracefully:
+        - If mentorship exists: fetch from related mentor/mentee objects
+        - If mentorship is deleted: fall back to profile ID in payload
+        - If partner's profile is hidden or deleted, still returns their username
+        """
+        if obj.category != TimelineEvent.Category.MCTE:
+            return None
+
+        if obj.author is None:
+            return None
+
+        # Try to get from active mentorship first
+        if obj.mentorship is not None:
+            # Determine partner based on author's role
+            if obj.author == obj.mentorship.mentor:
+                # Author is mentor, so partner is mentee
+                return obj.mentorship.mentee.username
+            elif obj.author == obj.mentorship.mentee:
+                # Author is mentee, so partner is mentor
+                return obj.mentorship.mentor.username
+
+        # Fall back to payload if mentorship was deleted
+        payload = obj.payload or {}
+        partner_id = payload.get("mentorship_partner_id")
+        if partner_id:
+            try:
+                partner_profile = Profile.objects.get(id=partner_id)
+                return partner_profile.username
+            except Profile.DoesNotExist:
+                # Partner profile was also deleted, but we tried our best
+                return None
+
+        return None
 
 
 class ProfilePostFeedSerializer(serializers.Serializer):

--- a/backend/profiles/serializers.py
+++ b/backend/profiles/serializers.py
@@ -721,10 +721,7 @@ class ProfilePostSerializer(serializers.Serializer):
         For MCTE events, returns the username of the mentee or mentor (whichever is not
         the author). For other event types, returns None.
 
-        Handles edge cases gracefully:
-        - If mentorship exists: fetch from related mentor/mentee objects
-        - If mentorship is deleted: fall back to profile ID in payload
-        - If partner's profile is hidden or deleted, still returns their username
+        The username is resolved from the live mentorship relation.
         """
         if obj.category != TimelineEvent.Category.MCTE:
             return None
@@ -732,26 +729,14 @@ class ProfilePostSerializer(serializers.Serializer):
         if obj.author is None:
             return None
 
-        # Try to get from active mentorship first
-        if obj.mentorship is not None:
-            # Determine partner based on author's role
-            if obj.author == obj.mentorship.mentor:
-                # Author is mentor, so partner is mentee
-                return obj.mentorship.mentee.username
-            elif obj.author == obj.mentorship.mentee:
-                # Author is mentee, so partner is mentor
-                return obj.mentorship.mentor.username
+        if obj.mentorship is None:
+            return None
 
-        # Fall back to payload if mentorship was deleted
-        payload = obj.payload or {}
-        partner_id = payload.get("mentorship_partner_id")
-        if partner_id:
-            try:
-                partner_profile = Profile.objects.get(id=partner_id)
-                return partner_profile.username
-            except Profile.DoesNotExist:
-                # Partner profile was also deleted, but we tried our best
-                return None
+        # Determine partner based on author's role.
+        if obj.author == obj.mentorship.mentor:
+            return obj.mentorship.mentee.username
+        if obj.author == obj.mentorship.mentee:
+            return obj.mentorship.mentor.username
 
         return None
 

--- a/backend/profiles/serializers.py
+++ b/backend/profiles/serializers.py
@@ -696,7 +696,7 @@ class ProfilePostSerializer(serializers.Serializer):
     mentorship_partner = serializers.SerializerMethodField()
     author = ProfilePostAuthorSerializer(read_only=True)
 
-    @extend_schema_field(OpenApiTypes.STR)
+    @extend_schema_field({"type": "string", "nullable": True})
     def get_community_name(self, obj: TimelineEvent) -> str | None:
         """Return the community name for CoP events.
 
@@ -714,7 +714,7 @@ class ProfilePostSerializer(serializers.Serializer):
         payload = obj.payload or {}
         return payload.get("community_name")
 
-    @extend_schema_field(OpenApiTypes.STR)
+    @extend_schema_field({"type": "string", "nullable": True})
     def get_mentorship_partner(self, obj: TimelineEvent) -> str | None:
         """Return the username of the mentorship partner for MCTE events.
 

--- a/backend/profiles/services.py
+++ b/backend/profiles/services.py
@@ -138,7 +138,11 @@ def list_profile_feed_events(
             | Q(category=TimelineEvent.Category.MCTE, show_on_profile=True)
             | Q(category=TimelineEvent.Category.COP, show_on_profile=True)
         )
-        .select_related("author")
+        .select_related(
+            "author",
+            "mentorship__mentor",
+            "mentorship__mentee",
+        )
         .annotate(effective_last_update=Coalesce("last_edited", "created_at"))
         .order_by("-created_at", "-effective_last_update", "-source_id")
     )
@@ -311,6 +315,7 @@ def create_cop_event(
         media_url=media_url,
         show_on_profile=show_on_profile,
         timestamp=timestamp if timestamp is not None else timezone.now(),
+        payload={"community_name": community_tag.name},
     )
 
     if timestamp is None:

--- a/backend/profiles/tests.py
+++ b/backend/profiles/tests.py
@@ -36,6 +36,7 @@ from profiles.services import (
     SlotNotBookedError,
     book_availability_slot,
     cancel_availability_booking,
+    create_cop_event,
     create_prp_event,
 )
 from profiles.views import PublicMentorProfilesSearchListAPIView
@@ -4637,3 +4638,261 @@ class PostMediaUploadTests(TestCase):
         file = self._make_image_file("post.jpg")
         response = self.client.post(self.UPLOAD_URL, {"file": file}, format="multipart")
         self.assertEqual(response.status_code, 404)
+
+
+class ProfileFeedDeletionScenarioTests(TestCase):
+    """Tests for profile feed serializer behaviour when related objects are deleted."""
+
+    def setUp(self) -> None:
+        self.api_client: Any = APIClient()
+
+        self.mentor_user = User.objects.create_user(
+            email="feed-mentor@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTOR,
+        )
+        self.mentor_profile = Profile.objects.create(
+            user=self.mentor_user,
+            username="feed_mentor",
+            display_name="Feed Mentor",
+            is_visible=True,
+        )
+
+        self.mentee_user = User.objects.create_user(
+            email="feed-mentee@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTEE,
+        )
+        self.mentee_profile = Profile.objects.create(
+            user=self.mentee_user,
+            username="feed_mentee",
+            display_name="Feed Mentee",
+            is_visible=True,
+        )
+
+        self.viewer_user = User.objects.create_user(
+            email="feed-viewer@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTEE,
+        )
+        self.viewer_profile = Profile.objects.create(
+            user=self.viewer_user,
+            username="feed_viewer",
+            display_name="Feed Viewer",
+            is_visible=True,
+        )
+        self.viewer_token = str(RefreshToken.for_user(self.viewer_user).access_token)
+
+        self.feed_url = f"/api/profiles/{self.mentor_profile.username}/posts/"
+
+    def _auth_viewer(self) -> None:
+        self.api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.viewer_token}")
+
+    def _create_match(self) -> Match:
+        request_obj = MentorshipRequest.objects.create(
+            mentor=self.mentor_profile,
+            mentee=self.mentee_profile,
+            status=MentorshipRequest.Status.ACCEPTED,
+        )
+        return ensure_match_and_initial_session(mentorship_request=request_obj)
+
+    # ------------------------------------------------------------------
+    # MCTE: deleted mentorship
+    # ------------------------------------------------------------------
+
+    def test_mcte_partner_returned_after_match_deleted(self) -> None:
+        """mentorship_partner is still returned from payload after the Match is deleted."""
+        match = self._create_match()
+        event = create_mcte_event(
+            match=match,
+            author_profile=self.mentor_profile,
+            event_type="achievement",
+            content="A milestone",
+            show_on_profile=True,
+        )
+
+        # Null the FK on the event to simulate the mentorship being gone
+        # (mirrors SET_NULL semantics; CASCADE would delete the event entirely)
+        TimelineEvent.objects.filter(id=event.id).update(mentorship=None)
+
+        self._auth_viewer()
+        response = self.api_client.get(self.feed_url + "?category=MCTE")
+
+        self.assertEqual(response.status_code, 200)
+        result = next(
+            item for item in response.data["results"] if item["source_id"] == event.source_id
+        )
+        self.assertEqual(result["mentorship_partner"], self.mentee_profile.username)
+
+    # ------------------------------------------------------------------
+    # MCTE: deleted mentorship + changed username
+    # ------------------------------------------------------------------
+
+    def test_mcte_partner_reflects_updated_username_after_match_deleted(self) -> None:
+        """After match deletion the payload ID resolves to the partner's current username."""
+        match = self._create_match()
+        event = create_mcte_event(
+            match=match,
+            author_profile=self.mentor_profile,
+            event_type="progress",
+            content="Progress note",
+            show_on_profile=True,
+        )
+
+        # Null the FK on the event, then rename the partner
+        TimelineEvent.objects.filter(id=event.id).update(mentorship=None)
+        self.mentee_profile.username = "renamed_mentee"
+        self.mentee_profile.save(update_fields=["username"])
+
+        self._auth_viewer()
+        response = self.api_client.get(self.feed_url + "?category=MCTE")
+
+        self.assertEqual(response.status_code, 200)
+        result = next(
+            item for item in response.data["results"] if item["source_id"] == event.source_id
+        )
+        self.assertEqual(result["mentorship_partner"], "renamed_mentee")
+
+    # ------------------------------------------------------------------
+    # MCTE: deleted mentorship + deleted partner profile
+    # ------------------------------------------------------------------
+
+    def test_mcte_partner_is_none_after_match_and_profile_deleted(self) -> None:
+        """mentorship_partner is None when both the match and partner profile are gone."""
+        match = self._create_match()
+        event = create_mcte_event(
+            match=match,
+            author_profile=self.mentor_profile,
+            event_type="social",
+            content="A social note",
+            show_on_profile=True,
+        )
+
+        # Null the FK on the event, then delete the partner profile and user
+        TimelineEvent.objects.filter(id=event.id).update(mentorship=None)
+        self.mentee_user.delete()  # cascades to mentee_profile
+
+        self._auth_viewer()
+        response = self.api_client.get(self.feed_url + "?category=MCTE")
+
+        self.assertEqual(response.status_code, 200)
+        result = next(
+            item for item in response.data["results"] if item["source_id"] == event.source_id
+        )
+        self.assertIsNone(result["mentorship_partner"])
+
+    # ------------------------------------------------------------------
+    # MCTE: active match, hidden partner
+    # ------------------------------------------------------------------
+
+    def test_mcte_partner_returned_when_partner_profile_hidden(self) -> None:
+        """mentorship_partner username is returned even when the partner's profile is hidden."""
+        match = self._create_match()
+        event = create_mcte_event(
+            match=match,
+            author_profile=self.mentor_profile,
+            event_type="achievement",
+            content="Achievement",
+            show_on_profile=True,
+        )
+
+        self.mentee_profile.is_visible = False
+        self.mentee_profile.save(update_fields=["is_visible"])
+
+        self._auth_viewer()
+        response = self.api_client.get(self.feed_url + "?category=MCTE")
+
+        self.assertEqual(response.status_code, 200)
+        result = next(
+            item for item in response.data["results"] if item["source_id"] == event.source_id
+        )
+        self.assertEqual(result["mentorship_partner"], self.mentee_profile.username)
+
+    # ------------------------------------------------------------------
+    # CoP: live community
+    # ------------------------------------------------------------------
+
+    def test_cop_community_name_returned_for_active_community(self) -> None:
+        """community_name is returned from the live CommunityTag record."""
+        community = CommunityTag.objects.create(
+            name="Active Community",
+            created_by=self.mentor_profile,
+        )
+        event = create_cop_event(
+            author_profile=self.mentor_profile,
+            community_tag=community,
+            event_type="social",
+            content="Hello community",
+            show_on_profile=True,
+        )
+
+        self._auth_viewer()
+        response = self.api_client.get(self.feed_url + "?category=CoP")
+
+        self.assertEqual(response.status_code, 200)
+        result = next(
+            item for item in response.data["results"] if item["source_id"] == event.source_id
+        )
+        self.assertEqual(result["community_id"], str(community.id))
+        self.assertEqual(result["community_name"], "Active Community")
+
+    # ------------------------------------------------------------------
+    # CoP: deleted community
+    # ------------------------------------------------------------------
+
+    def test_cop_community_name_falls_back_to_payload_after_community_deleted(self) -> None:
+        """community_name is served from payload after the CommunityTag is deleted."""
+        community = CommunityTag.objects.create(
+            name="Soon Deleted Community",
+            created_by=self.mentor_profile,
+        )
+        community_id = community.id
+        event = create_cop_event(
+            author_profile=self.mentor_profile,
+            community_tag=community,
+            event_type="social",
+            content="Post before deletion",
+            show_on_profile=True,
+        )
+
+        community.delete()
+
+        self._auth_viewer()
+        response = self.api_client.get(self.feed_url + "?category=CoP")
+
+        self.assertEqual(response.status_code, 200)
+        result = next(
+            item for item in response.data["results"] if item["source_id"] == event.source_id
+        )
+        self.assertEqual(str(result["community_id"]), str(community_id))
+        self.assertEqual(result["community_name"], "Soon Deleted Community")
+
+    # ------------------------------------------------------------------
+    # CoP: community_name reflects live renames
+    # ------------------------------------------------------------------
+
+    def test_cop_community_name_reflects_live_rename(self) -> None:
+        """community_name tracks the current live name, not the snapshot."""
+        community = CommunityTag.objects.create(
+            name="Original Name",
+            created_by=self.mentor_profile,
+        )
+        event = create_cop_event(
+            author_profile=self.mentor_profile,
+            community_tag=community,
+            event_type="achievement",
+            content="Post before rename",
+            show_on_profile=True,
+        )
+
+        community.name = "Renamed Community"
+        community.save(update_fields=["name"])
+
+        self._auth_viewer()
+        response = self.api_client.get(self.feed_url + "?category=CoP")
+
+        self.assertEqual(response.status_code, 200)
+        result = next(
+            item for item in response.data["results"] if item["source_id"] == event.source_id
+        )
+        self.assertEqual(result["community_name"], "Renamed Community")

--- a/backend/profiles/tests.py
+++ b/backend/profiles/tests.py
@@ -4697,68 +4697,11 @@ class ProfileFeedDeletionScenarioTests(TestCase):
         return ensure_match_and_initial_session(mentorship_request=request_obj)
 
     # ------------------------------------------------------------------
-    # MCTE: deleted mentorship
+    # MCTE: deleted mentorship (CASCADE)
     # ------------------------------------------------------------------
 
-    def test_mcte_partner_returned_after_match_deleted(self) -> None:
-        """mentorship_partner is still returned from payload after the Match is deleted."""
-        match = self._create_match()
-        event = create_mcte_event(
-            match=match,
-            author_profile=self.mentor_profile,
-            event_type="achievement",
-            content="A milestone",
-            show_on_profile=True,
-        )
-
-        # Null the FK on the event to simulate the mentorship being gone
-        # (mirrors SET_NULL semantics; CASCADE would delete the event entirely)
-        TimelineEvent.objects.filter(id=event.id).update(mentorship=None)
-
-        self._auth_viewer()
-        response = self.api_client.get(self.feed_url + "?category=MCTE")
-
-        self.assertEqual(response.status_code, 200)
-        result = next(
-            item for item in response.data["results"] if item["source_id"] == event.source_id
-        )
-        self.assertEqual(result["mentorship_partner"], self.mentee_profile.username)
-
-    # ------------------------------------------------------------------
-    # MCTE: deleted mentorship + changed username
-    # ------------------------------------------------------------------
-
-    def test_mcte_partner_reflects_updated_username_after_match_deleted(self) -> None:
-        """After match deletion the payload ID resolves to the partner's current username."""
-        match = self._create_match()
-        event = create_mcte_event(
-            match=match,
-            author_profile=self.mentor_profile,
-            event_type="progress",
-            content="Progress note",
-            show_on_profile=True,
-        )
-
-        # Null the FK on the event, then rename the partner
-        TimelineEvent.objects.filter(id=event.id).update(mentorship=None)
-        self.mentee_profile.username = "renamed_mentee"
-        self.mentee_profile.save(update_fields=["username"])
-
-        self._auth_viewer()
-        response = self.api_client.get(self.feed_url + "?category=MCTE")
-
-        self.assertEqual(response.status_code, 200)
-        result = next(
-            item for item in response.data["results"] if item["source_id"] == event.source_id
-        )
-        self.assertEqual(result["mentorship_partner"], "renamed_mentee")
-
-    # ------------------------------------------------------------------
-    # MCTE: deleted mentorship + deleted partner profile
-    # ------------------------------------------------------------------
-
-    def test_mcte_partner_is_none_after_match_and_profile_deleted(self) -> None:
-        """mentorship_partner is None when both the match and partner profile are gone."""
+    def test_mcte_event_removed_after_match_deleted(self) -> None:
+        """Deleting a match removes its MCTE events from the profile feed."""
         match = self._create_match()
         event = create_mcte_event(
             match=match,
@@ -4768,18 +4711,14 @@ class ProfileFeedDeletionScenarioTests(TestCase):
             show_on_profile=True,
         )
 
-        # Null the FK on the event, then delete the partner profile and user
-        TimelineEvent.objects.filter(id=event.id).update(mentorship=None)
-        self.mentee_user.delete()  # cascades to mentee_profile
+        match.request.delete()
 
         self._auth_viewer()
         response = self.api_client.get(self.feed_url + "?category=MCTE")
 
         self.assertEqual(response.status_code, 200)
-        result = next(
-            item for item in response.data["results"] if item["source_id"] == event.source_id
-        )
-        self.assertIsNone(result["mentorship_partner"])
+        source_ids = {item["source_id"] for item in response.data["results"]}
+        self.assertNotIn(event.source_id, source_ids)
 
     # ------------------------------------------------------------------
     # MCTE: active match, hidden partner

--- a/backend/profiles/views.py
+++ b/backend/profiles/views.py
@@ -80,6 +80,7 @@ PAGE_SIZE_NOT_INT_DETAIL = {"detail": "`page` and `pageSize` must be integers."}
 def _resolve_community_tag(tag_id: str, qs=None) -> "CommunityTag | None":
     """Return a CommunityTag by UUID or slug. Pass a custom queryset for select_related etc."""
     from uuid import UUID
+
     if qs is None:
         qs = CommunityTag.objects
     try:
@@ -274,9 +275,12 @@ class ProfilePostsListAPIView(ProfileLookupMixin, APIView):
             "Supports optional filtering by `category` and `event_type`. "
             "Results are ordered newest-first by action metadata: `created_at`, then "
             "`last_edited` as a tie-breaker. "
-            "Each result includes a `community_id` field: populated with the community tag "
-            "UUID for CoP posts (use it to link to `GET /api/profiles/tags/{community_id}/` "
-            "or `GET /api/profiles/tags/{community_id}/posts/`), and `null` for PrP and MCTE."
+            "For CoP posts, `community_id` and `community_name` are returned; "
+            "`community_name` is resolved from the live community and falls back to the "
+            "snapshotted payload value if the community has been deleted. "
+            "For MCTE posts, `mentorship_partner` is resolved from the active mentorship "
+            "relation and is `null` for PrP and CoP. Deleting a mentorship cascades to "
+            "its timeline events, so deleted mentorship events are not included in this feed."
         ),
         tags=["Profiles"],
     )


### PR DESCRIPTION
## Related Issue

Closes #508

## Description

With this PR:
- MCTE will return the username of the other participant in the mentorship.
- CoP will return the community_id and community_name.

Regarding MCTE:
- Mentorship deletion cascade deletes MCTE as well, which means the post will disappear from the profile feed in such an event.
- Participating user deletion cascade deletes MCTE as well, as above.

Regarding CoP:
- Community deletion does not delete community_id, hence it is possible for a CoP event to appear in the profile feed even after a community deletion. In such cases, community_name is taken from the stored (possibly outdated, pre community deletion) community_name payload.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or configuration

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code

## Notes

We might need to change the way MCTE events get cascade deleted when a mentorship is deactivated to keep the events in the profile.
