### PR TITLE
feat: mobile media upload support

### DIFF
--- a/mobile/__tests__/app/community-create.test.tsx
+++ b/mobile/__tests__/app/community-create.test.tsx
@@ -1,0 +1,112 @@
+import CreateCommunityScreen from "@/app/(tabs)/community/create";
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+const mockReplace = jest.fn();
+const mockCreateMutation = jest.fn();
+let mockUsername: string | undefined = "student";
+
+jest.mock("@expo/vector-icons", () => ({ Ionicons: "View" }));
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({
+    replace: mockReplace,
+  }),
+}));
+
+jest.mock("@/lib/auth/store", () => ({
+  useAuthStore: (selector: (state: any) => unknown) =>
+    selector({
+      user: mockUsername ? { username: mockUsername } : null,
+    }),
+}));
+
+jest.mock("@/lib/queries/communityTags", () => ({
+  useCreateCommunityTagMutation: (username?: string) =>
+    mockCreateMutation(username),
+}));
+
+describe("CreateCommunityScreen", () => {
+  const mutateAsync = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsername = "student";
+    mutateAsync.mockResolvedValue({
+      id: "tag-1",
+      name: "Backend Guild",
+      slug: "backend-guild",
+      description: "API design",
+      member_count: 1,
+      created_at: "2026-05-06T00:00:00Z",
+      created_by_username: "student",
+      is_member: true,
+    });
+    mockCreateMutation.mockReturnValue({
+      mutateAsync,
+      isPending: false,
+    });
+  });
+
+  it("uses the authenticated username for cache invalidation scope", () => {
+    render(<CreateCommunityScreen />);
+
+    expect(mockCreateMutation).toHaveBeenCalledWith("student");
+  });
+
+  it("returns to the community tab from the back button", () => {
+    const { getByTestId } = render(<CreateCommunityScreen />);
+
+    fireEvent.press(getByTestId("create-community-back-button"));
+
+    expect(mockReplace).toHaveBeenCalledWith("/(tabs)/community");
+  });
+
+  it("requires a community name before submit", async () => {
+    const { findByText, getByTestId } = render(<CreateCommunityScreen />);
+
+    fireEvent.press(getByTestId("create-community-submit"));
+
+    expect(await findByText("Community name is required.")).toBeTruthy();
+    expect(mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("creates a community and routes to its detail screen", async () => {
+    const { getByTestId } = render(<CreateCommunityScreen />);
+
+    fireEvent.changeText(
+      getByTestId("create-community-name-input"),
+      "  Backend Guild  ",
+    );
+    fireEvent.changeText(
+      getByTestId("create-community-description-input"),
+      "  API design and Django patterns  ",
+    );
+    fireEvent.press(getByTestId("create-community-submit"));
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({
+        name: "Backend Guild",
+        description: "API design and Django patterns",
+      });
+    });
+    expect(mockReplace).toHaveBeenCalledWith(
+      "/(tabs)/community/tag-1?from=community",
+    );
+  });
+
+  it("shows API errors when creation fails", async () => {
+    mutateAsync.mockRejectedValueOnce(
+      new Error("A community tag with this name already exists."),
+    );
+    const { findByText, getByTestId } = render(<CreateCommunityScreen />);
+
+    fireEvent.changeText(getByTestId("create-community-name-input"), "Backend");
+    fireEvent.press(getByTestId("create-community-submit"));
+
+    expect(
+      await findByText("A community tag with this name already exists."),
+    ).toBeTruthy();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/__tests__/app/community.test.tsx
+++ b/mobile/__tests__/app/community.test.tsx
@@ -82,6 +82,15 @@ describe("CommunityScreen", () => {
     expect(mockPush).toHaveBeenCalledWith("/(tabs)/discover");
   });
 
+  it("opens the create community page from the community prompt", () => {
+    const { getByTestId, getByText } = render(<CommunityScreen />);
+
+    expect(getByText("Create your own community")).toBeTruthy();
+    fireEvent.press(getByTestId("create-community-link"));
+
+    expect(mockPush).toHaveBeenCalledWith("/(tabs)/community/create");
+  });
+
   it("renders joined community cards and switches the feed placeholder copy", () => {
     mockMyCommunitiesQuery.mockReturnValue({
       isLoading: false,

--- a/mobile/__tests__/app/community.test.tsx
+++ b/mobile/__tests__/app/community.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 
 const mockPush = jest.fn();
 const mockMyCommunitiesQuery = jest.fn();
+const mockCommunityFeedQuery = jest.fn();
 let mockUsername: string | undefined = "student";
 
 jest.mock("@expo/vector-icons", () => ({ Ionicons: "View" }));
@@ -18,6 +19,24 @@ jest.mock("@/components/notifications/NotificationBell", () => ({
   NotificationBell: () => null,
 }));
 
+jest.mock("@/components/profile/ProfilePostCard", () => ({
+  ProfilePostCard: ({
+    communityLabel,
+    post,
+  }: {
+    communityLabel?: string | null;
+    post: { id: string; content: string };
+  }) => {
+    const { Text, View } = require("react-native");
+    return (
+      <View testID={`community-feed-post-${post.id}`}>
+        <Text>{post.content}</Text>
+        {communityLabel ? <Text>{communityLabel}</Text> : null}
+      </View>
+    );
+  },
+}));
+
 jest.mock("@/lib/auth/store", () => ({
   useAuthStore: (selector: (state: any) => unknown) =>
     selector({
@@ -30,11 +49,21 @@ jest.mock("@/lib/queries/communityTags", () => ({
     mockMyCommunitiesQuery(username),
 }));
 
+jest.mock("@/lib/queries/communityPosts", () => ({
+  useMyCommunityPostsFeedQuery: (...args: unknown[]) =>
+    mockCommunityFeedQuery(...args),
+}));
+
 describe("CommunityScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUsername = "student";
     mockMyCommunitiesQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    });
+    mockCommunityFeedQuery.mockReturnValue({
       data: [],
       isLoading: false,
       isError: false,
@@ -91,7 +120,7 @@ describe("CommunityScreen", () => {
     expect(mockPush).toHaveBeenCalledWith("/(tabs)/community/create");
   });
 
-  it("renders joined community cards and switches the feed placeholder copy", () => {
+  it("renders joined community cards before the create prompt and switches the feed placeholder copy", () => {
     mockMyCommunitiesQuery.mockReturnValue({
       isLoading: false,
       isError: false,
@@ -115,24 +144,80 @@ describe("CommunityScreen", () => {
       ],
     });
 
-    const { getByTestId, getByText, queryByTestId } = render(
+    const { getByTestId, getByText, queryByTestId, toJSON } = render(
       <CommunityScreen />,
     );
+    const treeText = JSON.stringify(toJSON());
 
     expect(getByTestId("community-card-backend-guild")).toBeTruthy();
     expect(getByTestId("community-card-one-person-lab")).toBeTruthy();
+    expect(treeText.indexOf("Backend Guild")).toBeLessThan(
+      treeText.indexOf("Create your own community"),
+    );
     expect(getByText("Backend Guild")).toBeTruthy();
     expect(getByText("12 members")).toBeTruthy();
     expect(getByText("1 member")).toBeTruthy();
-    expect(
-      getByText("Posts from your communities will appear here"),
-    ).toBeTruthy();
+    expect(getByText("No posts in your communities yet")).toBeTruthy();
     expect(queryByTestId("community-empty-state")).toBeNull();
 
     fireEvent.press(getByTestId("community-card-backend-guild"));
     expect(mockPush).toHaveBeenCalledWith(
       "/(tabs)/community/tag-1?from=community",
     );
+  });
+
+  it("fetches and renders posts from all joined communities", () => {
+    mockMyCommunitiesQuery.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: [
+        {
+          id: "tag-1",
+          name: "Backend Guild",
+          slug: "backend-guild",
+          description: "API design",
+          member_count: 12,
+          created_at: "2026-04-20T00:00:00Z",
+        },
+        {
+          id: "tag-2",
+          name: "AI Lab",
+          slug: "ai-lab",
+          description: "Machine learning",
+          member_count: 6,
+          created_at: "2026-04-21T00:00:00Z",
+        },
+      ],
+    });
+    mockCommunityFeedQuery.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: [
+        {
+          id: "post-1",
+          community_id: "tag-1",
+          content: "Backend post",
+        },
+        {
+          id: "post-2",
+          community_id: "tag-2",
+          content: "AI post",
+        },
+      ],
+    });
+
+    const { getAllByText, getByTestId } = render(<CommunityScreen />);
+
+    expect(mockCommunityFeedQuery).toHaveBeenCalledWith(
+      ["tag-1", "tag-2"],
+      5,
+      true,
+    );
+    expect(getByTestId("community-feed-posts")).toBeTruthy();
+    expect(getByTestId("community-feed-post-post-1")).toBeTruthy();
+    expect(getByTestId("community-feed-post-post-2")).toBeTruthy();
+    expect(getAllByText("Backend Guild").length).toBeGreaterThan(1);
+    expect(getAllByText("AI Lab").length).toBeGreaterThan(1);
   });
 
   it("still renders the empty state when the user is not restored yet", () => {

--- a/mobile/__tests__/app/messages/conversation.test.tsx
+++ b/mobile/__tests__/app/messages/conversation.test.tsx
@@ -4,6 +4,8 @@ import React from "react";
 const mockBack = jest.fn();
 const mockMutateAsync = jest.fn();
 const mockInvalidateQueries = jest.fn();
+const mockPickMessageImageFile = jest.fn();
+const mockPickMessagePdfFile = jest.fn();
 
 let mockConversationId = "conv-1";
 let mockMessagesLoading = false;
@@ -55,6 +57,11 @@ jest.mock("@/lib/queries/MessagingQueries", () => ({
     mutateAsync: mockMutateAsync,
     isPending: mockSendIsPending,
   }),
+}));
+
+jest.mock("@/lib/uploads/picker", () => ({
+  pickMessageImageFile: () => mockPickMessageImageFile(),
+  pickMessagePdfFile: () => mockPickMessagePdfFile(),
 }));
 
 import ConversationScreen from "@/app/messages/[conversation_id]";
@@ -110,6 +117,8 @@ describe("ConversationScreen — message input", () => {
     mockSendIsPending = false;
     mockMutateAsync.mockReset();
     mockInvalidateQueries.mockClear();
+    mockPickMessageImageFile.mockReset();
+    mockPickMessagePdfFile.mockReset();
   });
 
   it("renders message input", () => {
@@ -134,7 +143,10 @@ describe("ConversationScreen — message input", () => {
     fireEvent.changeText(getByTestId("message-input"), "  Hello!  ");
     fireEvent.press(getByTestId("send-button"));
     await waitFor(() => {
-      expect(mockMutateAsync).toHaveBeenCalledWith("Hello!");
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        body: "Hello!",
+        attachment: null,
+      });
     });
   });
 
@@ -152,6 +164,55 @@ describe("ConversationScreen — message input", () => {
     const { getByTestId } = renderScreen();
     fireEvent.press(getByTestId("send-button"));
     expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("opens attachment options and sends a selected image without text", async () => {
+    const image = {
+      uri: "file:///tmp/photo.jpg",
+      name: "photo.jpg",
+      type: "image/jpeg",
+    };
+    mockPickMessageImageFile.mockResolvedValueOnce(image);
+    mockMutateAsync.mockResolvedValueOnce(undefined);
+
+    const { getByTestId, getByText } = renderScreen();
+
+    fireEvent.press(getByTestId("attachment-plus-button"));
+    fireEvent.press(getByTestId("attach-image-button"));
+
+    await waitFor(() => {
+      expect(getByText("photo.jpg")).toBeTruthy();
+    });
+
+    fireEvent.press(getByTestId("send-button"));
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        body: "",
+        attachment: image,
+      });
+    });
+  });
+
+  it("selects and removes a PDF attachment", async () => {
+    const pdf = {
+      uri: "file:///tmp/report.pdf",
+      name: "report.pdf",
+      type: "application/pdf",
+    };
+    mockPickMessagePdfFile.mockResolvedValueOnce(pdf);
+
+    const { getByTestId, getByText, queryByText } = renderScreen();
+
+    fireEvent.press(getByTestId("attachment-plus-button"));
+    fireEvent.press(getByTestId("attach-pdf-button"));
+
+    await waitFor(() => {
+      expect(getByText("report.pdf")).toBeTruthy();
+    });
+
+    fireEvent.press(getByTestId("selected-attachment-remove"));
+    expect(queryByText("report.pdf")).toBeNull();
   });
 
   it("restores text if send fails", async () => {
@@ -251,7 +312,7 @@ describe("ConversationScreen — message list", () => {
     expect(getByText("Today")).toBeTruthy();
     expect(getByText("Yesterday hello")).toBeTruthy();
     expect(getByText("Today reply")).toBeTruthy();
-    expect(getByText("Attachment")).toBeTruthy();
+    expect(getByText("file.pdf")).toBeTruthy();
     expect(getByPlaceholderText("Message Ada…")).toBeTruthy();
   });
 

--- a/mobile/__tests__/app/profile.test.tsx
+++ b/mobile/__tests__/app/profile.test.tsx
@@ -1,5 +1,5 @@
 import ProfileScreen from "@/app/(tabs)/profile/index";
-import { fireEvent, render, waitFor } from "@testing-library/react-native";
+import { fireEvent, render, waitFor, act } from "@testing-library/react-native";
 import React from "react";
 import { Alert } from "react-native";
 
@@ -117,6 +117,7 @@ jest.spyOn(Alert, "alert");
 
 describe("ProfileScreen Layout", () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     mockAuthUser = {
       username: "Ali Aydin",
       app_usage_mode: "MENTOR",
@@ -124,8 +125,6 @@ describe("ProfileScreen Layout", () => {
     mockAvailabilityQuery.mockReturnValue({ data: undefined });
     mockMatchesQuery.mockReturnValue({ data: [] });
     mockMyCommunitiesQuery.mockReturnValue({ data: [] });
-    mockRouterPush.mockClear();
-    (Alert.alert as jest.Mock).mockClear?.();
     mockUpdateProfileMutateAsync.mockResolvedValue({
       display_name: "Ali Aydin",
       bio: "Profile bio",
@@ -285,14 +284,19 @@ describe("ProfileScreen Layout", () => {
     fireEvent.press(getByTestId("profile-edit-button"));
     fireEvent.press(await findByTestId("avatar-picker-button"));
     expect(await findByTestId("avatar-preview")).toBeTruthy();
-    fireEvent.press(getByTestId("save-button"));
+    
+    await act(async () => {
+      fireEvent.press(getByTestId("save-button"));
+    });
 
     await waitFor(() => {
-      expect(mockUpdateProfileMutateAsync).toHaveBeenCalledWith({
-        username: "Ali Aydin",
-        display_name: "Ali Aydin",
-        bio: "Profile bio",
-      });
+      expect(mockUpdateProfileMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          username: "Ali Aydin",
+          display_name: "Ali Aydin",
+          bio: "Profile bio",
+        }),
+      );
       expect(mockUploadProfilePicture).toHaveBeenCalledWith({
         uri: "file:///tmp/avatar.jpg",
         name: "avatar.jpg",
@@ -313,9 +317,25 @@ describe("ProfileScreen Layout", () => {
 
     fireEvent.press(getByTestId("profile-edit-button"));
     fireEvent.press(await findByTestId("avatar-remove-button"));
-    fireEvent.press(getByTestId("save-button"));
+
+    // Handle Alert
+    const [title, message, buttons] = (Alert.alert as jest.Mock).mock.calls[0];
+    const removeButton = buttons!.find((b: any) => b.text === "Remove");
+    
+    await act(async () => {
+      removeButton!.onPress!();
+    });
+
+    await act(async () => {
+      fireEvent.press(getByTestId("save-button"));
+    });
 
     await waitFor(() => {
+      expect(mockUpdateProfileMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          picture_url: "",
+        }),
+      );
       expect(mockDeleteProfilePicture).toHaveBeenCalledTimes(1);
       expect(queryByTestId("profile-avatar-image")).toBeNull();
       expect(getByTestId("profile-avatar-fallback")).toBeTruthy();

--- a/mobile/__tests__/app/profile.test.tsx
+++ b/mobile/__tests__/app/profile.test.tsx
@@ -6,12 +6,20 @@ import { Alert } from "react-native";
 const mockMatchesQuery = jest.fn();
 const mockAvailabilityQuery = jest.fn();
 const mockMyCommunitiesQuery = jest.fn();
+const mockUpdateProfileMutateAsync = jest.fn();
+const mockUploadProfilePicture = jest.fn();
+const mockDeleteProfilePicture = jest.fn();
 let mockAuthUser = {
   username: "Ali Aydin",
   app_usage_mode: "MENTOR",
 };
+const mockLaunchImageLibraryAsync = jest.fn();
 
 jest.mock("@expo/vector-icons", () => ({ Ionicons: "View" }));
+jest.mock("expo-image-picker", () => ({
+  launchImageLibraryAsync: (...args: unknown[]) =>
+    mockLaunchImageLibraryAsync(...args),
+}));
 jest.mock("@/components/notifications/NotificationBell", () => ({
   NotificationBell: () => null,
 }));
@@ -72,7 +80,7 @@ jest.mock("@/lib/queries/profile", () => ({
     error: null,
   }),
   useUpdateOwnProfileMutation: () => ({
-    mutateAsync: jest.fn(),
+    mutateAsync: mockUpdateProfileMutateAsync,
     isPending: false,
   }),
   useCreateProfilePostMutation: () => ({
@@ -83,6 +91,13 @@ jest.mock("@/lib/queries/profile", () => ({
     data: { count: 0, results: [] },
     isLoading: false,
   }),
+}));
+
+jest.mock("@/lib/queries/uploads", () => ({
+  uploadProfilePicture: (...args: unknown[]) =>
+    mockUploadProfilePicture(...args),
+  deleteProfilePicture: (...args: unknown[]) =>
+    mockDeleteProfilePicture(...args),
 }));
 
 jest.mock("@/lib/queries/communityTags", () => ({
@@ -111,6 +126,31 @@ describe("ProfileScreen Layout", () => {
     mockMyCommunitiesQuery.mockReturnValue({ data: [] });
     mockRouterPush.mockClear();
     (Alert.alert as jest.Mock).mockClear?.();
+    mockUpdateProfileMutateAsync.mockResolvedValue({
+      display_name: "Ali Aydin",
+      bio: "Profile bio",
+      picture_url: "https://cdn.example.com/current.jpg",
+    });
+    mockUploadProfilePicture.mockResolvedValue({
+      detail: "Profile picture uploaded.",
+      picture_url: "https://cdn.example.com/new-avatar.jpg",
+    });
+    mockDeleteProfilePicture.mockResolvedValue({
+      detail: "Profile picture removed.",
+      picture_url: "",
+    });
+    mockLaunchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [
+        {
+          uri: "file:///tmp/avatar.jpg",
+          fileName: "avatar.jpg",
+          mimeType: "image/jpeg",
+          width: 512,
+          height: 512,
+        },
+      ],
+    });
 
     (globalThis.fetch as jest.Mock) = jest
       .fn()
@@ -119,6 +159,7 @@ describe("ProfileScreen Layout", () => {
         json: async () => ({
           full_name: "Ali Aydin",
           bio: "Profile bio",
+          picture_url: "https://cdn.example.com/current.jpg",
           skills: ["React", "Testing"],
         }),
       })
@@ -206,6 +247,7 @@ describe("ProfileScreen Layout", () => {
         json: async () => ({
           full_name: "Ece Yilmaz",
           bio: "Profile bio",
+          picture_url: "",
           skills: ["React", "Testing"],
         }),
       })
@@ -233,6 +275,51 @@ describe("ProfileScreen Layout", () => {
 
     fireEvent.press(getByTestId("settings-button"));
     expect(mockRouterPush).toHaveBeenCalledWith("/settings");
+  });
+
+  it("loads the current avatar and updates it after profile edit save", async () => {
+    const { findByTestId, getByTestId } = render(<ProfileScreen />);
+
+    expect(await findByTestId("profile-avatar-image")).toBeTruthy();
+
+    fireEvent.press(getByTestId("profile-edit-button"));
+    fireEvent.press(await findByTestId("avatar-picker-button"));
+    expect(await findByTestId("avatar-preview")).toBeTruthy();
+    fireEvent.press(getByTestId("save-button"));
+
+    await waitFor(() => {
+      expect(mockUpdateProfileMutateAsync).toHaveBeenCalledWith({
+        username: "Ali Aydin",
+        display_name: "Ali Aydin",
+        bio: "Profile bio",
+      });
+      expect(mockUploadProfilePicture).toHaveBeenCalledWith({
+        uri: "file:///tmp/avatar.jpg",
+        name: "avatar.jpg",
+        type: "image/jpeg",
+      });
+      expect(getByTestId("profile-avatar-image").props.source).toEqual({
+        uri: "https://cdn.example.com/new-avatar.jpg",
+      });
+    });
+  });
+
+  it("removes the current avatar from the edit modal", async () => {
+    const { findByTestId, getByTestId, queryByTestId } = render(
+      <ProfileScreen />,
+    );
+
+    await findByTestId("profile-avatar-image");
+
+    fireEvent.press(getByTestId("profile-edit-button"));
+    fireEvent.press(await findByTestId("avatar-remove-button"));
+    fireEvent.press(getByTestId("save-button"));
+
+    await waitFor(() => {
+      expect(mockDeleteProfilePicture).toHaveBeenCalledTimes(1);
+      expect(queryByTestId("profile-avatar-image")).toBeNull();
+      expect(getByTestId("profile-avatar-fallback")).toBeTruthy();
+    });
   });
 
   it("does not crash when profile fetch fails", async () => {

--- a/mobile/__tests__/app/tabs-layout.test.tsx
+++ b/mobile/__tests__/app/tabs-layout.test.tsx
@@ -74,12 +74,14 @@ describe("TabLayout", () => {
     expect(getByTestId("tab-screen-user/[username]/posts")).toBeTruthy();
     expect(getByTestId("tab-screen-profile/posts")).toBeTruthy();
     expect(getByTestId("tab-screen-community/[tagId]/index")).toBeTruthy();
+    expect(getByTestId("tab-screen-community/create")).toBeTruthy();
     expect(getByTestId("tab-screen-community/[tagId]/members")).toBeTruthy();
-    
+
     expect(queryByTestId("visible-tab-user/[username]/index")).toBeNull();
     expect(queryByTestId("visible-tab-user/[username]/posts")).toBeNull();
     expect(queryByTestId("visible-tab-profile/posts")).toBeNull();
     expect(queryByTestId("visible-tab-community/[tagId]/index")).toBeNull();
+    expect(queryByTestId("visible-tab-community/create")).toBeNull();
     expect(queryByTestId("visible-tab-community/[tagId]/members")).toBeNull();
   });
 

--- a/mobile/__tests__/components/community/CommunityPostComposer.test.tsx
+++ b/mobile/__tests__/components/community/CommunityPostComposer.test.tsx
@@ -3,9 +3,40 @@ import React from "react";
 
 import { CommunityPostComposer } from "@/components/community/CommunityPostComposer";
 
+const mockLaunchImageLibraryAsync = jest.fn();
+const mockUploadPostMedia = jest.fn();
+
 jest.mock("@expo/vector-icons", () => ({ Ionicons: "View" }));
 
+jest.mock("expo-image-picker", () => ({
+  launchImageLibraryAsync: (...args: unknown[]) =>
+    mockLaunchImageLibraryAsync(...args),
+}));
+
+jest.mock("@/lib/queries/uploads", () => ({
+  uploadPostMedia: (...args: unknown[]) => mockUploadPostMedia(...args),
+}));
+
 describe("CommunityPostComposer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLaunchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [
+        {
+          uri: "file:///tmp/community-photo.png",
+          fileName: "community-photo.png",
+          mimeType: "image/png",
+          width: 800,
+          height: 800,
+        },
+      ],
+    });
+    mockUploadPostMedia.mockResolvedValue({
+      url: "https://cdn.example.com/community-photo.jpg",
+    });
+  });
+
   it("submits trimmed content, selected type, and profile visibility", async () => {
     const onSubmit = jest.fn().mockResolvedValue(true);
 
@@ -30,6 +61,39 @@ describe("CommunityPostComposer", () => {
         event_type: "progress",
         content: "Community update",
         show_on_profile: true,
+      });
+    });
+  });
+
+  it("uploads selected media before submitting community posts", async () => {
+    const onSubmit = jest.fn().mockResolvedValue(true);
+
+    const { getByTestId, getByPlaceholderText } = render(
+      <CommunityPostComposer onSubmit={onSubmit} />,
+    );
+
+    fireEvent.press(getByTestId("community-composer-media-button"));
+    await waitFor(() => {
+      expect(getByTestId("community-composer-media-preview")).toBeTruthy();
+    });
+
+    fireEvent.changeText(
+      getByPlaceholderText("What is happening in this community?"),
+      "  Photo update  ",
+    );
+    fireEvent.press(getByTestId("community-composer-submit"));
+
+    await waitFor(() => {
+      expect(mockUploadPostMedia).toHaveBeenCalledWith({
+        uri: "file:///tmp/community-photo.png",
+        name: "community-photo.png",
+        type: "image/png",
+      });
+      expect(onSubmit).toHaveBeenCalledWith({
+        event_type: "social",
+        content: "Photo update",
+        media_url: "https://cdn.example.com/community-photo.jpg",
+        show_on_profile: false,
       });
     });
   });

--- a/mobile/__tests__/components/community/CommunityPostComposer.test.tsx
+++ b/mobile/__tests__/components/community/CommunityPostComposer.test.tsx
@@ -1,38 +1,29 @@
-import { fireEvent, render, waitFor } from "@testing-library/react-native";
+import { fireEvent, render, waitFor, act } from "@testing-library/react-native";
 import React from "react";
 
 import { CommunityPostComposer } from "@/components/community/CommunityPostComposer";
-
-const mockLaunchImageLibraryAsync = jest.fn();
-const mockUploadPostMedia = jest.fn();
+import { pickPostMediaFile } from "@/lib/uploads/picker";
+import { uploadPostMedia } from "@/lib/queries/uploads";
 
 jest.mock("@expo/vector-icons", () => ({ Ionicons: "View" }));
 
-jest.mock("expo-image-picker", () => ({
-  launchImageLibraryAsync: (...args: unknown[]) =>
-    mockLaunchImageLibraryAsync(...args),
+jest.mock("@/lib/uploads/picker", () => ({
+  pickPostMediaFile: jest.fn(),
 }));
 
 jest.mock("@/lib/queries/uploads", () => ({
-  uploadPostMedia: (...args: unknown[]) => mockUploadPostMedia(...args),
+  uploadPostMedia: jest.fn(),
 }));
 
 describe("CommunityPostComposer", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockLaunchImageLibraryAsync.mockResolvedValue({
-      canceled: false,
-      assets: [
-        {
-          uri: "file:///tmp/community-photo.png",
-          fileName: "community-photo.png",
-          mimeType: "image/png",
-          width: 800,
-          height: 800,
-        },
-      ],
+    (pickPostMediaFile as jest.Mock).mockResolvedValue({
+      uri: "file:///tmp/community-photo.png",
+      name: "community-photo.png",
+      type: "image/png",
     });
-    mockUploadPostMedia.mockResolvedValue({
+    (uploadPostMedia as jest.Mock).mockResolvedValue({
       url: "https://cdn.example.com/community-photo.jpg",
     });
   });
@@ -54,7 +45,10 @@ describe("CommunityPostComposer", () => {
       "valueChange",
       true,
     );
-    fireEvent.press(getByTestId("community-composer-submit"));
+    
+    await act(async () => {
+      fireEvent.press(getByTestId("community-composer-submit"));
+    });
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith({
@@ -72,7 +66,10 @@ describe("CommunityPostComposer", () => {
       <CommunityPostComposer onSubmit={onSubmit} />,
     );
 
-    fireEvent.press(getByTestId("community-composer-media-button"));
+    await act(async () => {
+      fireEvent.press(getByTestId("community-composer-media-button"));
+    });
+    
     await waitFor(() => {
       expect(getByTestId("community-composer-media-preview")).toBeTruthy();
     });
@@ -81,10 +78,13 @@ describe("CommunityPostComposer", () => {
       getByPlaceholderText("What is happening in this community?"),
       "  Photo update  ",
     );
-    fireEvent.press(getByTestId("community-composer-submit"));
+    
+    await act(async () => {
+      fireEvent.press(getByTestId("community-composer-submit"));
+    });
 
     await waitFor(() => {
-      expect(mockUploadPostMedia).toHaveBeenCalledWith({
+      expect(uploadPostMedia).toHaveBeenCalledWith({
         uri: "file:///tmp/community-photo.png",
         name: "community-photo.png",
         type: "image/png",

--- a/mobile/__tests__/components/connections/MenteeCard.test.tsx
+++ b/mobile/__tests__/components/connections/MenteeCard.test.tsx
@@ -23,6 +23,28 @@ describe("MenteeCard — rendering", () => {
     const { queryAllByTestId } = render(<MenteeCard {...baseProps} tags={[]} />);
     expect(queryAllByTestId("mentee-tag")).toHaveLength(0);
   });
+
+  it("renders avatar image when avatarUrl is provided", () => {
+    const { getByTestId, queryByTestId } = render(
+      <MenteeCard
+        {...baseProps}
+        avatarUrl="https://cdn.example.com/john.jpg"
+      />,
+    );
+
+    expect(getByTestId("mentee-avatar-image")).toBeTruthy();
+    expect(queryByTestId("mentee-avatar-fallback")).toBeNull();
+  });
+
+  it("falls back to initials when avatarUrl is missing", () => {
+    const { getByTestId, queryByTestId, getByText } = render(
+      <MenteeCard {...baseProps} />,
+    );
+
+    expect(getByTestId("mentee-avatar-fallback")).toBeTruthy();
+    expect(queryByTestId("mentee-avatar-image")).toBeNull();
+    expect(getByText("JS")).toBeTruthy();
+  });
 });
 
 describe("MenteeCard — interactions", () => {

--- a/mobile/__tests__/components/connections/MentorCard.test.tsx
+++ b/mobile/__tests__/components/connections/MentorCard.test.tsx
@@ -18,6 +18,25 @@ describe("MentorCard — rendering", () => {
     expect(getByTestId("mentor-message-button")).toBeTruthy();
     expect(getByTestId("mentor-more-button")).toBeTruthy();
   });
+
+  it("renders avatar image when avatarUrl is provided", () => {
+    const { getByTestId, queryByTestId } = render(
+      <MentorCard {...baseProps} avatarUrl="https://cdn.example.com/jane.jpg" />,
+    );
+
+    expect(getByTestId("mentor-avatar-image")).toBeTruthy();
+    expect(queryByTestId("mentor-avatar-fallback")).toBeNull();
+  });
+
+  it("falls back to initials when avatarUrl is missing", () => {
+    const { getByTestId, queryByTestId, getByText } = render(
+      <MentorCard {...baseProps} />,
+    );
+
+    expect(getByTestId("mentor-avatar-fallback")).toBeTruthy();
+    expect(queryByTestId("mentor-avatar-image")).toBeNull();
+    expect(getByText("JD")).toBeTruthy();
+  });
 });
 
 describe("MentorCard — interactions", () => {

--- a/mobile/__tests__/components/connections/PendingRequestCard.test.tsx
+++ b/mobile/__tests__/components/connections/PendingRequestCard.test.tsx
@@ -49,6 +49,28 @@ describe("PendingRequestCard — rendering", () => {
     );
     expect(getByTestId("pending-reschedule-badge")).toBeTruthy();
   });
+
+  it("renders avatar image when avatarUrl is provided", () => {
+    const { getByTestId, queryByTestId } = render(
+      <PendingRequestCard
+        {...baseProps}
+        avatarUrl="https://cdn.example.com/alice.jpg"
+      />,
+    );
+
+    expect(getByTestId("pending-avatar-image")).toBeTruthy();
+    expect(queryByTestId("pending-avatar-fallback")).toBeNull();
+  });
+
+  it("falls back to initials when avatarUrl is missing", () => {
+    const { getByTestId, queryByTestId, getByText } = render(
+      <PendingRequestCard {...baseProps} />,
+    );
+
+    expect(getByTestId("pending-avatar-fallback")).toBeTruthy();
+    expect(queryByTestId("pending-avatar-image")).toBeNull();
+    expect(getByText("AS")).toBeTruthy();
+  });
 });
 
 describe("PendingRequestCard — interactions", () => {

--- a/mobile/__tests__/components/discover/MentorCard.test.tsx
+++ b/mobile/__tests__/components/discover/MentorCard.test.tsx
@@ -1,0 +1,44 @@
+import { MentorCard } from "@/components/discover/MentorCard";
+import type { DiscoverMentorProfile } from "@/lib/discover/types";
+import { render } from "@testing-library/react-native";
+import React from "react";
+
+const profile: DiscoverMentorProfile = {
+  id: "profile-1",
+  username: "ada",
+  full_name: "Ada Lovelace",
+  bio: "Mentors analytical engine projects.",
+  hidden: false,
+  picture_url: "",
+  title: "Mentor",
+  show_initials_only: false,
+  skills: ["Math"],
+  average_rating: "5.0",
+  total_mentee_count: 4,
+};
+
+describe("Discover MentorCard", () => {
+  it("renders profile pictures from discovery payloads", () => {
+    const { getByTestId, queryByTestId } = render(
+      <MentorCard
+        profile={{
+          ...profile,
+          picture_url: "https://cdn.example.com/ada.jpg",
+        }}
+      />,
+    );
+
+    expect(getByTestId("discover-avatar-ada-image")).toBeTruthy();
+    expect(queryByTestId("discover-avatar-ada-fallback")).toBeNull();
+  });
+
+  it("falls back to initials when discovery has no profile picture", () => {
+    const { getByTestId, queryByTestId, getByText } = render(
+      <MentorCard profile={profile} />,
+    );
+
+    expect(getByTestId("discover-avatar-ada-fallback")).toBeTruthy();
+    expect(queryByTestId("discover-avatar-ada-image")).toBeNull();
+    expect(getByText("AL")).toBeTruthy();
+  });
+});

--- a/mobile/__tests__/components/profile/EditProfileModal.test.tsx
+++ b/mobile/__tests__/components/profile/EditProfileModal.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, waitFor } from "@testing-library/react-native";
+import { View, Alert } from "react-native";
+import { fireEvent, render, waitFor, act } from "@testing-library/react-native";
 import React from "react";
 
 import { EditProfileModal } from "@/components/profile/EditProfileModal";
@@ -13,6 +14,8 @@ jest.mock("expo-image-picker", () => ({
 }));
 
 describe("EditProfileModal", () => {
+  const alertSpy = jest.spyOn(Alert, "alert");
+
   beforeEach(() => {
     jest.clearAllMocks();
     globalThis.alert = jest.fn();
@@ -31,7 +34,7 @@ describe("EditProfileModal", () => {
   });
 
   it("saves trimmed profile values via save button", async () => {
-    const onSave = jest.fn();
+    const onSave = jest.fn().mockResolvedValue(true);
     const onClose = jest.fn();
 
     const { getByTestId } = render(
@@ -46,7 +49,9 @@ describe("EditProfileModal", () => {
     fireEvent.changeText(getByTestId("name-input"), "  Ali Aydin  ");
     fireEvent.changeText(getByTestId("bio-input"), "  Loves mentoring on React Native.  ");
 
-    fireEvent.press(getByTestId("save-button"));
+    await act(async () => {
+      fireEvent.press(getByTestId("save-button"));
+    });
 
     await waitFor(() => {
       expect(onSave).toHaveBeenCalledWith({
@@ -58,7 +63,7 @@ describe("EditProfileModal", () => {
       });
       expect(onClose).toHaveBeenCalled();
     });
-  });
+  }, 10000);
 
   it("blocks save and alerts when name is empty", () => {
     const onSave = jest.fn();
@@ -95,19 +100,6 @@ describe("EditProfileModal", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("does not render an unsupported cover photo edit button", () => {
-    const { queryByText } = render(
-      <EditProfileModal
-        visible
-        onClose={jest.fn()}
-        initialData={{ name: "Ali", bio: "Initial bio" }}
-        onSave={jest.fn()}
-      />,
-    );
-
-    expect(queryByText("Edit Cover")).toBeNull();
-  });
-
   it("previews a picked avatar and includes it in save data", async () => {
     const onSave = jest.fn().mockResolvedValue(true);
 
@@ -124,11 +116,15 @@ describe("EditProfileModal", () => {
       />,
     );
 
-    fireEvent.press(getByTestId("avatar-picker-button"));
+    await act(async () => {
+      fireEvent.press(getByTestId("avatar-picker-button"));
+    });
 
     expect(await findByTestId("avatar-preview")).toBeTruthy();
 
-    fireEvent.press(getByTestId("save-button"));
+    await act(async () => {
+      fireEvent.press(getByTestId("save-button"));
+    });
 
     await waitFor(() => {
       expect(onSave).toHaveBeenCalledWith(
@@ -161,10 +157,25 @@ describe("EditProfileModal", () => {
     );
 
     expect(getByTestId("avatar-preview")).toBeTruthy();
-    fireEvent.press(getByTestId("avatar-remove-button"));
+    
+    await act(async () => {
+      fireEvent.press(getByTestId("avatar-remove-button"));
+    });
+
+    // Handle Alert.alert
+    const [title, message, buttons] = alertSpy.mock.calls[0];
+    expect(title).toBe("Remove Profile Photo");
+    const removeButton = buttons!.find((b: any) => b.text === "Remove");
+    
+    await act(async () => {
+      removeButton!.onPress!();
+    });
+
     expect(queryByTestId("avatar-preview")).toBeNull();
 
-    fireEvent.press(getByTestId("save-button"));
+    await act(async () => {
+      fireEvent.press(getByTestId("save-button"));
+    });
 
     await waitFor(() => {
       expect(onSave).toHaveBeenCalledWith(

--- a/mobile/__tests__/components/profile/EditProfileModal.test.tsx
+++ b/mobile/__tests__/components/profile/EditProfileModal.test.tsx
@@ -95,6 +95,19 @@ describe("EditProfileModal", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("does not render an unsupported cover photo edit button", () => {
+    const { queryByText } = render(
+      <EditProfileModal
+        visible
+        onClose={jest.fn()}
+        initialData={{ name: "Ali", bio: "Initial bio" }}
+        onSave={jest.fn()}
+      />,
+    );
+
+    expect(queryByText("Edit Cover")).toBeNull();
+  });
+
   it("previews a picked avatar and includes it in save data", async () => {
     const onSave = jest.fn().mockResolvedValue(true);
 

--- a/mobile/__tests__/components/profile/EditProfileModal.test.tsx
+++ b/mobile/__tests__/components/profile/EditProfileModal.test.tsx
@@ -1,17 +1,36 @@
-import { fireEvent, render } from "@testing-library/react-native";
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
 import React from "react";
 
 import { EditProfileModal } from "@/components/profile/EditProfileModal";
 
+const mockLaunchImageLibraryAsync = jest.fn();
+
 jest.mock("@expo/vector-icons", () => ({ Ionicons: "View" }));
+
+jest.mock("expo-image-picker", () => ({
+  launchImageLibraryAsync: (...args: unknown[]) =>
+    mockLaunchImageLibraryAsync(...args),
+}));
 
 describe("EditProfileModal", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     globalThis.alert = jest.fn();
+    mockLaunchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [
+        {
+          uri: "file:///tmp/avatar.jpg",
+          fileName: "avatar.jpg",
+          mimeType: "image/jpeg",
+          width: 512,
+          height: 512,
+        },
+      ],
+    });
   });
 
-  it("saves trimmed profile values via save button", () => {
+  it("saves trimmed profile values via save button", async () => {
     const onSave = jest.fn();
     const onClose = jest.fn();
 
@@ -29,11 +48,16 @@ describe("EditProfileModal", () => {
 
     fireEvent.press(getByTestId("save-button"));
 
-    expect(onSave).toHaveBeenCalledWith({
-      name: "Ali Aydin",
-      bio: "Loves mentoring on React Native.",
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith({
+        name: "Ali Aydin",
+        bio: "Loves mentoring on React Native.",
+        pictureFile: null,
+        pictureUrl: undefined,
+        removePicture: false,
+      });
+      expect(onClose).toHaveBeenCalled();
     });
-    expect(onClose).toHaveBeenCalled();
   });
 
   it("blocks save and alerts when name is empty", () => {
@@ -69,5 +93,73 @@ describe("EditProfileModal", () => {
 
     fireEvent.press(getByTestId("close-button"));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("previews a picked avatar and includes it in save data", async () => {
+    const onSave = jest.fn().mockResolvedValue(true);
+
+    const { findByTestId, getByTestId } = render(
+      <EditProfileModal
+        visible
+        onClose={jest.fn()}
+        initialData={{
+          name: "Ali",
+          bio: "Initial bio",
+          pictureUrl: "https://cdn.example.com/current.jpg",
+        }}
+        onSave={onSave}
+      />,
+    );
+
+    fireEvent.press(getByTestId("avatar-picker-button"));
+
+    expect(await findByTestId("avatar-preview")).toBeTruthy();
+
+    fireEvent.press(getByTestId("save-button"));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pictureFile: {
+            uri: "file:///tmp/avatar.jpg",
+            name: "avatar.jpg",
+            type: "image/jpeg",
+          },
+          removePicture: false,
+        }),
+      );
+    });
+  });
+
+  it("marks the current avatar for removal", async () => {
+    const onSave = jest.fn().mockResolvedValue(true);
+
+    const { getByTestId, queryByTestId } = render(
+      <EditProfileModal
+        visible
+        onClose={jest.fn()}
+        initialData={{
+          name: "Ali",
+          bio: "Initial bio",
+          pictureUrl: "https://cdn.example.com/current.jpg",
+        }}
+        onSave={onSave}
+      />,
+    );
+
+    expect(getByTestId("avatar-preview")).toBeTruthy();
+    fireEvent.press(getByTestId("avatar-remove-button"));
+    expect(queryByTestId("avatar-preview")).toBeNull();
+
+    fireEvent.press(getByTestId("save-button"));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pictureFile: null,
+          removePicture: true,
+        }),
+      );
+    });
   });
 });

--- a/mobile/__tests__/components/profile/ProfilePostCard.test.tsx
+++ b/mobile/__tests__/components/profile/ProfilePostCard.test.tsx
@@ -1,0 +1,93 @@
+import { ProfilePostCard } from "@/components/profile/ProfilePostCard";
+import type { ProfilePost } from "@/lib/queries/profile";
+import { fireEvent, render } from "@testing-library/react-native";
+import React from "react";
+import { Linking } from "react-native";
+
+jest.mock("@expo/vector-icons", () => ({ Ionicons: "View" }));
+
+const openUrlSpy = jest
+  .spyOn(Linking, "openURL")
+  .mockImplementation(() => Promise.resolve({} as never));
+
+function buildPost(overrides: Partial<ProfilePost> = {}): ProfilePost {
+  return {
+    id: "post-1",
+    source_id: "post-1",
+    category: "CoP",
+    event_type: "social",
+    content: "A post",
+    media_url: null,
+    timestamp: "2026-05-06T10:00:00Z",
+    created_at: "2026-05-06T10:00:00Z",
+    last_edited: null,
+    show_on_profile: true,
+    community_id: "tag-1",
+    actor_role: null,
+    author: {
+      id: "profile-1",
+      username: "ali",
+      display_name: "Ali Mehmet",
+      picture_url: "",
+      title: "",
+    },
+    ...overrides,
+  };
+}
+
+describe("ProfilePostCard", () => {
+  beforeEach(() => {
+    openUrlSpy.mockClear();
+  });
+
+  it("renders image media in a larger filled preview", () => {
+    const { getByTestId, queryByTestId } = render(
+      <ProfilePostCard
+        expanded
+        post={buildPost({
+          media_url: "https://cdn.example.com/profile-photo.jpg",
+        })}
+      />,
+    );
+
+    const image = getByTestId("post-card-media-post-1");
+
+    expect(image.props.resizeMode).toBe("cover");
+    expect(image.props.className).toContain("h-72");
+    expect(queryByTestId("post-card-attachment-post-1")).toBeNull();
+  });
+
+  it("keeps preview image media compact but still filled", () => {
+    const { getByTestId } = render(
+      <ProfilePostCard
+        post={buildPost({
+          media_url: "https://cdn.example.com/profile-photo.webp",
+        })}
+      />,
+    );
+
+    const image = getByTestId("post-card-media-post-1");
+
+    expect(image.props.resizeMode).toBe("cover");
+    expect(image.props.className).toContain("h-52");
+  });
+
+  it("renders PDF media as an attachment without showing the raw URL", () => {
+    const { getByTestId, queryByTestId, queryByText } = render(
+      <ProfilePostCard
+        post={buildPost({
+          media_url: "https://cdn.example.com/files/resume.pdf",
+        })}
+      />,
+    );
+
+    fireEvent.press(getByTestId("post-card-attachment-post-1"));
+
+    expect(queryByTestId("post-card-media-post-1")).toBeNull();
+    expect(queryByText("https://cdn.example.com/files/resume.pdf")).toBeNull();
+    expect(queryByText("Attachment")).toBeTruthy();
+    expect(openUrlSpy).toHaveBeenCalledWith(
+      "https://cdn.example.com/files/resume.pdf",
+    );
+  });
+});

--- a/mobile/__tests__/components/profile/ProfilePostComposer.test.tsx
+++ b/mobile/__tests__/components/profile/ProfilePostComposer.test.tsx
@@ -1,38 +1,29 @@
-import { fireEvent, render, waitFor } from "@testing-library/react-native";
+import { fireEvent, render, waitFor, act } from "@testing-library/react-native";
 import React from "react";
 
 import { ProfilePostComposer } from "@/components/profile/ProfilePostComposer";
-
-const mockLaunchImageLibraryAsync = jest.fn();
-const mockUploadPostMedia = jest.fn();
+import { pickPostMediaFile } from "@/lib/uploads/picker";
+import { uploadPostMedia } from "@/lib/queries/uploads";
 
 jest.mock("@expo/vector-icons", () => ({ Ionicons: "View" }));
 
-jest.mock("expo-image-picker", () => ({
-  launchImageLibraryAsync: (...args: unknown[]) =>
-    mockLaunchImageLibraryAsync(...args),
+jest.mock("@/lib/uploads/picker", () => ({
+  pickPostMediaFile: jest.fn(),
 }));
 
 jest.mock("@/lib/queries/uploads", () => ({
-  uploadPostMedia: (...args: unknown[]) => mockUploadPostMedia(...args),
+  uploadPostMedia: jest.fn(),
 }));
 
 describe("ProfilePostComposer", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockLaunchImageLibraryAsync.mockResolvedValue({
-      canceled: false,
-      assets: [
-        {
-          uri: "file:///tmp/profile-photo.jpg",
-          fileName: "profile-photo.jpg",
-          mimeType: "image/jpeg",
-          width: 1200,
-          height: 800,
-        },
-      ],
+    (pickPostMediaFile as jest.Mock).mockResolvedValue({
+      uri: "file:///tmp/profile-photo.jpg",
+      name: "profile-photo.jpg",
+      type: "image/jpeg",
     });
-    mockUploadPostMedia.mockResolvedValue({
+    (uploadPostMedia as jest.Mock).mockResolvedValue({
       url: "https://cdn.example.com/profile-photo.jpg",
     });
   });
@@ -50,7 +41,10 @@ describe("ProfilePostComposer", () => {
       "  Hello profile  ",
     );
     fireEvent.press(getByTestId("profile-composer-type-achievement"));
-    fireEvent.press(getByTestId("profile-composer-submit"));
+    
+    await act(async () => {
+      fireEvent.press(getByTestId("profile-composer-submit"));
+    });
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith({
@@ -59,7 +53,7 @@ describe("ProfilePostComposer", () => {
       });
       expect(onClose).toHaveBeenCalledTimes(1);
     });
-  });
+  }, 10000);
 
   it("uploads selected media before submitting the post", async () => {
     const onSubmit = jest.fn().mockResolvedValue(true);
@@ -69,7 +63,9 @@ describe("ProfilePostComposer", () => {
       <ProfilePostComposer visible onClose={onClose} onSubmit={onSubmit} />,
     );
 
-    fireEvent.press(getByTestId("profile-composer-media-button"));
+    await act(async () => {
+      fireEvent.press(getByTestId("profile-composer-media-button"));
+    });
 
     await waitFor(() => {
       expect(getByTestId("profile-composer-media-preview")).toBeTruthy();
@@ -79,10 +75,13 @@ describe("ProfilePostComposer", () => {
       getByPlaceholderText("What would you like to share?"),
       "  Post with photo  ",
     );
-    fireEvent.press(getByTestId("profile-composer-submit"));
+    
+    await act(async () => {
+      fireEvent.press(getByTestId("profile-composer-submit"));
+    });
 
     await waitFor(() => {
-      expect(mockUploadPostMedia).toHaveBeenCalledWith({
+      expect(uploadPostMedia).toHaveBeenCalledWith({
         uri: "file:///tmp/profile-photo.jpg",
         name: "profile-photo.jpg",
         type: "image/jpeg",
@@ -102,11 +101,17 @@ describe("ProfilePostComposer", () => {
       <ProfilePostComposer visible onClose={jest.fn()} onSubmit={onSubmit} />,
     );
 
-    fireEvent.press(getByTestId("profile-composer-media-button"));
+    await act(async () => {
+      fireEvent.press(getByTestId("profile-composer-media-button"));
+    });
+    
     await waitFor(() => {
       expect(getByTestId("profile-composer-media-preview")).toBeTruthy();
     });
-    fireEvent.press(getByTestId("profile-composer-media-remove"));
+    
+    await act(async () => {
+      fireEvent.press(getByTestId("profile-composer-media-remove"));
+    });
 
     expect(queryByTestId("profile-composer-media-preview")).toBeNull();
 
@@ -114,10 +119,13 @@ describe("ProfilePostComposer", () => {
       getByPlaceholderText("What would you like to share?"),
       "  Text only  ",
     );
-    fireEvent.press(getByTestId("profile-composer-submit"));
+    
+    await act(async () => {
+      fireEvent.press(getByTestId("profile-composer-submit"));
+    });
 
     await waitFor(() => {
-      expect(mockUploadPostMedia).not.toHaveBeenCalled();
+      expect(uploadPostMedia).not.toHaveBeenCalled();
       expect(onSubmit).toHaveBeenCalledWith({
         event_type: "social",
         content: "Text only",
@@ -126,21 +134,27 @@ describe("ProfilePostComposer", () => {
   });
 
   it("shows upload errors and does not submit when media upload fails", async () => {
-    mockUploadPostMedia.mockRejectedValueOnce(new Error("Upload failed"));
+    (uploadPostMedia as jest.Mock).mockRejectedValueOnce(new Error("Upload failed"));
     const onSubmit = jest.fn();
 
     const { findByTestId, getByTestId, getByPlaceholderText } = render(
       <ProfilePostComposer visible onClose={jest.fn()} onSubmit={onSubmit} />,
     );
 
-    fireEvent.press(getByTestId("profile-composer-media-button"));
+    await act(async () => {
+      fireEvent.press(getByTestId("profile-composer-media-button"));
+    });
+    
     await findByTestId("profile-composer-media-preview");
 
     fireEvent.changeText(
       getByPlaceholderText("What would you like to share?"),
       "  This should wait  ",
     );
-    fireEvent.press(getByTestId("profile-composer-submit"));
+    
+    await act(async () => {
+      fireEvent.press(getByTestId("profile-composer-submit"));
+    });
 
     expect(await findByTestId("profile-composer-media-error")).toBeTruthy();
     expect(onSubmit).not.toHaveBeenCalled();

--- a/mobile/__tests__/components/profile/ProfilePostComposer.test.tsx
+++ b/mobile/__tests__/components/profile/ProfilePostComposer.test.tsx
@@ -3,9 +3,40 @@ import React from "react";
 
 import { ProfilePostComposer } from "@/components/profile/ProfilePostComposer";
 
+const mockLaunchImageLibraryAsync = jest.fn();
+const mockUploadPostMedia = jest.fn();
+
 jest.mock("@expo/vector-icons", () => ({ Ionicons: "View" }));
 
+jest.mock("expo-image-picker", () => ({
+  launchImageLibraryAsync: (...args: unknown[]) =>
+    mockLaunchImageLibraryAsync(...args),
+}));
+
+jest.mock("@/lib/queries/uploads", () => ({
+  uploadPostMedia: (...args: unknown[]) => mockUploadPostMedia(...args),
+}));
+
 describe("ProfilePostComposer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLaunchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [
+        {
+          uri: "file:///tmp/profile-photo.jpg",
+          fileName: "profile-photo.jpg",
+          mimeType: "image/jpeg",
+          width: 1200,
+          height: 800,
+        },
+      ],
+    });
+    mockUploadPostMedia.mockResolvedValue({
+      url: "https://cdn.example.com/profile-photo.jpg",
+    });
+  });
+
   it("submits trimmed content and selected event type", async () => {
     const onSubmit = jest.fn().mockResolvedValue(true);
     const onClose = jest.fn();
@@ -28,5 +59,90 @@ describe("ProfilePostComposer", () => {
       });
       expect(onClose).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("uploads selected media before submitting the post", async () => {
+    const onSubmit = jest.fn().mockResolvedValue(true);
+    const onClose = jest.fn();
+
+    const { getByTestId, getByPlaceholderText } = render(
+      <ProfilePostComposer visible onClose={onClose} onSubmit={onSubmit} />,
+    );
+
+    fireEvent.press(getByTestId("profile-composer-media-button"));
+
+    await waitFor(() => {
+      expect(getByTestId("profile-composer-media-preview")).toBeTruthy();
+    });
+
+    fireEvent.changeText(
+      getByPlaceholderText("What would you like to share?"),
+      "  Post with photo  ",
+    );
+    fireEvent.press(getByTestId("profile-composer-submit"));
+
+    await waitFor(() => {
+      expect(mockUploadPostMedia).toHaveBeenCalledWith({
+        uri: "file:///tmp/profile-photo.jpg",
+        name: "profile-photo.jpg",
+        type: "image/jpeg",
+      });
+      expect(onSubmit).toHaveBeenCalledWith({
+        event_type: "social",
+        content: "Post with photo",
+        media_url: "https://cdn.example.com/profile-photo.jpg",
+      });
+    });
+  });
+
+  it("removes selected media before submitting", async () => {
+    const onSubmit = jest.fn().mockResolvedValue(true);
+
+    const { getByTestId, getByPlaceholderText, queryByTestId } = render(
+      <ProfilePostComposer visible onClose={jest.fn()} onSubmit={onSubmit} />,
+    );
+
+    fireEvent.press(getByTestId("profile-composer-media-button"));
+    await waitFor(() => {
+      expect(getByTestId("profile-composer-media-preview")).toBeTruthy();
+    });
+    fireEvent.press(getByTestId("profile-composer-media-remove"));
+
+    expect(queryByTestId("profile-composer-media-preview")).toBeNull();
+
+    fireEvent.changeText(
+      getByPlaceholderText("What would you like to share?"),
+      "  Text only  ",
+    );
+    fireEvent.press(getByTestId("profile-composer-submit"));
+
+    await waitFor(() => {
+      expect(mockUploadPostMedia).not.toHaveBeenCalled();
+      expect(onSubmit).toHaveBeenCalledWith({
+        event_type: "social",
+        content: "Text only",
+      });
+    });
+  });
+
+  it("shows upload errors and does not submit when media upload fails", async () => {
+    mockUploadPostMedia.mockRejectedValueOnce(new Error("Upload failed"));
+    const onSubmit = jest.fn();
+
+    const { findByTestId, getByTestId, getByPlaceholderText } = render(
+      <ProfilePostComposer visible onClose={jest.fn()} onSubmit={onSubmit} />,
+    );
+
+    fireEvent.press(getByTestId("profile-composer-media-button"));
+    await findByTestId("profile-composer-media-preview");
+
+    fireEvent.changeText(
+      getByPlaceholderText("What would you like to share?"),
+      "  This should wait  ",
+    );
+    fireEvent.press(getByTestId("profile-composer-submit"));
+
+    expect(await findByTestId("profile-composer-media-error")).toBeTruthy();
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 });

--- a/mobile/__tests__/components/timeline/TimelineEventComposer.test.tsx
+++ b/mobile/__tests__/components/timeline/TimelineEventComposer.test.tsx
@@ -1,38 +1,29 @@
-import { fireEvent, render, waitFor } from "@testing-library/react-native";
+import { fireEvent, render, waitFor, act } from "@testing-library/react-native";
 import React from "react";
 
 import { TimelineEventComposer } from "@/components/timeline/TimelineEventComposer";
-
-const mockLaunchImageLibraryAsync = jest.fn();
-const mockUploadPostMedia = jest.fn();
+import { pickPostMediaFile } from "@/lib/uploads/picker";
+import { uploadPostMedia } from "@/lib/queries/uploads";
 
 jest.mock("@expo/vector-icons", () => ({ Ionicons: "View" }));
 
-jest.mock("expo-image-picker", () => ({
-  launchImageLibraryAsync: (...args: unknown[]) =>
-    mockLaunchImageLibraryAsync(...args),
+jest.mock("@/lib/uploads/picker", () => ({
+  pickPostMediaFile: jest.fn(),
 }));
 
 jest.mock("@/lib/queries/uploads", () => ({
-  uploadPostMedia: (...args: unknown[]) => mockUploadPostMedia(...args),
+  uploadPostMedia: jest.fn(),
 }));
 
 describe("TimelineEventComposer", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockLaunchImageLibraryAsync.mockResolvedValue({
-      canceled: false,
-      assets: [
-        {
-          uri: "file:///tmp/milestone.webp",
-          fileName: "milestone.webp",
-          mimeType: "image/webp",
-          width: 900,
-          height: 600,
-        },
-      ],
+    (pickPostMediaFile as jest.Mock).mockResolvedValue({
+      uri: "file:///tmp/milestone.webp",
+      name: "milestone.webp",
+      type: "image/webp",
     });
-    mockUploadPostMedia.mockResolvedValue({
+    (uploadPostMedia as jest.Mock).mockResolvedValue({
       url: "https://cdn.example.com/milestone.jpg",
     });
   });
@@ -55,7 +46,10 @@ describe("TimelineEventComposer", () => {
     );
     fireEvent.press(getByTestId("timeline-composer-type-progress"));
     fireEvent(getByTestId("timeline-composer-profile-toggle"), "valueChange", true);
-    fireEvent.press(getByTestId("timeline-composer-submit"));
+    
+    await act(async () => {
+      fireEvent.press(getByTestId("timeline-composer-submit"));
+    });
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith({
@@ -74,7 +68,10 @@ describe("TimelineEventComposer", () => {
       <TimelineEventComposer visible onClose={jest.fn()} onSubmit={onSubmit} />,
     );
 
-    fireEvent.press(getByTestId("timeline-composer-media-button"));
+    await act(async () => {
+      fireEvent.press(getByTestId("timeline-composer-media-button"));
+    });
+    
     await waitFor(() => {
       expect(getByTestId("timeline-composer-media-preview")).toBeTruthy();
     });
@@ -83,10 +80,13 @@ describe("TimelineEventComposer", () => {
       getByPlaceholderText("What happened on this journey?"),
       "  Added a diagram  ",
     );
-    fireEvent.press(getByTestId("timeline-composer-submit"));
+    
+    await act(async () => {
+      fireEvent.press(getByTestId("timeline-composer-submit"));
+    });
 
     await waitFor(() => {
-      expect(mockUploadPostMedia).toHaveBeenCalledWith({
+      expect(uploadPostMedia).toHaveBeenCalledWith({
         uri: "file:///tmp/milestone.webp",
         name: "milestone.webp",
         type: "image/webp",

--- a/mobile/__tests__/components/timeline/TimelineEventComposer.test.tsx
+++ b/mobile/__tests__/components/timeline/TimelineEventComposer.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+import { TimelineEventComposer } from "@/components/timeline/TimelineEventComposer";
+
+const mockLaunchImageLibraryAsync = jest.fn();
+const mockUploadPostMedia = jest.fn();
+
+jest.mock("@expo/vector-icons", () => ({ Ionicons: "View" }));
+
+jest.mock("expo-image-picker", () => ({
+  launchImageLibraryAsync: (...args: unknown[]) =>
+    mockLaunchImageLibraryAsync(...args),
+}));
+
+jest.mock("@/lib/queries/uploads", () => ({
+  uploadPostMedia: (...args: unknown[]) => mockUploadPostMedia(...args),
+}));
+
+describe("TimelineEventComposer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLaunchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [
+        {
+          uri: "file:///tmp/milestone.webp",
+          fileName: "milestone.webp",
+          mimeType: "image/webp",
+          width: 900,
+          height: 600,
+        },
+      ],
+    });
+    mockUploadPostMedia.mockResolvedValue({
+      url: "https://cdn.example.com/milestone.jpg",
+    });
+  });
+
+  it("submits trimmed milestone content and profile visibility", async () => {
+    const onSubmit = jest.fn().mockResolvedValue(true);
+    const onClose = jest.fn();
+
+    const { getByTestId, getByPlaceholderText } = render(
+      <TimelineEventComposer
+        visible
+        onClose={onClose}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.changeText(
+      getByPlaceholderText("What happened on this journey?"),
+      "  Finished the first sprint  ",
+    );
+    fireEvent.press(getByTestId("timeline-composer-type-progress"));
+    fireEvent(getByTestId("timeline-composer-profile-toggle"), "valueChange", true);
+    fireEvent.press(getByTestId("timeline-composer-submit"));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        event_type: "progress",
+        content: "Finished the first sprint",
+        show_on_profile: true,
+      });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("uploads selected media before submitting milestones", async () => {
+    const onSubmit = jest.fn().mockResolvedValue(true);
+
+    const { getByTestId, getByPlaceholderText } = render(
+      <TimelineEventComposer visible onClose={jest.fn()} onSubmit={onSubmit} />,
+    );
+
+    fireEvent.press(getByTestId("timeline-composer-media-button"));
+    await waitFor(() => {
+      expect(getByTestId("timeline-composer-media-preview")).toBeTruthy();
+    });
+
+    fireEvent.changeText(
+      getByPlaceholderText("What happened on this journey?"),
+      "  Added a diagram  ",
+    );
+    fireEvent.press(getByTestId("timeline-composer-submit"));
+
+    await waitFor(() => {
+      expect(mockUploadPostMedia).toHaveBeenCalledWith({
+        uri: "file:///tmp/milestone.webp",
+        name: "milestone.webp",
+        type: "image/webp",
+      });
+      expect(onSubmit).toHaveBeenCalledWith({
+        event_type: "achievement",
+        content: "Added a diagram",
+        media_url: "https://cdn.example.com/milestone.jpg",
+        show_on_profile: false,
+      });
+    });
+  });
+});

--- a/mobile/__tests__/lib/api-client.test.ts
+++ b/mobile/__tests__/lib/api-client.test.ts
@@ -1,4 +1,10 @@
-import { ApiError, apiGet, apiPatch, apiPost } from "@/lib/api/client";
+import {
+  ApiError,
+  apiGet,
+  apiPatch,
+  apiPost,
+  apiPostMultipart,
+} from "@/lib/api/client";
 import { API_BASE_URL } from "@/lib/api/config";
 
 const mockGetState = jest.fn();
@@ -152,6 +158,38 @@ describe("api client", () => {
     });
     const noContent = await apiPost<void>("/api/items/1/archive/");
     expect(noContent).toBeUndefined();
+  });
+
+  it("sends multipart POST without a JSON content type", async () => {
+    mockFetchResponse({
+      ok: true,
+      status: 201,
+      json: async () => ({ url: "https://cdn.example.com/file.jpg" }),
+    });
+    const formData = new FormData();
+    formData.append("file", {
+      uri: "file:///tmp/photo.jpg",
+      name: "photo.jpg",
+      type: "image/jpeg",
+    } as unknown as Blob);
+
+    const result = await apiPostMultipart<{ url: string }>(
+      "/api/profiles/me/uploads/",
+      formData,
+    );
+
+    expect(result).toEqual({ url: "https://cdn.example.com/file.jpg" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${API_BASE_URL}/api/profiles/me/uploads/`,
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          Authorization: "Bearer token-123",
+        },
+        body: formData,
+      }),
+    );
   });
 
   it("supports PATCH and bubbles parsed API error", async () => {

--- a/mobile/__tests__/lib/uploads.test.ts
+++ b/mobile/__tests__/lib/uploads.test.ts
@@ -1,0 +1,68 @@
+import {
+  deleteProfilePicture,
+  uploadPostMedia,
+  uploadProfilePicture,
+} from "@/lib/queries/uploads";
+
+const mockApiPostMultipart = jest.fn();
+const mockApiDelete = jest.fn();
+
+jest.mock("@/lib/api/client", () => ({
+  apiDelete: (...args: unknown[]) => mockApiDelete(...args),
+  apiPostMultipart: (...args: unknown[]) => mockApiPostMultipart(...args),
+}));
+
+describe("upload query helpers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("uploads post media through the self media endpoint", async () => {
+    mockApiPostMultipart.mockResolvedValueOnce({
+      url: "https://cdn.example.com/post.jpg",
+    });
+
+    const response = await uploadPostMedia({
+      uri: "file:///tmp/post.jpg",
+      name: "post.jpg",
+      type: "image/jpeg",
+    });
+
+    expect(response.url).toBe("https://cdn.example.com/post.jpg");
+    expect(mockApiPostMultipart).toHaveBeenCalledWith(
+      "/api/profiles/me/uploads/",
+      expect.any(FormData),
+    );
+  });
+
+  it("uploads profile pictures through the profile picture endpoint", async () => {
+    mockApiPostMultipart.mockResolvedValueOnce({
+      detail: "Profile picture uploaded.",
+      picture_url: "https://cdn.example.com/avatar.jpg",
+    });
+
+    const response = await uploadProfilePicture({
+      uri: "file:///tmp/avatar.jpg",
+      name: "avatar.jpg",
+      type: "image/jpeg",
+    });
+
+    expect(response.picture_url).toBe("https://cdn.example.com/avatar.jpg");
+    expect(mockApiPostMultipart).toHaveBeenCalledWith(
+      "/api/profiles/me/picture/",
+      expect.any(FormData),
+    );
+  });
+
+  it("deletes the uploaded profile picture", async () => {
+    mockApiDelete.mockResolvedValueOnce({
+      detail: "Profile picture removed.",
+      picture_url: "",
+    });
+
+    const response = await deleteProfilePicture();
+
+    expect(response.picture_url).toBe("");
+    expect(mockApiDelete).toHaveBeenCalledWith("/api/profiles/me/picture/");
+  });
+});

--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -94,6 +94,14 @@ export default function TabLayout() {
       />
 
       <Tabs.Screen
+        name="community/create"
+        options={{
+          href: null,
+          headerShown: false,
+        }}
+      />
+
+      <Tabs.Screen
         name="community/[tagId]/members"
         options={{
           href: null,

--- a/mobile/app/(tabs)/community.tsx
+++ b/mobile/app/(tabs)/community.tsx
@@ -102,6 +102,26 @@ export default function CommunityScreen() {
               </Text>
             </TouchableOpacity>
           </View>
+          <TouchableOpacity
+            testID="create-community-link"
+            activeOpacity={0.88}
+            onPress={() => router.push("/(tabs)/community/create")}
+            className="mb-4 rounded-2xl border border-primary/20 bg-primary/10 p-4 dark:border-primary-dim/25 dark:bg-primary-dim/10"
+          >
+            <View className="flex-row items-center gap-3">
+              <View className="h-11 w-11 items-center justify-center rounded-full bg-primary dark:bg-primary-dim">
+                <Text className="text-xl font-extrabold text-white">+</Text>
+              </View>
+              <View className="flex-1">
+                <Text className="text-base font-extrabold text-on-surface dark:text-on-surface-dark">
+                  Create your own community
+                </Text>
+                <Text className="mt-1 text-sm leading-5 text-on-surface-soft dark:text-on-surface-soft-dark">
+                  Start a focused space around a topic, skill, or shared goal.
+                </Text>
+              </View>
+            </View>
+          </TouchableOpacity>
           {myCommunitiesQuery.isLoading ? (
             <View
               testID="community-loading-state"

--- a/mobile/app/(tabs)/community.tsx
+++ b/mobile/app/(tabs)/community.tsx
@@ -1,6 +1,8 @@
 import { NotificationBell } from "@/components/notifications/NotificationBell";
+import { ProfilePostCard } from "@/components/profile/ProfilePostCard";
 import { ErrorBanner } from "@/components/ui/ErrorBanner";
 import { useAuthStore } from "@/lib/auth/store";
+import { useMyCommunityPostsFeedQuery } from "@/lib/queries/communityPosts";
 import {
   type CommunityTag,
   useMyCommunityTagsQuery,
@@ -16,9 +18,8 @@ import {
 } from "react-native";
 
 const plannedFeedItems = [
-  "Community discussions",
-  "Recommended posts",
-  "Member updates",
+  "Join communities to see their latest posts here.",
+  "Posts from every community you join will be collected in this feed.",
 ];
 
 function formatMemberCount(count: number) {
@@ -65,6 +66,12 @@ export default function CommunityScreen() {
   const myCommunitiesQuery = useMyCommunityTagsQuery(currentUsername);
   const communities = myCommunitiesQuery.data ?? [];
   const hasCommunities = communities.length > 0;
+  const communityFeedQuery = useMyCommunityPostsFeedQuery(
+    communities.map((tag) => tag.id),
+    5,
+    hasCommunities,
+  );
+  const communityFeedPosts = communityFeedQuery.data ?? [];
   const openCommunity = (tag: CommunityTag) => {
     router.push(`/(tabs)/community/${encodeURIComponent(tag.id)}?from=community`);
   };
@@ -102,26 +109,6 @@ export default function CommunityScreen() {
               </Text>
             </TouchableOpacity>
           </View>
-          <TouchableOpacity
-            testID="create-community-link"
-            activeOpacity={0.88}
-            onPress={() => router.push("/(tabs)/community/create")}
-            className="mb-4 rounded-2xl border border-primary/20 bg-primary/10 p-4 dark:border-primary-dim/25 dark:bg-primary-dim/10"
-          >
-            <View className="flex-row items-center gap-3">
-              <View className="h-11 w-11 items-center justify-center rounded-full bg-primary dark:bg-primary-dim">
-                <Text className="text-xl font-extrabold text-white">+</Text>
-              </View>
-              <View className="flex-1">
-                <Text className="text-base font-extrabold text-on-surface dark:text-on-surface-dark">
-                  Create your own community
-                </Text>
-                <Text className="mt-1 text-sm leading-5 text-on-surface-soft dark:text-on-surface-soft-dark">
-                  Start a focused space around a topic, skill, or shared goal.
-                </Text>
-              </View>
-            </View>
-          </TouchableOpacity>
           {myCommunitiesQuery.isLoading ? (
             <View
               testID="community-loading-state"
@@ -158,27 +145,78 @@ export default function CommunityScreen() {
               </Text>
             </View>
           )}
+          <TouchableOpacity
+            testID="create-community-link"
+            activeOpacity={0.88}
+            onPress={() => router.push("/(tabs)/community/create")}
+            className="mt-4 rounded-2xl border border-primary/20 bg-primary/10 p-4 dark:border-primary-dim/25 dark:bg-primary-dim/10"
+          >
+            <View className="flex-row items-center gap-3">
+              <View className="h-11 w-11 items-center justify-center rounded-full bg-primary dark:bg-primary-dim">
+                <Text className="text-xl font-extrabold text-white">+</Text>
+              </View>
+              <View className="flex-1">
+                <Text className="text-base font-extrabold text-on-surface dark:text-on-surface-dark">
+                  Create your own community
+                </Text>
+                <Text className="mt-1 text-sm leading-5 text-on-surface-soft dark:text-on-surface-soft-dark">
+                  Start a focused space around a topic, skill, or shared goal.
+                </Text>
+              </View>
+            </View>
+          </TouchableOpacity>
         </View>
 
         <View>
           <Text className="text-lg font-bold text-on-surface dark:text-on-surface-dark mb-3">
             Community Feed
           </Text>
-          <View className="border-l-2 border-divider dark:border-divider-dark pl-4 py-1">
-            <Text className="text-sm font-semibold text-on-surface dark:text-on-surface-dark mb-2">
-              {hasCommunities
-                ? "Posts from your communities will appear here"
-                : "Join communities to build your feed"}
-            </Text>
-            {plannedFeedItems.map((item) => (
-              <Text
-                key={item}
-                className="text-sm text-on-surface-soft/80 dark:text-on-surface-soft-dark/80 mb-1"
-              >
-                {item}
+          {communityFeedQuery.isLoading ? (
+            <View
+              testID="community-feed-loading"
+              className="rounded-xl border border-divider bg-surface-card p-6 items-center dark:border-divider-dark dark:bg-surface-card-dark"
+            >
+              <ActivityIndicator />
+              <Text className="mt-3 text-sm font-medium text-on-surface-soft dark:text-on-surface-soft-dark">
+                Loading community posts...
               </Text>
-            ))}
-          </View>
+            </View>
+          ) : communityFeedQuery.isError ? (
+            <ErrorBanner
+              title="Could not load community feed"
+              message="Posts from your communities are temporarily unavailable."
+            />
+          ) : communityFeedPosts.length > 0 ? (
+            <View testID="community-feed-posts" className="gap-3">
+              {communityFeedPosts.map((post) => (
+                <ProfilePostCard
+                  key={`${post.community_id}-${post.id}`}
+                  post={post}
+                  expanded
+                  communityLabel={
+                    communities.find((tag) => tag.id === post.community_id)
+                      ?.name ?? null
+                  }
+                />
+              ))}
+            </View>
+          ) : (
+            <View className="border-l-2 border-divider dark:border-divider-dark pl-4 py-1">
+              <Text className="text-sm font-semibold text-on-surface dark:text-on-surface-dark mb-2">
+                {hasCommunities
+                  ? "No posts in your communities yet"
+                  : "Join communities to build your feed"}
+              </Text>
+              {plannedFeedItems.map((item) => (
+                <Text
+                  key={item}
+                  className="text-sm text-on-surface-soft/80 dark:text-on-surface-soft-dark/80 mb-1"
+                >
+                  {item}
+                </Text>
+              ))}
+            </View>
+          )}
         </View>
       </ScrollView>
     </View>

--- a/mobile/app/(tabs)/community/create.tsx
+++ b/mobile/app/(tabs)/community/create.tsx
@@ -1,0 +1,201 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { useState } from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { ErrorBanner } from "@/components/ui/ErrorBanner";
+import { SuccessCard } from "@/components/ui/SuccessCard";
+import { useAuthStore } from "@/lib/auth/store";
+import { useCreateCommunityTagMutation } from "@/lib/queries/communityTags";
+
+const DESCRIPTION_LIMIT = 280;
+
+function getErrorMessage(error: unknown, fallback: string) {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+  return fallback;
+}
+
+export default function CreateCommunityScreen() {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const currentUsername = useAuthStore((state) => state.user?.username);
+  const createCommunityMutation = useCreateCommunityTagMutation(currentUsername);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [formError, setFormError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const trimmedName = name.trim();
+  const trimmedDescription = description.trim();
+  const canSubmit = !createCommunityMutation.isPending;
+
+  const handleSubmit = async () => {
+    if (!trimmedName) {
+      setFormError("Community name is required.");
+      return;
+    }
+
+    try {
+      setFormError(null);
+      setSuccessMessage(null);
+      const tag = await createCommunityMutation.mutateAsync({
+        name: trimmedName,
+        description: trimmedDescription,
+      });
+      setSuccessMessage(`${tag.name} is ready.`);
+      router.replace(
+        `/(tabs)/community/${encodeURIComponent(tag.id)}?from=community`,
+      );
+    } catch (error) {
+      setFormError(
+        getErrorMessage(error, "Could not create this community right now."),
+      );
+    }
+  };
+
+  return (
+    <View className="flex-1 bg-surface dark:bg-surface-dark">
+      <View
+        className="z-10 border-b border-divider bg-surface-card shadow-sm dark:border-divider-dark dark:bg-surface-card-dark"
+        style={{ paddingTop: insets.top }}
+      >
+        <View className="flex-row items-center gap-3 px-4 pb-3 pt-2">
+          <TouchableOpacity
+            testID="create-community-back-button"
+            onPress={() => router.replace("/(tabs)/community")}
+            className="h-10 w-10 items-center justify-center rounded-full bg-surface dark:bg-surface-dark"
+          >
+            <Ionicons name="chevron-back" size={20} color="#2f7d68" />
+          </TouchableOpacity>
+          <View className="flex-1">
+            <Text className="text-xl font-extrabold text-on-surface dark:text-on-surface-dark">
+              Create Community
+            </Text>
+            <Text className="text-xs font-semibold text-on-surface-soft dark:text-on-surface-soft-dark">
+              Build a space people can join.
+            </Text>
+          </View>
+        </View>
+      </View>
+
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        className="flex-1"
+      >
+        <ScrollView
+          className="flex-1 px-4 pt-4"
+          contentContainerStyle={{ paddingBottom: 140 }}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          {formError ? (
+            <View className="mb-4">
+              <ErrorBanner message={formError} />
+            </View>
+          ) : null}
+
+          {successMessage ? (
+            <View className="mb-4">
+              <SuccessCard message={successMessage} />
+            </View>
+          ) : null}
+
+          <View className="rounded-2xl border border-divider bg-surface-card p-4 dark:border-divider-dark dark:bg-surface-card-dark">
+            <View className="mb-5">
+              <View className="mb-3 h-14 w-14 items-center justify-center rounded-2xl bg-primary/10 dark:bg-primary-dim/15">
+                <Ionicons name="people-outline" size={26} color="#2f7d68" />
+              </View>
+              <Text className="text-2xl font-extrabold text-on-surface dark:text-on-surface-dark">
+                Create your own community
+              </Text>
+              <Text className="mt-2 text-sm leading-5 text-on-surface-soft dark:text-on-surface-soft-dark">
+                Choose a name people can recognize, then add a short description
+                that explains who belongs here.
+              </Text>
+            </View>
+
+            <View className="gap-y-5">
+              <View>
+                <Text className="mb-2 text-sm font-bold text-on-surface dark:text-on-surface-dark">
+                  Community name
+                </Text>
+                <TextInput
+                  testID="create-community-name-input"
+                  value={name}
+                  onChangeText={setName}
+                  placeholder="e.g. Backend Guild"
+                  placeholderTextColor="#8b8d98"
+                  maxLength={80}
+                  autoCapitalize="words"
+                  className="h-14 rounded-xl border border-divider bg-surface px-3 text-base font-semibold text-on-surface dark:border-divider-dark dark:bg-surface-dark dark:text-on-surface-dark"
+                  style={
+                    Platform.OS === "android"
+                      ? { textAlignVertical: "center", paddingVertical: 0 }
+                      : undefined
+                  }
+                />
+              </View>
+
+              <View>
+                <View className="mb-2 flex-row items-end justify-between">
+                  <Text className="text-sm font-bold text-on-surface dark:text-on-surface-dark">
+                    Description
+                  </Text>
+                  <Text className="text-xs font-semibold text-on-surface-muted dark:text-on-surface-muted-dark">
+                    {description.length}/{DESCRIPTION_LIMIT}
+                  </Text>
+                </View>
+                <TextInput
+                  testID="create-community-description-input"
+                  value={description}
+                  onChangeText={setDescription}
+                  placeholder="What will members learn, discuss, or build together?"
+                  placeholderTextColor="#8b8d98"
+                  multiline
+                  maxLength={DESCRIPTION_LIMIT}
+                  textAlignVertical="top"
+                  className="min-h-[132px] rounded-xl border border-divider bg-surface px-3 py-3 text-base leading-5 text-on-surface dark:border-divider-dark dark:bg-surface-dark dark:text-on-surface-dark"
+                />
+              </View>
+            </View>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+
+      <View
+        className="border-t border-divider bg-surface px-4 pt-3 dark:border-divider-dark dark:bg-surface-dark"
+        style={{ paddingBottom: Math.max(insets.bottom, 16) }}
+      >
+        <TouchableOpacity
+          testID="create-community-submit"
+          activeOpacity={0.9}
+          disabled={!canSubmit}
+          onPress={handleSubmit}
+          className={`h-12 items-center justify-center rounded-xl ${
+            trimmedName && canSubmit
+              ? "bg-primary dark:bg-primary-dim"
+              : "bg-gray-300"
+          }`}
+        >
+          {createCommunityMutation.isPending ? (
+            <ActivityIndicator size="small" color="#ffffff" />
+          ) : (
+            <Text className="font-bold text-white">Create Community</Text>
+          )}
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}

--- a/mobile/app/(tabs)/profile/index.tsx
+++ b/mobile/app/(tabs)/profile/index.tsx
@@ -9,7 +9,8 @@ import { AvailabilityPreview } from "@/components/profile/AvailabilityPreview";
 import { EditAvailabilityModal } from "@/components/profile/EditAvailabilityModal";
 import {
   EditProfileModal,
-  UserProfileData,
+  type SaveProfileData,
+  type UserProfileData,
 } from "@/components/profile/EditProfileModal";
 import { EditSkillsModal } from "@/components/profile/EditSkillsModal";
 import { ProfileHeader } from "@/components/profile/ProfileHeader";
@@ -40,6 +41,10 @@ import {
   useProfileReviewsQuery,
   useUpdateOwnProfileMutation,
 } from "@/lib/queries/profile";
+import {
+  deleteProfilePicture,
+  uploadProfilePicture,
+} from "@/lib/queries/uploads";
 
 const PROFILE_DEFAULTS = {
   skills: [] as string[],
@@ -301,6 +306,7 @@ export default function ProfileScreen() {
   const [userData, setUserData] = useState<UserProfileData>({
     name: authUser?.username ?? "User",
     bio: "",
+    pictureUrl: "",
   });
 
   useEffect(() => {
@@ -363,6 +369,7 @@ export default function ProfileScreen() {
           ...prev,
           name: payload.full_name || prev.name,
           bio: payload.bio || "",
+          pictureUrl: payload.picture_url || "",
         }));
 
         setIsProfileHidden(Boolean(payload.hidden));
@@ -506,29 +513,44 @@ export default function ProfileScreen() {
     });
   };
 
-  const handleSaveProfileHeader = async (updatedData: UserProfileData) => {
+  const handleSaveProfileHeader = async (updatedData: SaveProfileData) => {
     if (!currentUsername) {
       setUserData(updatedData);
-      return;
+      return true;
     }
 
     try {
       setPageError(null);
+      let pictureUrl = userData.pictureUrl ?? "";
       const response = await updateProfileMutation.mutateAsync({
         username: currentUsername,
         display_name: updatedData.name,
         bio: updatedData.bio,
       });
+
+      if (updatedData.pictureFile) {
+        const pictureResponse = await uploadProfilePicture(
+          updatedData.pictureFile,
+        );
+        pictureUrl = pictureResponse.picture_url;
+      } else if (updatedData.removePicture) {
+        const pictureResponse = await deleteProfilePicture();
+        pictureUrl = pictureResponse.picture_url;
+      }
+
       setUserData({
         name: response.display_name || updatedData.name,
         bio: response.bio || updatedData.bio,
+        pictureUrl,
       });
+      return true;
     } catch (error) {
       setPageError(
         error instanceof Error
           ? error.message
           : "Could not update profile details.",
       );
+      return false;
     }
   };
 
@@ -618,6 +640,7 @@ export default function ProfileScreen() {
           menteesHelped={isMentorMode ? menteesCount : 0}
           showStats={isMentorMode}
           showMenteesHelped={isMentorMode}
+          imageUrl={userData.pictureUrl || undefined}
           onEdit={() => setEditProfileModalOpen(true)}
         />
 
@@ -704,10 +727,7 @@ export default function ProfileScreen() {
         visible={isEditProfileModalOpen}
         onClose={() => setEditProfileModalOpen(false)}
         initialData={userData}
-        onSave={(updatedData) => {
-          void handleSaveProfileHeader(updatedData);
-          setEditProfileModalOpen(false);
-        }}
+        onSave={handleSaveProfileHeader}
       />
       <ProfilePostComposer
         visible={isPostComposerOpen}

--- a/mobile/app/(tabs)/profile/index.tsx
+++ b/mobile/app/(tabs)/profile/index.tsx
@@ -526,6 +526,7 @@ export default function ProfileScreen() {
         username: currentUsername,
         display_name: updatedData.name,
         bio: updatedData.bio,
+        ...(updatedData.removePicture ? { picture_url: "" } : {}),
       });
 
       if (updatedData.pictureFile) {

--- a/mobile/app/messages/[conversation_id].tsx
+++ b/mobile/app/messages/[conversation_id].tsx
@@ -7,6 +7,7 @@ import {
   FlatList,
   Image,
   KeyboardAvoidingView,
+  Linking,
   NativeScrollEvent,
   NativeSyntheticEvent,
   Platform,
@@ -24,6 +25,11 @@ import {
   useSendMessage,
   type Message,
 } from "@/lib/queries/MessagingQueries";
+import type { LocalUploadFile } from "@/lib/queries/uploads";
+import {
+  pickMessageImageFile,
+  pickMessagePdfFile,
+} from "@/lib/uploads/picker";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -61,6 +67,17 @@ function formatDateLabel(dateStr: string): string {
 
 function isDifferentDay(a: string, b: string): boolean {
   return new Date(a).toDateString() !== new Date(b).toDateString();
+}
+
+function isImageAttachment(url: string): boolean {
+  const path = url.split("?")[0]?.toLowerCase() ?? "";
+  return /\.(jpe?g|png|gif|webp)$/.test(path);
+}
+
+function getAttachmentLabel(url: string): string {
+  const path = url.split("?")[0] ?? "";
+  const fileName = decodeURIComponent(path.split("/").pop() || "");
+  return fileName || "Attachment";
 }
 
 // ---------------------------------------------------------------------------
@@ -139,6 +156,8 @@ function DateSeparator({ dateStr }: { dateStr: string }) {
 }
 
 function MessageBubble({ message, isMe }: { message: Message; isMe: boolean }) {
+  const attachmentUrl = message.attachment_url;
+
   return (
     <View className={`w-full mb-1 ${isMe ? "items-end" : "items-start"}`}>
       <View style={{ maxWidth: "80%" }}>
@@ -154,21 +173,56 @@ function MessageBubble({ message, isMe }: { message: Message; isMe: boolean }) {
             elevation: 1,
           }}
         >
-          <Text
-            className={`text-[14px] leading-5 ${
-              isMe ? "text-white" : "text-on-surface"
-            }`}
-          >
-            {message.body}
-          </Text>
-          {message.attachment_url ? (
+          {message.body ? (
             <Text
-              className={`text-[12px] mt-1 underline ${
-                isMe ? "text-white/70" : "text-primary"
+              className={`text-[14px] leading-5 ${
+                isMe ? "text-white" : "text-on-surface"
               }`}
             >
-              Attachment
+              {message.body}
             </Text>
+          ) : null}
+          {attachmentUrl ? (
+            <TouchableOpacity
+              testID={`message-attachment-${message.id}`}
+              activeOpacity={0.85}
+              onPress={() => {
+                void Linking.openURL(attachmentUrl);
+              }}
+              className={message.body ? "mt-2" : ""}
+            >
+              {isImageAttachment(attachmentUrl) ? (
+                <Image
+                  source={{ uri: attachmentUrl }}
+                  className="rounded-xl mb-2"
+                  style={{ width: 180, height: 130 }}
+                  resizeMode="cover"
+                />
+              ) : null}
+              <View
+                className={`flex-row items-center rounded-xl px-3 py-2 ${
+                  isMe ? "bg-white/15" : "bg-white"
+                }`}
+              >
+                <Ionicons
+                  name={
+                    isImageAttachment(attachmentUrl)
+                      ? "image"
+                      : "document-text"
+                  }
+                  size={16}
+                  color={isMe ? "#ffffff" : "#4a7c6f"}
+                />
+                <Text
+                  className={`text-[12px] font-semibold ml-2 flex-1 ${
+                    isMe ? "text-white" : "text-primary"
+                  }`}
+                  numberOfLines={1}
+                >
+                  {getAttachmentLabel(attachmentUrl)}
+                </Text>
+              </View>
+            </TouchableOpacity>
           ) : null}
         </View>
         <Text
@@ -226,6 +280,9 @@ export default function ConversationScreen() {
 
   const sendMessage = useSendMessage(conversation_id ?? "");
   const [text, setText] = useState("");
+  const [attachment, setAttachment] = useState<LocalUploadFile | null>(null);
+  const [showAttachOptions, setShowAttachOptions] = useState(false);
+  const [attachmentError, setAttachmentError] = useState<string | null>(null);
   const flatListRef = useRef<FlatList<ListItem>>(null);
   const isNearBottomRef = useRef(true);
   const hasInitialScrollDoneRef = useRef(false);
@@ -284,10 +341,14 @@ export default function ConversationScreen() {
 
   const handleSend = useCallback(async () => {
     const body = text.trim();
-    if (!body || sendMessage.isPending || !conversation_id) return;
+    const currentAttachment = attachment;
+    if ((!body && !currentAttachment) || sendMessage.isPending || !conversation_id) return;
     setText("");
+    setAttachment(null);
+    setShowAttachOptions(false);
+    setAttachmentError(null);
     try {
-      await sendMessage.mutateAsync(body);
+      await sendMessage.mutateAsync({ body, attachment: currentAttachment });
       queryClient.invalidateQueries({
         queryKey: ["messaging", "messages", conversation_id],
       });
@@ -295,10 +356,37 @@ export default function ConversationScreen() {
         queryKey: ["messaging", "conversations"],
       });
     } catch {
-      // Restore text if send failed
+      // Restore draft if send failed
       setText(body);
+      setAttachment(currentAttachment);
     }
-  }, [text, sendMessage, queryClient, conversation_id]);
+  }, [text, attachment, sendMessage, queryClient, conversation_id]);
+
+  const handlePickImage = useCallback(async () => {
+    setAttachmentError(null);
+    try {
+      const file = await pickMessageImageFile();
+      if (file) {
+        setAttachment(file);
+        setShowAttachOptions(false);
+      }
+    } catch {
+      setAttachmentError("Could not attach that image.");
+    }
+  }, []);
+
+  const handlePickPdf = useCallback(async () => {
+    setAttachmentError(null);
+    try {
+      const file = await pickMessagePdfFile();
+      if (file) {
+        setAttachment(file);
+        setShowAttachOptions(false);
+      }
+    } catch {
+      setAttachmentError("Could not attach that PDF.");
+    }
+  }, []);
 
   const renderItem = useCallback(
     ({ item }: { item: ListItem }) => {
@@ -417,7 +505,89 @@ export default function ConversationScreen() {
           className="bg-surface-card border-t border-divider px-4 pt-3"
           style={{ paddingBottom: Math.max(insets.bottom, 12) }}
         >
+          {showAttachOptions ? (
+            <View className="flex-row gap-2 mb-3">
+              <TouchableOpacity
+                testID="attach-image-button"
+                activeOpacity={0.85}
+                onPress={handlePickImage}
+                className="flex-row items-center bg-surface-input rounded-xl px-3 py-2"
+              >
+                <Ionicons name="image-outline" size={18} color="#4a7c6f" />
+                <Text className="text-[13px] font-semibold text-on-surface ml-2">
+                  Image
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                testID="attach-pdf-button"
+                activeOpacity={0.85}
+                onPress={handlePickPdf}
+                className="flex-row items-center bg-surface-input rounded-xl px-3 py-2"
+              >
+                <Ionicons
+                  name="document-text-outline"
+                  size={18}
+                  color="#4a7c6f"
+                />
+                <Text className="text-[13px] font-semibold text-on-surface ml-2">
+                  PDF
+                </Text>
+              </TouchableOpacity>
+            </View>
+          ) : null}
+
+          {attachment ? (
+            <View
+              testID="selected-attachment"
+              className="flex-row items-center bg-surface-input rounded-xl px-3 py-2 mb-3"
+            >
+              <Ionicons
+                name={
+                  attachment.type.startsWith("image/")
+                    ? "image"
+                    : "document-text"
+                }
+                size={18}
+                color="#4a7c6f"
+              />
+              <Text
+                className="text-[13px] font-semibold text-on-surface ml-2 flex-1"
+                numberOfLines={1}
+              >
+                {attachment.name}
+              </Text>
+              <TouchableOpacity
+                testID="selected-attachment-remove"
+                activeOpacity={0.7}
+                onPress={() => setAttachment(null)}
+              >
+                <Ionicons name="close-circle" size={20} color="#8a8172" />
+              </TouchableOpacity>
+            </View>
+          ) : null}
+
+          {attachmentError ? (
+            <Text className="text-[12px] text-red-700 mb-2">
+              {attachmentError}
+            </Text>
+          ) : null}
+
           <View className="flex-row items-end" style={{ gap: 10 }}>
+            <TouchableOpacity
+              testID="attachment-plus-button"
+              onPress={() => setShowAttachOptions((current) => !current)}
+              activeOpacity={0.8}
+              disabled={sendMessage.isPending}
+              className="items-center justify-center rounded-xl bg-surface-input"
+              style={{
+                width: 48,
+                height: 48,
+                opacity: sendMessage.isPending ? 0.45 : 1,
+              }}
+            >
+              <Ionicons name="add" size={24} color="#4a7c6f" />
+            </TouchableOpacity>
+
             <View
               className="flex-1 bg-surface-input rounded-xl px-4 py-3"
               style={{ minHeight: 48 }}
@@ -444,12 +614,15 @@ export default function ConversationScreen() {
               testID="send-button"
               onPress={handleSend}
               activeOpacity={0.8}
-              disabled={!text.trim() || sendMessage.isPending}
+              disabled={(!text.trim() && !attachment) || sendMessage.isPending}
               className="items-center justify-center rounded-xl bg-primary"
               style={{
                 width: 48,
                 height: 48,
-                opacity: !text.trim() || sendMessage.isPending ? 0.45 : 1,
+                opacity:
+                  (!text.trim() && !attachment) || sendMessage.isPending
+                    ? 0.45
+                    : 1,
               }}
             >
               {sendMessage.isPending ? (

--- a/mobile/components/community/CommunityPostComposer.tsx
+++ b/mobile/components/community/CommunityPostComposer.tsx
@@ -9,6 +9,9 @@ import {
   View,
 } from "react-native";
 
+import { PostMediaPicker } from "@/components/posts/PostMediaPicker";
+import { uploadPostMedia } from "@/lib/queries/uploads";
+import type { LocalUploadFile } from "@/lib/queries/uploads";
 import type { CreateCommunityPostPayload } from "@/lib/queries/communityPosts";
 
 const EVENT_TYPES: {
@@ -35,13 +38,19 @@ export function CommunityPostComposer({
     useState<CreateCommunityPostPayload["event_type"]>("social");
   const [content, setContent] = useState("");
   const [showOnProfile, setShowOnProfile] = useState(false);
+  const [media, setMedia] = useState<LocalUploadFile | null>(null);
+  const [mediaError, setMediaError] = useState<string | null>(null);
+  const [isUploadingMedia, setUploadingMedia] = useState(false);
 
-  const canSubmit = content.trim().length > 0 && !isSubmitting;
+  const isBusy = Boolean(isSubmitting) || isUploadingMedia;
+  const canSubmit = content.trim().length > 0 && !isBusy;
 
   const resetForm = () => {
     setContent("");
     setShowOnProfile(false);
     setEventType("social");
+    setMedia(null);
+    setMediaError(null);
   };
 
   const handleSubmit = async () => {
@@ -49,9 +58,30 @@ export function CommunityPostComposer({
       return;
     }
 
+    setMediaError(null);
+
+    let mediaUrl: string | null | undefined;
+    if (media) {
+      try {
+        setUploadingMedia(true);
+        const uploadResponse = await uploadPostMedia(media);
+        mediaUrl = uploadResponse.url;
+      } catch (error) {
+        setMediaError(
+          error instanceof Error && error.message.trim()
+            ? error.message
+            : "Could not upload this photo.",
+        );
+        return;
+      } finally {
+        setUploadingMedia(false);
+      }
+    }
+
     const didSubmit = await onSubmit({
       event_type: eventType,
       content: content.trim(),
+      ...(mediaUrl ? { media_url: mediaUrl } : {}),
       show_on_profile: showOnProfile,
     });
 
@@ -136,6 +166,26 @@ export function CommunityPostComposer({
             className="mt-4 min-h-[120px] rounded-xl border border-divider bg-surface px-3 py-3 text-on-surface dark:border-divider-dark dark:bg-surface-dark dark:text-on-surface-dark"
           />
 
+          <PostMediaPicker
+            disabled={isBusy}
+            media={media}
+            onChange={(nextMedia) => {
+              setMediaError(null);
+              setMedia(nextMedia);
+            }}
+            onError={setMediaError}
+            testIDPrefix="community-composer"
+          />
+
+          {mediaError ? (
+            <Text
+              testID="community-composer-media-error"
+              className="mt-2 text-xs font-semibold text-error dark:text-red-200"
+            >
+              {mediaError}
+            </Text>
+          ) : null}
+
           <View className="mt-4 flex-row items-center justify-between gap-3">
             <View className="flex-1">
               <Text className="text-sm font-bold text-on-surface dark:text-on-surface-dark">
@@ -163,7 +213,7 @@ export function CommunityPostComposer({
               canSubmit ? "bg-primary dark:bg-primary-dim" : "bg-gray-300"
             }`}
           >
-            {isSubmitting ? (
+            {isBusy ? (
               <ActivityIndicator size="small" color="#ffffff" />
             ) : (
               <Text className="font-bold text-white">Post to Community</Text>

--- a/mobile/components/connections/MenteeCard.tsx
+++ b/mobile/components/connections/MenteeCard.tsx
@@ -1,6 +1,8 @@
 import React from "react";
-import { View, Text, Image, TouchableOpacity } from "react-native";
+import { View, Text, TouchableOpacity } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
+
+import { UserAvatar } from "@/components/ui/UserAvatar";
 
 export interface MenteeTag {
   label: string;
@@ -35,18 +37,12 @@ export function MenteeCard({
         onPress={onPress}
         className="flex-row items-center gap-3.5 mb-3.5"
       >
-        {avatarUrl ? (
-          <Image
-            source={{ uri: avatarUrl }}
-            className="w-20 h-20 rounded-full"
-          />
-        ) : (
-          <View className="w-20 h-20 rounded-full bg-surface-active items-center justify-center">
-            <Text className="text-[22px] font-bold text-primary">
-              {name.charAt(0)}
-            </Text>
-          </View>
-        )}
+        <UserAvatar
+          imageUrl={avatarUrl}
+          name={name}
+          size="xl"
+          testIDPrefix="mentee-avatar"
+        />
         <View className="flex-1">
           <Text className="text-base font-bold text-on-surface">{name}</Text>
           <Text className="text-[13px] text-on-surface-soft mt-0.5">

--- a/mobile/components/connections/MentorCard.tsx
+++ b/mobile/components/connections/MentorCard.tsx
@@ -1,6 +1,8 @@
 import React from "react";
-import { View, Text, Image, TouchableOpacity } from "react-native";
+import { View, Text, TouchableOpacity } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
+
+import { UserAvatar } from "@/components/ui/UserAvatar";
 
 export interface MentorCardProps {
   id: string;
@@ -28,15 +30,13 @@ export function MentorCard({
         onPress={onPress}
         className="flex-row gap-4 items-center"
       >
-        {avatarUrl ? (
-          <Image source={{ uri: avatarUrl }} className="w-15 h-15 rounded-lg" />
-        ) : (
-          <View className="w-15 h-15 rounded-lg bg-surface-active items-center justify-center">
-            <Text className="text-[22px] font-bold text-primary">
-              {name.charAt(0)}
-            </Text>
-          </View>
-        )}
+        <UserAvatar
+          imageUrl={avatarUrl}
+          name={name}
+          shape="rounded"
+          size="md"
+          testIDPrefix="mentor-avatar"
+        />
 
         <View className="flex-1">
           <Text className="text-base font-bold text-on-surface">{name}</Text>

--- a/mobile/components/connections/PendingRequestCard.tsx
+++ b/mobile/components/connections/PendingRequestCard.tsx
@@ -1,5 +1,7 @@
 import React from "react";
-import { View, Text, Image, TouchableOpacity } from "react-native";
+import { View, Text, TouchableOpacity } from "react-native";
+
+import { UserAvatar } from "@/components/ui/UserAvatar";
 
 export interface PendingRequestCardProps {
   id: string;
@@ -61,18 +63,12 @@ export function PendingRequestCard({
         onPress={onShowProfile}
         disabled={!onShowProfile}
       >
-        {avatarUrl ? (
-          <Image
-            source={{ uri: avatarUrl }}
-            className="w-[72px] h-[72px] rounded-full"
-          />
-        ) : (
-          <View className="w-[72px] h-[72px] rounded-full bg-surface-active items-center justify-center">
-            <Text className="text-[26px] font-bold text-primary">
-              {name.charAt(0)}
-            </Text>
-          </View>
-        )}
+        <UserAvatar
+          imageUrl={avatarUrl}
+          name={name}
+          size="lg"
+          testIDPrefix="pending-avatar"
+        />
       </TouchableOpacity>
 
       {/* Content */}

--- a/mobile/components/discover/MentorCard.tsx
+++ b/mobile/components/discover/MentorCard.tsx
@@ -1,20 +1,12 @@
 import React from "react";
 import { Text, TouchableOpacity, View } from "react-native";
 
+import { UserAvatar } from "@/components/ui/UserAvatar";
 import { type DiscoverMentorProfile } from "@/lib/discover/types";
 
 interface MentorCardProps {
   profile: DiscoverMentorProfile;
   onPress?: (profile: DiscoverMentorProfile) => void;
-}
-
-function getInitials(name: string): string {
-  const parts = name.split(" ").filter(Boolean);
-  const initials = parts
-    .map((part) => part[0])
-    .join("")
-    .toUpperCase();
-  return initials.slice(0, 2) || "?";
 }
 
 export function MentorCard({ profile, onPress }: Readonly<MentorCardProps>) {
@@ -25,10 +17,13 @@ export function MentorCard({ profile, onPress }: Readonly<MentorCardProps>) {
       className="bg-surface-card dark:bg-surface-card-dark border border-divider dark:border-divider-dark rounded-2xl p-4 mb-3"
     >
       <View className="flex-row items-center mb-3">
-        <View className="w-12 h-12 rounded-full bg-surface-active dark:bg-surface-active-dark items-center justify-center mr-3">
-          <Text className="text-primary dark:text-primary-dim font-bold">
-            {getInitials(profile.full_name)}
-          </Text>
+        <View className="mr-3">
+          <UserAvatar
+            imageUrl={profile.picture_url}
+            name={profile.full_name}
+            size="sm"
+            testIDPrefix={`discover-avatar-${profile.username}`}
+          />
         </View>
         <View className="flex-1">
           <Text

--- a/mobile/components/posts/PostMediaPicker.tsx
+++ b/mobile/components/posts/PostMediaPicker.tsx
@@ -1,0 +1,96 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Image, Text, TouchableOpacity, View } from "react-native";
+
+import { pickPostImageFile } from "@/lib/uploads/picker";
+import type { LocalUploadFile } from "@/lib/queries/uploads";
+
+interface PostMediaPickerProps {
+  disabled?: boolean;
+  media: LocalUploadFile | null;
+  onChange: (media: LocalUploadFile | null) => void;
+  onError?: (message: string) => void;
+  testIDPrefix: string;
+}
+
+function getPickerErrorMessage(error: unknown) {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+  return "Could not open your photo library.";
+}
+
+export function PostMediaPicker({
+  disabled,
+  media,
+  onChange,
+  onError,
+  testIDPrefix,
+}: Readonly<PostMediaPickerProps>) {
+  const handlePick = async () => {
+    if (disabled) {
+      return;
+    }
+
+    try {
+      const nextMedia = await pickPostImageFile();
+      if (nextMedia) {
+        onChange(nextMedia);
+      }
+    } catch (error) {
+      onError?.(getPickerErrorMessage(error));
+    }
+  };
+
+  return (
+    <View className="mt-4 rounded-xl border border-dashed border-divider px-3 py-3 dark:border-divider-dark">
+      <View className="flex-row items-center justify-between gap-3">
+        <View className="min-w-0 flex-1">
+          <Text className="text-sm font-bold text-on-surface dark:text-on-surface-dark">
+            Photo
+          </Text>
+          <Text
+            numberOfLines={1}
+            className="mt-0.5 text-xs text-on-surface-soft dark:text-on-surface-soft-dark"
+          >
+            {media ? media.name : "Optional image attachment"}
+          </Text>
+        </View>
+
+        <TouchableOpacity
+          testID={`${testIDPrefix}-media-button`}
+          activeOpacity={0.85}
+          disabled={disabled}
+          onPress={handlePick}
+          className="h-10 flex-row items-center justify-center gap-1.5 rounded-full bg-surface-active px-3 dark:bg-surface-active-dark"
+        >
+          <Ionicons name="image-outline" size={16} color="#2f7d68" />
+          <Text className="text-xs font-bold text-primary dark:text-primary-dim">
+            {media ? "Change" : "Add"}
+          </Text>
+        </TouchableOpacity>
+      </View>
+
+      {media ? (
+        <View className="mt-3">
+          <Image
+            testID={`${testIDPrefix}-media-preview`}
+            source={{ uri: media.uri }}
+            resizeMode="cover"
+            className="h-36 w-full rounded-xl bg-surface-active dark:bg-surface-active-dark"
+          />
+          <TouchableOpacity
+            testID={`${testIDPrefix}-media-remove`}
+            activeOpacity={0.85}
+            disabled={disabled}
+            onPress={() => onChange(null)}
+            className="mt-2 self-start rounded-full border border-divider px-3 py-1.5 dark:border-divider-dark"
+          >
+            <Text className="text-xs font-bold text-on-surface-soft dark:text-on-surface-soft-dark">
+              Remove photo
+            </Text>
+          </TouchableOpacity>
+        </View>
+      ) : null}
+    </View>
+  );
+}

--- a/mobile/components/posts/PostMediaPicker.tsx
+++ b/mobile/components/posts/PostMediaPicker.tsx
@@ -1,7 +1,7 @@
 import { Ionicons } from "@expo/vector-icons";
 import { Image, Text, TouchableOpacity, View } from "react-native";
 
-import { pickPostImageFile } from "@/lib/uploads/picker";
+import { pickPostMediaFile } from "@/lib/uploads/picker";
 import type { LocalUploadFile } from "@/lib/queries/uploads";
 
 interface PostMediaPickerProps {
@@ -16,7 +16,7 @@ function getPickerErrorMessage(error: unknown) {
   if (error instanceof Error && error.message.trim()) {
     return error.message;
   }
-  return "Could not open your photo library.";
+  return "Could not open your library.";
 }
 
 export function PostMediaPicker({
@@ -32,7 +32,7 @@ export function PostMediaPicker({
     }
 
     try {
-      const nextMedia = await pickPostImageFile();
+      const nextMedia = await pickPostMediaFile();
       if (nextMedia) {
         onChange(nextMedia);
       }
@@ -41,18 +41,20 @@ export function PostMediaPicker({
     }
   };
 
+  const isImage = media?.type.startsWith("image/");
+
   return (
     <View className="mt-4 rounded-xl border border-dashed border-divider px-3 py-3 dark:border-divider-dark">
       <View className="flex-row items-center justify-between gap-3">
         <View className="min-w-0 flex-1">
           <Text className="text-sm font-bold text-on-surface dark:text-on-surface-dark">
-            Photo
+            Media
           </Text>
           <Text
             numberOfLines={1}
             className="mt-0.5 text-xs text-on-surface-soft dark:text-on-surface-soft-dark"
           >
-            {media ? media.name : "Optional image attachment"}
+            {media ? media.name : "Optional image or PDF attachment"}
           </Text>
         </View>
 
@@ -63,7 +65,11 @@ export function PostMediaPicker({
           onPress={handlePick}
           className="h-10 flex-row items-center justify-center gap-1.5 rounded-full bg-surface-active px-3 dark:bg-surface-active-dark"
         >
-          <Ionicons name="image-outline" size={16} color="#2f7d68" />
+          <Ionicons
+            name={media ? "sync-outline" : "add-circle-outline"}
+            size={16}
+            color="#2f7d68"
+          />
           <Text className="text-xs font-bold text-primary dark:text-primary-dim">
             {media ? "Change" : "Add"}
           </Text>
@@ -72,12 +78,25 @@ export function PostMediaPicker({
 
       {media ? (
         <View className="mt-3">
-          <Image
-            testID={`${testIDPrefix}-media-preview`}
-            source={{ uri: media.uri }}
-            resizeMode="cover"
-            className="h-36 w-full rounded-xl bg-surface-active dark:bg-surface-active-dark"
-          />
+          {isImage ? (
+            <Image
+              testID={`${testIDPrefix}-media-preview`}
+              source={{ uri: media.uri }}
+              resizeMode="cover"
+              className="h-36 w-full rounded-xl bg-surface-active dark:bg-surface-active-dark"
+            />
+          ) : (
+            <View
+              testID={`${testIDPrefix}-document-preview`}
+              className="h-36 w-full items-center justify-center rounded-xl bg-surface-active dark:bg-surface-active-dark"
+            >
+              <Ionicons name="document-text-outline" size={48} color="#6b7280" />
+              <Text className="mt-2 text-xs font-semibold text-on-surface-soft">
+                {media.name}
+              </Text>
+            </View>
+          )}
+
           <TouchableOpacity
             testID={`${testIDPrefix}-media-remove`}
             activeOpacity={0.85}
@@ -86,7 +105,7 @@ export function PostMediaPicker({
             className="mt-2 self-start rounded-full border border-divider px-3 py-1.5 dark:border-divider-dark"
           >
             <Text className="text-xs font-bold text-on-surface-soft dark:text-on-surface-soft-dark">
-              Remove photo
+              Remove attachment
             </Text>
           </TouchableOpacity>
         </View>

--- a/mobile/components/profile/EditProfileModal.tsx
+++ b/mobile/components/profile/EditProfileModal.tsx
@@ -148,17 +148,7 @@ export function EditProfileModal({
           >
             <View className="mb-8">
               {/* 1. The Cover Photo Area */}
-              <View className="h-32 bg-indigo-50 relative -mx-6">
-                <TouchableOpacity
-                  className="absolute bottom-3 right-4 bg-gray-900/60 px-3 py-1.5 rounded-full flex-row items-center"
-                  onPress={() => console.log("TODO: Change Cover Photo")}
-                >
-                  <Ionicons name="camera" size={16} color="white" />
-                  <Text className="text-white text-xs font-bold ml-1.5">
-                    Edit Cover
-                  </Text>
-                </TouchableOpacity>
-              </View>
+              <View className="h-32 bg-indigo-50 relative -mx-6" />
 
               {/* 2. The Overlapping Avatar */}
               <View className="items-center -mt-12">

--- a/mobile/components/profile/EditProfileModal.tsx
+++ b/mobile/components/profile/EditProfileModal.tsx
@@ -9,6 +9,7 @@ import {
   TextInput,
   KeyboardAvoidingView,
   Platform,
+  Alert,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
@@ -132,7 +133,11 @@ export function EditProfileModal({
             className="bg-gray-900 px-5 py-2 rounded-full"
           >
             <Text className="text-white font-bold text-sm">
-              {isSaving ? "Saving..." : "Save"}
+              {isSaving
+                ? pictureFile
+                  ? "Uploading..."
+                  : "Saving..."
+                : "Save"}
             </Text>
           </TouchableOpacity>
         </View>
@@ -185,8 +190,21 @@ export function EditProfileModal({
                   <TouchableOpacity
                     testID="avatar-remove-button"
                     onPress={() => {
-                      setPictureFile(null);
-                      setRemovePicture(true);
+                      Alert.alert(
+                        "Remove Profile Photo",
+                        "Are you sure you want to remove your current profile picture?",
+                        [
+                          { text: "Cancel", style: "cancel" },
+                          {
+                            text: "Remove",
+                            style: "destructive",
+                            onPress: () => {
+                              setPictureFile(null);
+                              setRemovePicture(true);
+                            },
+                          },
+                        ],
+                      );
                     }}
                     className="mt-3 rounded-full border border-gray-200 px-4 py-2"
                   >

--- a/mobile/components/profile/EditProfileModal.tsx
+++ b/mobile/components/profile/EditProfileModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import {
   View,
   Text,
+  Image,
   Modal,
   TouchableOpacity,
   ScrollView,
@@ -12,16 +13,25 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 
+import { pickImageFile } from "@/lib/uploads/picker";
+import type { LocalUploadFile } from "@/lib/queries/uploads";
+
 export interface UserProfileData {
   name: string;
   bio: string;
+  pictureUrl?: string;
+}
+
+export interface SaveProfileData extends UserProfileData {
+  pictureFile?: LocalUploadFile | null;
+  removePicture?: boolean;
 }
 
 interface EditProfileModalProps {
   visible: boolean;
   onClose: () => void;
   initialData: UserProfileData;
-  onSave: (data: UserProfileData) => void;
+  onSave: (data: SaveProfileData) => Promise<boolean | void> | boolean | void;
 }
 
 export function EditProfileModal({
@@ -34,22 +44,62 @@ export function EditProfileModal({
 
   const [name, setName] = useState("");
   const [bio, setBio] = useState("");
+  const [pictureFile, setPictureFile] = useState<LocalUploadFile | null>(null);
+  const [removePicture, setRemovePicture] = useState(false);
+  const [pickerError, setPickerError] = useState<string | null>(null);
+  const [isSaving, setSaving] = useState(false);
 
   useEffect(() => {
     if (visible) {
       setName(initialData.name);
       setBio(initialData.bio);
+      setPictureFile(null);
+      setRemovePicture(false);
+      setPickerError(null);
     }
   }, [visible, initialData]);
 
-  const handleSave = () => {
+  const handlePickAvatar = async () => {
+    try {
+      setPickerError(null);
+      const nextFile = await pickImageFile();
+      if (nextFile) {
+        setPictureFile(nextFile);
+        setRemovePicture(false);
+      }
+    } catch (error) {
+      setPickerError(
+        error instanceof Error && error.message.trim()
+          ? error.message
+          : "Could not open your photo library.",
+      );
+    }
+  };
+
+  const handleSave = async () => {
     if (!name.trim()) {
       alert("Name cannot be empty!");
       return;
     }
-    onSave({ name: name.trim(), bio: bio.trim() });
+
+    setSaving(true);
+    const didSave = await onSave({
+      name: name.trim(),
+      bio: bio.trim(),
+      pictureUrl: initialData.pictureUrl,
+      pictureFile,
+      removePicture,
+    });
+    setSaving(false);
+
+    if (didSave === false) {
+      return;
+    }
     onClose();
   };
+
+  const previewUrl =
+    pictureFile?.uri || (!removePicture ? initialData.pictureUrl : "");
 
   return (
     <Modal
@@ -78,9 +128,12 @@ export function EditProfileModal({
           <TouchableOpacity
             testID="save-button"
             onPress={handleSave}
+            disabled={isSaving}
             className="bg-gray-900 px-5 py-2 rounded-full"
           >
-            <Text className="text-white font-bold text-sm">Save</Text>
+            <Text className="text-white font-bold text-sm">
+              {isSaving ? "Saving..." : "Save"}
+            </Text>
           </TouchableOpacity>
         </View>
 
@@ -116,18 +169,50 @@ export function EditProfileModal({
                       className="w-22 h-22 bg-indigo-100 rounded-full items-center justify-center border-4 border-white overflow-hidden"
                       style={{ width: 88, height: 88 }}
                     >
-                      <Text className="text-3xl font-bold text-indigo-700">
-                        {name ? name.charAt(0).toUpperCase() : "?"}
-                      </Text>
+                      {previewUrl ? (
+                        <Image
+                          testID="avatar-preview"
+                          source={{ uri: previewUrl }}
+                          className="h-full w-full"
+                          resizeMode="cover"
+                        />
+                      ) : (
+                        <Text className="text-3xl font-bold text-indigo-700">
+                          {name ? name.charAt(0).toUpperCase() : "?"}
+                        </Text>
+                      )}
                     </View>
                   </View>
                   <TouchableOpacity
+                    testID="avatar-picker-button"
                     className="absolute bottom-0 right-0 bg-gray-900 w-8 h-8 rounded-full items-center justify-center border-2 border-white"
-                    onPress={() => console.log("TODO: Change Avatar")}
+                    onPress={handlePickAvatar}
                   >
                     <Ionicons name="camera" size={14} color="white" />
                   </TouchableOpacity>
                 </View>
+                {previewUrl ? (
+                  <TouchableOpacity
+                    testID="avatar-remove-button"
+                    onPress={() => {
+                      setPictureFile(null);
+                      setRemovePicture(true);
+                    }}
+                    className="mt-3 rounded-full border border-gray-200 px-4 py-2"
+                  >
+                    <Text className="text-xs font-bold text-gray-600">
+                      Remove photo
+                    </Text>
+                  </TouchableOpacity>
+                ) : null}
+                {pickerError ? (
+                  <Text
+                    testID="avatar-picker-error"
+                    className="mt-2 text-xs font-semibold text-red-600"
+                  >
+                    {pickerError}
+                  </Text>
+                ) : null}
               </View>
             </View>
 

--- a/mobile/components/profile/ProfileHeader.tsx
+++ b/mobile/components/profile/ProfileHeader.tsx
@@ -64,9 +64,16 @@ export function ProfileHeader({
         <View className="w-24 h-24 bg-surface-card dark:bg-surface-card-dark rounded-full p-1 shadow-sm border border-divider dark:border-divider-dark">
           <View className="w-full h-full bg-surface dark:bg-surface-dark rounded-full items-center justify-center overflow-hidden">
             {imageUrl ? (
-              <Image source={{ uri: imageUrl }} className="w-full h-full" />
+              <Image
+                testID="profile-avatar-image"
+                source={{ uri: imageUrl }}
+                className="w-full h-full"
+              />
             ) : (
-              <Text className="text-3xl font-bold text-on-surface-soft dark:text-on-surface-soft-dark">
+              <Text
+                testID="profile-avatar-fallback"
+                className="text-3xl font-bold text-on-surface-soft dark:text-on-surface-soft-dark"
+              >
                 {name.charAt(0)}
               </Text>
             )}
@@ -86,6 +93,7 @@ export function ProfileHeader({
 
           {onEdit ? (
             <Pressable
+              testID="profile-edit-button"
               className="h-8 w-8 items-center justify-center bg-surface dark:bg-surface-dark rounded-lg border border-divider dark:border-divider-dark"
               onPress={onEdit}
             >

--- a/mobile/components/profile/ProfilePostCard.tsx
+++ b/mobile/components/profile/ProfilePostCard.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from "@expo/vector-icons";
 import React from "react";
-import { Image, Text, View } from "react-native";
+import { Image, Linking, Text, TouchableOpacity, View } from "react-native";
 
 import type { ProfilePost } from "@/lib/queries/profile";
 
@@ -66,6 +66,16 @@ function getInitials(name: string): string {
   return initials || "?";
 }
 
+function isImageMediaUrl(mediaUrl: string): boolean {
+  const normalized = mediaUrl.split("?")[0]?.toLowerCase() ?? "";
+  const filename = normalized.split("/").pop() ?? "";
+  if (filename.endsWith(".pdf")) {
+    return false;
+  }
+
+  return /\.(jpe?g|png|gif|webp)$/.test(filename) || !filename.includes(".");
+}
+
 interface ProfilePostCardProps {
   post: ProfilePost;
   /** When true, content is not truncated. Default: false (preview mode). */
@@ -91,6 +101,7 @@ export function ProfilePostCard({
   const authorSubtitle = post.author?.title || post.author?.username || "";
   const accentColor = getAccentColor(post.event_type);
   const iconName = getIconName(post.category, post.event_type);
+  const hasImageMedia = post.media_url ? isImageMediaUrl(post.media_url) : false;
 
   return (
     <View
@@ -162,14 +173,41 @@ export function ProfilePostCard({
         </Text>
       ) : null}
 
-      {/* Media thumbnail */}
-      {post.media_url ? (
+      {post.media_url && hasImageMedia ? (
         <Image
           testID={`post-card-media-${post.id}`}
           source={{ uri: post.media_url }}
-          className="mt-3 h-36 w-full rounded-xl bg-surface-active dark:bg-surface-active-dark"
+          className={`mt-3 w-full rounded-xl bg-surface-active dark:bg-surface-active-dark ${
+            expanded ? "h-72" : "h-52"
+          }`}
           resizeMode="cover"
         />
+      ) : null}
+
+      {post.media_url && !hasImageMedia ? (
+        <TouchableOpacity
+          testID={`post-card-attachment-${post.id}`}
+          activeOpacity={0.82}
+          onPress={() => {
+            void Linking.openURL(post.media_url ?? "");
+          }}
+          className="mt-3 flex-row items-center gap-3 rounded-xl border border-divider bg-surface-active px-3 py-3 dark:border-divider-dark dark:bg-surface-active-dark"
+        >
+          <View className="h-10 w-10 items-center justify-center rounded-full bg-surface-card dark:bg-surface-card-dark">
+            <Ionicons name="document-attach-outline" size={20} color="#2f7d68" />
+          </View>
+          <View className="min-w-0 flex-1">
+            <Text className="text-sm font-bold text-on-surface dark:text-on-surface-dark">
+              Attachment
+            </Text>
+            <Text
+              numberOfLines={1}
+              className="text-xs text-on-surface-soft dark:text-on-surface-soft-dark"
+            >
+              Open file
+            </Text>
+          </View>
+        </TouchableOpacity>
       ) : null}
     </View>
   );

--- a/mobile/components/profile/ProfilePostComposer.tsx
+++ b/mobile/components/profile/ProfilePostComposer.tsx
@@ -14,6 +14,9 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
+import { PostMediaPicker } from "@/components/posts/PostMediaPicker";
+import { uploadPostMedia } from "@/lib/queries/uploads";
+import type { LocalUploadFile } from "@/lib/queries/uploads";
 import type { CreateProfilePostPayload } from "@/lib/queries/profile";
 
 const EVENT_TYPES: {
@@ -42,12 +45,18 @@ export function ProfilePostComposer({
   const [eventType, setEventType] =
     useState<CreateProfilePostPayload["event_type"]>("social");
   const [content, setContent] = useState("");
+  const [media, setMedia] = useState<LocalUploadFile | null>(null);
+  const [mediaError, setMediaError] = useState<string | null>(null);
+  const [isUploadingMedia, setUploadingMedia] = useState(false);
 
-  const canSubmit = content.trim().length > 0 && !isSubmitting;
+  const isBusy = Boolean(isSubmitting) || isUploadingMedia;
+  const canSubmit = content.trim().length > 0 && !isBusy;
 
   const resetForm = () => {
     setContent("");
     setEventType("social");
+    setMedia(null);
+    setMediaError(null);
   };
 
   const handleSubmit = async () => {
@@ -55,9 +64,30 @@ export function ProfilePostComposer({
       return;
     }
 
+    setMediaError(null);
+
+    let mediaUrl: string | null | undefined;
+    if (media) {
+      try {
+        setUploadingMedia(true);
+        const uploadResponse = await uploadPostMedia(media);
+        mediaUrl = uploadResponse.url;
+      } catch (error) {
+        setMediaError(
+          error instanceof Error && error.message.trim()
+            ? error.message
+            : "Could not upload this photo.",
+        );
+        return;
+      } finally {
+        setUploadingMedia(false);
+      }
+    }
+
     const didSubmit = await onSubmit({
       event_type: eventType,
       content: content.trim(),
+      ...(mediaUrl ? { media_url: mediaUrl } : {}),
     });
 
     if (didSubmit === false) {
@@ -155,11 +185,25 @@ export function ProfilePostComposer({
                 className="mt-4 min-h-[140px] rounded-xl border border-divider bg-surface-card px-3 py-3 text-on-surface dark:border-divider-dark dark:bg-surface-card-dark dark:text-on-surface-dark"
               />
 
-              <View className="mt-4 rounded-xl border border-dashed border-divider px-3 py-3 dark:border-divider-dark">
-                <Text className="text-xs font-semibold text-on-surface-soft dark:text-on-surface-soft-dark">
-                  This post will appear in your profile feed.
+              <PostMediaPicker
+                disabled={isBusy}
+                media={media}
+                onChange={(nextMedia) => {
+                  setMediaError(null);
+                  setMedia(nextMedia);
+                }}
+                onError={setMediaError}
+                testIDPrefix="profile-composer"
+              />
+
+              {mediaError ? (
+                <Text
+                  testID="profile-composer-media-error"
+                  className="mt-2 text-xs font-semibold text-error dark:text-red-200"
+                >
+                  {mediaError}
                 </Text>
-              </View>
+              ) : null}
             </ScrollView>
 
             <SafeAreaView
@@ -175,7 +219,7 @@ export function ProfilePostComposer({
                   canSubmit ? "bg-primary dark:bg-primary-dim" : "bg-gray-300"
                 }`}
               >
-                {isSubmitting ? (
+                {isBusy ? (
                   <ActivityIndicator size="small" color="#ffffff" />
                 ) : (
                   <Text className="font-bold text-white">Post to Profile</Text>

--- a/mobile/components/timeline/TimelineEventComposer.tsx
+++ b/mobile/components/timeline/TimelineEventComposer.tsx
@@ -15,6 +15,9 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
+import { PostMediaPicker } from "@/components/posts/PostMediaPicker";
+import { uploadPostMedia } from "@/lib/queries/uploads";
+import type { LocalUploadFile } from "@/lib/queries/uploads";
 import type { MCTEEventType } from "@/lib/queries/mentorship";
 
 const EVENT_TYPES: {
@@ -46,13 +49,19 @@ export function TimelineEventComposer({
   const [eventType, setEventType] = useState<MCTEEventType>("achievement");
   const [content, setContent] = useState("");
   const [showOnProfile, setShowOnProfile] = useState(false);
+  const [media, setMedia] = useState<LocalUploadFile | null>(null);
+  const [mediaError, setMediaError] = useState<string | null>(null);
+  const [isUploadingMedia, setUploadingMedia] = useState(false);
 
-  const canSubmit = content.trim().length > 0 && !isSubmitting;
+  const isBusy = Boolean(isSubmitting) || isUploadingMedia;
+  const canSubmit = content.trim().length > 0 && !isBusy;
 
   const resetForm = () => {
     setContent("");
     setShowOnProfile(false);
     setEventType("achievement");
+    setMedia(null);
+    setMediaError(null);
   };
 
   const handleSubmit = async () => {
@@ -60,9 +69,30 @@ export function TimelineEventComposer({
       return;
     }
 
+    setMediaError(null);
+
+    let mediaUrl: string | null | undefined;
+    if (media) {
+      try {
+        setUploadingMedia(true);
+        const uploadResponse = await uploadPostMedia(media);
+        mediaUrl = uploadResponse.url;
+      } catch (error) {
+        setMediaError(
+          error instanceof Error && error.message.trim()
+            ? error.message
+            : "Could not upload this photo.",
+        );
+        return;
+      } finally {
+        setUploadingMedia(false);
+      }
+    }
+
     const didSubmit = await onSubmit({
       event_type: eventType,
       content: content.trim(),
+      ...(mediaUrl ? { media_url: mediaUrl } : {}),
       show_on_profile: showOnProfile,
     });
 
@@ -163,6 +193,26 @@ export function TimelineEventComposer({
                 className="mt-4 min-h-[112px] rounded-xl border border-divider bg-surface-card px-3 py-3 text-on-surface dark:border-divider-dark dark:bg-surface-card-dark dark:text-on-surface-dark"
               />
 
+              <PostMediaPicker
+                disabled={isBusy}
+                media={media}
+                onChange={(nextMedia) => {
+                  setMediaError(null);
+                  setMedia(nextMedia);
+                }}
+                onError={setMediaError}
+                testIDPrefix="timeline-composer"
+              />
+
+              {mediaError ? (
+                <Text
+                  testID="timeline-composer-media-error"
+                  className="mt-2 text-xs font-semibold text-error dark:text-red-200"
+                >
+                  {mediaError}
+                </Text>
+              ) : null}
+
               <View className="mt-4 flex-row items-center justify-between gap-3 pb-4">
                 <View className="flex-1">
                   <Text className="text-sm font-bold text-on-surface dark:text-on-surface-dark">
@@ -197,7 +247,7 @@ export function TimelineEventComposer({
                   canSubmit ? "bg-primary dark:bg-primary-dim" : "bg-gray-300"
                 }`}
               >
-                {isSubmitting ? (
+                {isBusy ? (
                   <ActivityIndicator size="small" color="#ffffff" />
                 ) : (
                   <Text className="font-bold text-white">Save Milestone</Text>

--- a/mobile/components/ui/UserAvatar.tsx
+++ b/mobile/components/ui/UserAvatar.tsx
@@ -1,0 +1,73 @@
+import { Image, Text, View } from "react-native";
+
+export type AvatarShape = "circle" | "rounded";
+export type AvatarSize = "sm" | "md" | "lg" | "xl";
+
+interface UserAvatarProps {
+  imageUrl?: string | null;
+  name: string;
+  shape?: AvatarShape;
+  size?: AvatarSize;
+  testIDPrefix?: string;
+}
+
+const SIZE_CLASSES: Record<AvatarSize, string> = {
+  sm: "h-12 w-12",
+  md: "h-15 w-15",
+  lg: "h-[72px] w-[72px]",
+  xl: "h-20 w-20",
+};
+
+const TEXT_CLASSES: Record<AvatarSize, string> = {
+  sm: "text-base",
+  md: "text-[22px]",
+  lg: "text-[26px]",
+  xl: "text-[22px]",
+};
+
+function getInitials(name: string): string {
+  const initials = name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((part) => part[0] ?? "")
+    .join("")
+    .toUpperCase();
+
+  return initials || "?";
+}
+
+export function UserAvatar({
+  imageUrl,
+  name,
+  shape = "circle",
+  size = "sm",
+  testIDPrefix = "user-avatar",
+}: Readonly<UserAvatarProps>) {
+  const shapeClass = shape === "circle" ? "rounded-full" : "rounded-lg";
+  const sizeClass = SIZE_CLASSES[size];
+
+  if (imageUrl?.trim()) {
+    return (
+      <Image
+        testID={`${testIDPrefix}-image`}
+        source={{ uri: imageUrl }}
+        className={`${sizeClass} ${shapeClass} bg-surface-active dark:bg-surface-active-dark`}
+        resizeMode="cover"
+      />
+    );
+  }
+
+  return (
+    <View
+      testID={`${testIDPrefix}-fallback`}
+      className={`${sizeClass} ${shapeClass} bg-surface-active dark:bg-surface-active-dark items-center justify-center`}
+    >
+      <Text
+        className={`${TEXT_CLASSES[size]} font-bold text-primary dark:text-primary-dim`}
+      >
+        {getInitials(name)}
+      </Text>
+    </View>
+  );
+}

--- a/mobile/lib/api/client.ts
+++ b/mobile/lib/api/client.ts
@@ -87,6 +87,38 @@ export async function apiPost<TResponse, TPayload = unknown>(
 }
 
 /**
+ * Perform a typed multipart POST request against the backend API.
+ * The caller must provide a FormData body; React Native sets the multipart
+ * boundary automatically when Content-Type is omitted.
+ */
+export async function apiPostMultipart<TResponse>(
+  path: string,
+  formData: FormData,
+): Promise<TResponse> {
+  const accessToken = useAuthStore.getState().accessToken;
+
+  const response = await fetchWithTimeout(`${API_BASE_URL}${path}`, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+    },
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const message = await readErrorMessage(response);
+    throw new ApiError(response.status, message);
+  }
+
+  if (response.status === 204) {
+    return undefined as TResponse;
+  }
+
+  return (await response.json()) as TResponse;
+}
+
+/**
  * Perform a typed PATCH request against the backend API.
  * Uses the access token from auth store.
  *

--- a/mobile/lib/api/client.ts
+++ b/mobile/lib/api/client.ts
@@ -104,7 +104,7 @@ export async function apiPostMultipart<TResponse>(
       ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
     },
     body: formData,
-  });
+  }, 60000); // Increased timeout to 60s for file uploads
 
   if (!response.ok) {
     const message = await readErrorMessage(response);

--- a/mobile/lib/queries/MessagingQueries.ts
+++ b/mobile/lib/queries/MessagingQueries.ts
@@ -57,13 +57,13 @@ export function useMessages(conversationId: string) {
 
 export function useSendMessage(conversationId: string) {
   return useMutation({
-    mutationFn: ({ body = "", attachment = null }: SendMessageInput) => {
+    mutationFn: async ({ body = "", attachment = null }: SendMessageInput) => {
       const formData = new FormData();
       if (body) {
         formData.append("body", body);
       }
       if (attachment) {
-        appendUploadFile(formData, "attachment", attachment);
+        await appendUploadFile(formData, "attachment", attachment);
       }
 
       return apiPostMultipart<Message>(

--- a/mobile/lib/queries/MessagingQueries.ts
+++ b/mobile/lib/queries/MessagingQueries.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { apiGet, apiPost } from "@/lib/api/client";
+import { apiGet, apiPostMultipart } from "@/lib/api/client";
+import { appendUploadFile, type LocalUploadFile } from "@/lib/queries/uploads";
 
 export interface ProfileSummary {
   id: string;
@@ -27,6 +28,11 @@ export interface Message {
   created_at: string;
 }
 
+export interface SendMessageInput {
+  body?: string;
+  attachment?: LocalUploadFile | null;
+}
+
 export function useConversations() {
   return useQuery({
     queryKey: ["messaging", "conversations"],
@@ -51,9 +57,19 @@ export function useMessages(conversationId: string) {
 
 export function useSendMessage(conversationId: string) {
   return useMutation({
-    mutationFn: (body: string) =>
-      apiPost<Message>(`/api/messages/conversations/${conversationId}/`, {
-        body,
-      }),
+    mutationFn: ({ body = "", attachment = null }: SendMessageInput) => {
+      const formData = new FormData();
+      if (body) {
+        formData.append("body", body);
+      }
+      if (attachment) {
+        appendUploadFile(formData, "attachment", attachment);
+      }
+
+      return apiPostMultipart<Message>(
+        `/api/messages/conversations/${conversationId}/`,
+        formData,
+      );
+    },
   });
 }

--- a/mobile/lib/queries/communityPosts.ts
+++ b/mobile/lib/queries/communityPosts.ts
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 
 import { apiDelete, apiGet, apiPatch, apiPost } from "@/lib/api/client";
 import {
@@ -60,6 +65,8 @@ export const communityPostsQueryKeys = {
     offset: number,
     eventType?: CommunityPostEventType,
   ) => ["community-posts", tagId, limit, offset, eventType ?? "all"] as const,
+  myFeed: (tagIds: string[], limit: number) =>
+    ["community-posts", "me", "feed", tagIds.join(","), limit] as const,
 };
 
 function buildQueryString(params: Record<string, string | number | undefined>) {
@@ -107,6 +114,42 @@ export function useCommunityPostsQuery(
     enabled: Boolean(params.tagId) && enabled,
     staleTime: 30_000,
   });
+}
+
+export function useMyCommunityPostsFeedQuery(
+  tagIds: string[],
+  limitPerCommunity = 5,
+  enabled = true,
+) {
+  const uniqueTagIds = [...new Set(tagIds.filter(Boolean))];
+  const queries = useQueries({
+    queries: uniqueTagIds.map((tagId) => ({
+      queryKey: communityPostsQueryKeys.list(tagId, limitPerCommunity, 0),
+      queryFn: () =>
+        fetchCommunityPosts({
+          tagId,
+          limit: limitPerCommunity,
+          offset: 0,
+        }),
+      enabled: enabled && uniqueTagIds.length > 0,
+      staleTime: 30_000,
+    })),
+  });
+
+  const posts = queries
+    .flatMap((query) => query.data?.results ?? [])
+    .sort(
+      (left, right) =>
+        new Date(right.timestamp).getTime() - new Date(left.timestamp).getTime(),
+    );
+
+  return {
+    data: posts,
+    isLoading: queries.some((query) => query.isLoading),
+    isFetching: queries.some((query) => query.isFetching),
+    isError: queries.some((query) => query.isError),
+    error: queries.find((query) => query.error)?.error,
+  };
 }
 
 export function useCreateCommunityPostMutation(currentUsername?: string) {

--- a/mobile/lib/queries/profile.ts
+++ b/mobile/lib/queries/profile.ts
@@ -59,6 +59,7 @@ interface UpdateProfilePayload {
   display_name?: string;
   bio?: string;
   skills?: string[];
+  picture_url?: string;
 }
 
 interface ProfilePatchResponse {

--- a/mobile/lib/queries/uploads.ts
+++ b/mobile/lib/queries/uploads.ts
@@ -1,0 +1,56 @@
+import { apiDelete, apiPostMultipart } from "@/lib/api/client";
+
+export interface LocalUploadFile {
+  uri: string;
+  name: string;
+  type: string;
+}
+
+export interface PostMediaUploadResponse {
+  url: string;
+}
+
+export interface ProfilePictureUploadResponse {
+  detail: string;
+  picture_url: string;
+}
+
+function appendUploadFile(
+  formData: FormData,
+  fieldName: string,
+  file: LocalUploadFile,
+) {
+  formData.append(fieldName, {
+    uri: file.uri,
+    name: file.name,
+    type: file.type,
+  } as unknown as Blob);
+}
+
+export function uploadPostMedia(
+  file: LocalUploadFile,
+): Promise<PostMediaUploadResponse> {
+  const formData = new FormData();
+  appendUploadFile(formData, "file", file);
+
+  return apiPostMultipart<PostMediaUploadResponse>(
+    "/api/profiles/me/uploads/",
+    formData,
+  );
+}
+
+export function uploadProfilePicture(
+  file: LocalUploadFile,
+): Promise<ProfilePictureUploadResponse> {
+  const formData = new FormData();
+  appendUploadFile(formData, "picture", file);
+
+  return apiPostMultipart<ProfilePictureUploadResponse>(
+    "/api/profiles/me/picture/",
+    formData,
+  );
+}
+
+export function deleteProfilePicture(): Promise<ProfilePictureUploadResponse> {
+  return apiDelete<ProfilePictureUploadResponse>("/api/profiles/me/picture/");
+}

--- a/mobile/lib/queries/uploads.ts
+++ b/mobile/lib/queries/uploads.ts
@@ -15,7 +15,7 @@ export interface ProfilePictureUploadResponse {
   picture_url: string;
 }
 
-function appendUploadFile(
+export function appendUploadFile(
   formData: FormData,
   fieldName: string,
   file: LocalUploadFile,

--- a/mobile/lib/queries/uploads.ts
+++ b/mobile/lib/queries/uploads.ts
@@ -1,3 +1,4 @@
+import { Platform } from "react-native";
 import { apiDelete, apiPostMultipart } from "@/lib/api/client";
 
 export interface LocalUploadFile {
@@ -15,23 +16,31 @@ export interface ProfilePictureUploadResponse {
   picture_url: string;
 }
 
-export function appendUploadFile(
+export async function appendUploadFile(
   formData: FormData,
   fieldName: string,
   file: LocalUploadFile,
 ) {
-  formData.append(fieldName, {
-    uri: file.uri,
-    name: file.name,
-    type: file.type,
-  } as unknown as Blob);
+  if (Platform.OS === "web") {
+    // On web, we need to convert the URI to a real Blob/File
+    const response = await fetch(file.uri);
+    const blob = await response.blob();
+    formData.append(fieldName, blob, file.name);
+  } else {
+    // On native, we use the standard React Native object
+    formData.append(fieldName, {
+      uri: file.uri,
+      name: file.name,
+      type: file.type,
+    } as any);
+  }
 }
 
-export function uploadPostMedia(
+export async function uploadPostMedia(
   file: LocalUploadFile,
 ): Promise<PostMediaUploadResponse> {
   const formData = new FormData();
-  appendUploadFile(formData, "file", file);
+  await appendUploadFile(formData, "file", file);
 
   return apiPostMultipart<PostMediaUploadResponse>(
     "/api/profiles/me/uploads/",
@@ -39,11 +48,11 @@ export function uploadPostMedia(
   );
 }
 
-export function uploadProfilePicture(
+export async function uploadProfilePicture(
   file: LocalUploadFile,
 ): Promise<ProfilePictureUploadResponse> {
   const formData = new FormData();
-  appendUploadFile(formData, "picture", file);
+  await appendUploadFile(formData, "picture", file);
 
   return apiPostMultipart<ProfilePictureUploadResponse>(
     "/api/profiles/me/picture/",

--- a/mobile/lib/uploads/picker.ts
+++ b/mobile/lib/uploads/picker.ts
@@ -15,7 +15,7 @@ function extensionFromMimeType(mimeType?: string | null): string {
   return "jpg";
 }
 
-export async function pickPostImageFile(): Promise<LocalUploadFile | null> {
+export async function pickImageFile(): Promise<LocalUploadFile | null> {
   const result = await ImagePicker.launchImageLibraryAsync({
     allowsMultipleSelection: false,
     mediaTypes: ["images"],
@@ -40,3 +40,5 @@ export async function pickPostImageFile(): Promise<LocalUploadFile | null> {
     type,
   };
 }
+
+export const pickPostImageFile = pickImageFile;

--- a/mobile/lib/uploads/picker.ts
+++ b/mobile/lib/uploads/picker.ts
@@ -1,0 +1,42 @@
+import * as ImagePicker from "expo-image-picker";
+
+import type { LocalUploadFile } from "@/lib/queries/uploads";
+
+function extensionFromMimeType(mimeType?: string | null): string {
+  if (mimeType === "image/png") {
+    return "png";
+  }
+  if (mimeType === "image/gif") {
+    return "gif";
+  }
+  if (mimeType === "image/webp") {
+    return "webp";
+  }
+  return "jpg";
+}
+
+export async function pickPostImageFile(): Promise<LocalUploadFile | null> {
+  const result = await ImagePicker.launchImageLibraryAsync({
+    allowsMultipleSelection: false,
+    mediaTypes: ["images"],
+    quality: 0.9,
+  });
+
+  if (result.canceled) {
+    return null;
+  }
+
+  const asset = result.assets[0];
+  if (!asset) {
+    return null;
+  }
+
+  const type = asset.mimeType ?? "image/jpeg";
+  const extension = extensionFromMimeType(type);
+
+  return {
+    uri: asset.uri,
+    name: asset.fileName ?? `post-media.${extension}`,
+    type,
+  };
+}

--- a/mobile/lib/uploads/picker.ts
+++ b/mobile/lib/uploads/picker.ts
@@ -1,50 +1,97 @@
 import * as ImagePicker from "expo-image-picker";
+import { Alert } from "react-native";
 
 import type { LocalUploadFile } from "@/lib/queries/uploads";
 
+const MB = 1024 * 1024;
+const LIMITS = {
+  PROFILE: 5 * MB,
+  POST: 10 * MB,
+  CHAT: 20 * MB,
+};
+
 function extensionFromMimeType(mimeType?: string | null): string {
-  if (mimeType === "image/png") {
-    return "png";
-  }
-  if (mimeType === "image/gif") {
-    return "gif";
-  }
-  if (mimeType === "image/webp") {
-    return "webp";
-  }
+  if (mimeType === "image/png") return "png";
+  if (mimeType === "image/gif") return "gif";
+  if (mimeType === "image/webp") return "webp";
+  if (mimeType === "application/pdf") return "pdf";
   return "jpg";
 }
 
-export async function pickImageFile(): Promise<LocalUploadFile | null> {
+function validateFileSize(size: number | undefined, limit: number): boolean {
+  if (size && size > limit) {
+    const limitMB = limit / MB;
+    Alert.alert(
+      "File Too Large",
+      `The selected file is ${Math.round(size / MB)}MB. Maximum allowed size is ${limitMB}MB.`,
+    );
+    return false;
+  }
+  return true;
+}
+
+export async function pickProfilePictureFile(): Promise<LocalUploadFile | null> {
   const result = await ImagePicker.launchImageLibraryAsync({
     allowsMultipleSelection: false,
     mediaTypes: ["images"],
-    quality: 0.9,
+    quality: 0.8,
   });
 
-  if (result.canceled) {
-    return null;
-  }
+  if (result.canceled || !result.assets[0]) return null;
 
   const asset = result.assets[0];
-  if (!asset) {
-    return null;
-  }
+  if (!validateFileSize(asset.fileSize, LIMITS.PROFILE)) return null;
 
   const type = asset.mimeType ?? "image/jpeg";
   const extension = extensionFromMimeType(type);
 
   return {
     uri: asset.uri,
-    name: asset.fileName ?? `post-media.${extension}`,
+    name: asset.fileName ?? `profile-picture.${extension}`,
     type,
   };
 }
 
-export const pickPostImageFile = pickImageFile;
+export async function pickPostMediaFile(): Promise<LocalUploadFile | null> {
+  const DocumentPicker = await import("expo-document-picker");
+  const result = await DocumentPicker.getDocumentAsync({
+    type: ["image/*", "application/pdf"],
+    copyToCacheDirectory: true,
+    multiple: false,
+  });
+
+  if (result.canceled || !result.assets[0]) return null;
+
+  const asset = result.assets[0];
+  if (!validateFileSize(asset.size, LIMITS.POST)) return null;
+
+  return {
+    uri: asset.uri,
+    name: asset.name || "attachment",
+    type: asset.mimeType || "application/octet-stream",
+  };
+}
 
 export async function pickMessageImageFile(): Promise<LocalUploadFile | null> {
-  return pickImageFile();
+  const result = await ImagePicker.launchImageLibraryAsync({
+    allowsMultipleSelection: false,
+    mediaTypes: ["images"],
+    quality: 0.8,
+  });
+
+  if (result.canceled || !result.assets[0]) return null;
+
+  const asset = result.assets[0];
+  if (!validateFileSize(asset.fileSize, LIMITS.CHAT)) return null;
+
+  const type = asset.mimeType ?? "image/jpeg";
+  const extension = extensionFromMimeType(type);
+
+  return {
+    uri: asset.uri,
+    name: asset.fileName ?? `chat-image.${extension}`,
+    type,
+  };
 }
 
 export async function pickMessagePdfFile(): Promise<LocalUploadFile | null> {
@@ -55,14 +102,10 @@ export async function pickMessagePdfFile(): Promise<LocalUploadFile | null> {
     multiple: false,
   });
 
-  if (result.canceled) {
-    return null;
-  }
+  if (result.canceled || !result.assets[0]) return null;
 
   const asset = result.assets[0];
-  if (!asset) {
-    return null;
-  }
+  if (!validateFileSize(asset.size, LIMITS.CHAT)) return null;
 
   return {
     uri: asset.uri,
@@ -70,3 +113,7 @@ export async function pickMessagePdfFile(): Promise<LocalUploadFile | null> {
     type: asset.mimeType || "application/pdf",
   };
 }
+
+// Deprecated alias for backward compatibility
+export const pickImageFile = pickProfilePictureFile;
+export const pickPostImageFile = pickPostMediaFile;

--- a/mobile/lib/uploads/picker.ts
+++ b/mobile/lib/uploads/picker.ts
@@ -42,3 +42,31 @@ export async function pickImageFile(): Promise<LocalUploadFile | null> {
 }
 
 export const pickPostImageFile = pickImageFile;
+
+export async function pickMessageImageFile(): Promise<LocalUploadFile | null> {
+  return pickImageFile();
+}
+
+export async function pickMessagePdfFile(): Promise<LocalUploadFile | null> {
+  const DocumentPicker = await import("expo-document-picker");
+  const result = await DocumentPicker.getDocumentAsync({
+    type: "application/pdf",
+    copyToCacheDirectory: true,
+    multiple: false,
+  });
+
+  if (result.canceled) {
+    return null;
+  }
+
+  const asset = result.assets[0];
+  if (!asset) {
+    return null;
+  }
+
+  return {
+    uri: asset.uri,
+    name: asset.name || "attachment.pdf",
+    type: asset.mimeType || "application/pdf",
+  };
+}

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -17,6 +17,7 @@
         "expo": "~54.0.33",
         "expo-constants": "~18.0.13",
         "expo-dev-client": "~6.0.21",
+        "expo-document-picker": "~14.0.8",
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
@@ -7503,6 +7504,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-2.0.0.tgz",
       "integrity": "sha512-BvAMPt6x+vyXpThsyjjOYyjwfjREV4OOpQkZ0tNl+nGpsPfcY9mc6DRACoWnH9KpLzyIt3BOgh3cuy/h/OxQjw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-document-picker": {
+      "version": "14.0.8",
+      "resolved": "https://registry.npmjs.org/expo-document-picker/-/expo-document-picker-14.0.8.tgz",
+      "integrity": "sha512-3tyQKpPqWWFlI8p9RiMX1+T1Zge5mEKeBuXWp1h8PEItFMUDSiOJbQ112sfdC6Hxt8wSxreV9bCRl/NgBdt+fA==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -23,6 +23,7 @@
     "expo": "~54.0.33",
     "expo-constants": "~18.0.13",
     "expo-dev-client": "~6.0.21",
+    "expo-document-picker": "~14.0.8",
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",


### PR DESCRIPTION
## Related Issue

- Closes #472 
- Closes #473 
- Closes #238 

## Description

Adds mobile support for cloud-backed profile and post media uploads. This PR introduces community creation from the Community tab, authenticated multipart upload clients, optional media attachments for profile/timeline/community post composers, safer post attachment rendering, profile avatar upload/removal, and consistent avatar rendering across profile, discovery, and connection surfaces. It also updates the Community tab feed to aggregate posts from joined communities.

Also added pdf/image upload support to messages with attachment loading ui

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or configuration

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code