### PR TITLE
feat(auth): honor REQUIRE_EMAIL_VERIFICATION flag in IsEmailVerified

### DIFF
--- a/backend/accounts/permissions.py
+++ b/backend/accounts/permissions.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from rest_framework.permissions import BasePermission
 
 from .models import UserRole
@@ -54,5 +55,8 @@ class IsEmailVerified(BasePermission):
     def has_permission(self, request, view):
         if not request.user or not request.user.is_authenticated:
             return False
+
+        if not getattr(settings, "REQUIRE_EMAIL_VERIFICATION", True):
+            return True
 
         return bool(getattr(request.user, "is_email_verified", False))

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -1414,6 +1414,23 @@ class IsEmailVerifiedPermissionTests(TestCase):
         request.user = user  # type: ignore[attr-defined]
         self.assertTrue(self.permission.has_permission(request, Mock()))
 
+    @override_settings(REQUIRE_EMAIL_VERIFICATION=False)
+    def test_allows_unverified_user_when_flag_disabled(self) -> None:
+        """Bypass flag lets unverified users through so devs can test gated flows."""
+        user = User.objects.create_user(email="bypass@example.com", password="P!aaabbbb")
+        user.is_email_verified = False
+        user.save(update_fields=["is_email_verified"])
+        request = self.factory.get("/")
+        request.user = user  # type: ignore[attr-defined]
+        self.assertTrue(self.permission.has_permission(request, Mock()))
+
+    @override_settings(REQUIRE_EMAIL_VERIFICATION=False)
+    def test_still_denies_anonymous_when_flag_disabled(self) -> None:
+        """Bypass flag must not weaken authentication; anonymous is still rejected."""
+        request = self.factory.get("/")
+        request.user = AnonymousUser()  # type: ignore[attr-defined]
+        self.assertFalse(self.permission.has_permission(request, Mock()))
+
 
 # ---------------------------------------------------------------------------
 # OAuth2 Login Tests


### PR DESCRIPTION
## Summary
Addresses the review feedback on #431: registration already auto-verifies new users when `REQUIRE_EMAIL_VERIFICATION=False`, but the `IsEmailVerified` permission still rejected legacy unverified users, so flipping the flag did not actually disable email verification gating for development and testing.

This change makes the permission short-circuit to `True` when the flag is `False`, while still rejecting anonymous requests so authentication is not weakened.

## Test plan
- [ ] Existing \`IsEmailVerifiedPermissionTests\` cases still pass with the default \`REQUIRE_EMAIL_VERIFICATION=True\`.
- [ ] New test confirms an unverified authenticated user is allowed when the flag is False.
- [ ] New test confirms anonymous requests are still rejected when the flag is False.
- [ ] Set \`REQUIRE_EMAIL_VERIFICATION=False\` locally, register a fresh user, and verify a gated endpoint (e.g. mentorship request creation) succeeds without going through the verify-email flow.