### PR TITLE
feat(web): add forgot password and reset password pages 

### DIFF
--- a/web/src/components/layout/UnauthorizedFooter.tsx
+++ b/web/src/components/layout/UnauthorizedFooter.tsx
@@ -15,7 +15,7 @@ export function UnauthorizedFooter() {
 
 
                 {/* Links */}
-                <nav className="flex items-center gap-5">
+                <nav aria-label="Footer navigation" className="flex items-center gap-5">
                     {FOOTER_LINKS.map(({ to, label }) => (
                         <NavLink
                             key={to}

--- a/web/src/components/layout/UnauthorizedHeader.tsx
+++ b/web/src/components/layout/UnauthorizedHeader.tsx
@@ -14,7 +14,7 @@ export function UnauthorizedHeader() {
 
 
                 {/* Nav */}
-                <nav className="hidden sm:flex items-center gap-6">
+                <nav aria-label="Main navigation" className="hidden sm:flex items-center gap-6">
                     {NAV_LINKS.map(({ to, label }) => (
                         <NavLink
                             key={to}

--- a/web/src/lib/queries/AuthQueries.ts
+++ b/web/src/lib/queries/AuthQueries.ts
@@ -166,7 +166,7 @@ export async function forgotPasswordFn(data: { email: string }) {
     if (!res.ok && res.status !== 400) await throwApiError(res)
 }
 
-export async function resetPasswordFn(data: { token: string; password: string }) {
+export async function resetPasswordFn(data: { token: string; new_password: string; confirm_password: string }) {
     const res = await fetch(`${API_BASE_URL}/auth/reset-password/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/web/src/lib/queries/AuthQueries.ts
+++ b/web/src/lib/queries/AuthQueries.ts
@@ -155,3 +155,29 @@ export function useUpdateAppUsageMode() {
         mutationFn: updateAppUsageModeFn,
     })
 }
+
+export async function forgotPasswordFn(data: { email: string }) {
+    const res = await fetch(`${API_BASE_URL}/auth/forgot-password/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+    })
+    // Always swallow errors — generic response to prevent account enumeration
+    if (!res.ok && res.status !== 400) await throwApiError(res)
+}
+
+export async function resetPasswordFn(data: { token: string; password: string }) {
+    const res = await fetch(`${API_BASE_URL}/auth/reset-password/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+    })
+    if (!res.ok) await throwApiError(res)
+}
+
+export function clearAuthState() {
+    localStorage.removeItem('access_token')
+    localStorage.removeItem('refresh_token')
+    localStorage.removeItem('id')
+    queryClient.clear()
+}

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as OnBoardingRouteRouteImport } from './routes/_onBoarding/route'
 import { Route as AuthorizedRouteRouteImport } from './routes/_authorized/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ProfilesUsernameRouteImport } from './routes/profiles.$username'
+import { Route as UnauthorizedResetPasswordRouteImport } from './routes/_unauthorized/reset-password'
 import { Route as UnauthorizedRegisterRouteImport } from './routes/_unauthorized/register'
 import { Route as UnauthorizedLoginRouteImport } from './routes/_unauthorized/login'
 import { Route as UnauthorizedForgotPasswordRouteImport } from './routes/_unauthorized/forgot-password'
@@ -24,7 +25,6 @@ import { Route as AuthorizedMessagesRouteImport } from './routes/_authorized/mes
 import { Route as AuthorizedDiscoverRouteImport } from './routes/_authorized/discover'
 import { Route as AuthorizedDashboardRouteImport } from './routes/_authorized/dashboard'
 import { Route as AuthorizedConnectionsRouteImport } from './routes/_authorized/connections'
-import { Route as UnauthorizedResetPasswordTokenRouteImport } from './routes/_unauthorized/reset-password.$token'
 
 const UnauthorizedRouteRoute = UnauthorizedRouteRouteImport.update({
   id: '/_unauthorized',
@@ -48,6 +48,12 @@ const ProfilesUsernameRoute = ProfilesUsernameRouteImport.update({
   path: '/profiles/$username',
   getParentRoute: () => rootRouteImport,
 } as any)
+const UnauthorizedResetPasswordRoute =
+  UnauthorizedResetPasswordRouteImport.update({
+    id: '/reset-password',
+    path: '/reset-password',
+    getParentRoute: () => UnauthorizedRouteRoute,
+  } as any)
 const UnauthorizedRegisterRoute = UnauthorizedRegisterRouteImport.update({
   id: '/register',
   path: '/register',
@@ -100,12 +106,6 @@ const AuthorizedConnectionsRoute = AuthorizedConnectionsRouteImport.update({
   path: '/connections',
   getParentRoute: () => AuthorizedRouteRoute,
 } as any)
-const UnauthorizedResetPasswordTokenRoute =
-  UnauthorizedResetPasswordTokenRouteImport.update({
-    id: '/reset-password/$token',
-    path: '/reset-password/$token',
-    getParentRoute: () => UnauthorizedRouteRoute,
-  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -119,8 +119,8 @@ export interface FileRoutesByFullPath {
   '/forgot-password': typeof UnauthorizedForgotPasswordRoute
   '/login': typeof UnauthorizedLoginRoute
   '/register': typeof UnauthorizedRegisterRoute
+  '/reset-password': typeof UnauthorizedResetPasswordRoute
   '/profiles/$username': typeof ProfilesUsernameRoute
-  '/reset-password/$token': typeof UnauthorizedResetPasswordTokenRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -134,8 +134,8 @@ export interface FileRoutesByTo {
   '/forgot-password': typeof UnauthorizedForgotPasswordRoute
   '/login': typeof UnauthorizedLoginRoute
   '/register': typeof UnauthorizedRegisterRoute
+  '/reset-password': typeof UnauthorizedResetPasswordRoute
   '/profiles/$username': typeof ProfilesUsernameRoute
-  '/reset-password/$token': typeof UnauthorizedResetPasswordTokenRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -153,8 +153,8 @@ export interface FileRoutesById {
   '/_unauthorized/forgot-password': typeof UnauthorizedForgotPasswordRoute
   '/_unauthorized/login': typeof UnauthorizedLoginRoute
   '/_unauthorized/register': typeof UnauthorizedRegisterRoute
+  '/_unauthorized/reset-password': typeof UnauthorizedResetPasswordRoute
   '/profiles/$username': typeof ProfilesUsernameRoute
-  '/_unauthorized/reset-password/$token': typeof UnauthorizedResetPasswordTokenRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -170,8 +170,8 @@ export interface FileRouteTypes {
     | '/forgot-password'
     | '/login'
     | '/register'
+    | '/reset-password'
     | '/profiles/$username'
-    | '/reset-password/$token'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -185,8 +185,8 @@ export interface FileRouteTypes {
     | '/forgot-password'
     | '/login'
     | '/register'
+    | '/reset-password'
     | '/profiles/$username'
-    | '/reset-password/$token'
   id:
     | '__root__'
     | '/'
@@ -203,8 +203,8 @@ export interface FileRouteTypes {
     | '/_unauthorized/forgot-password'
     | '/_unauthorized/login'
     | '/_unauthorized/register'
+    | '/_unauthorized/reset-password'
     | '/profiles/$username'
-    | '/_unauthorized/reset-password/$token'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -251,6 +251,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/profiles/$username'
       preLoaderRoute: typeof ProfilesUsernameRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/_unauthorized/reset-password': {
+      id: '/_unauthorized/reset-password'
+      path: '/reset-password'
+      fullPath: '/reset-password'
+      preLoaderRoute: typeof UnauthorizedResetPasswordRouteImport
+      parentRoute: typeof UnauthorizedRouteRoute
     }
     '/_unauthorized/register': {
       id: '/_unauthorized/register'
@@ -322,13 +329,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthorizedConnectionsRouteImport
       parentRoute: typeof AuthorizedRouteRoute
     }
-    '/_unauthorized/reset-password/$token': {
-      id: '/_unauthorized/reset-password/$token'
-      path: '/reset-password/$token'
-      fullPath: '/reset-password/$token'
-      preLoaderRoute: typeof UnauthorizedResetPasswordTokenRouteImport
-      parentRoute: typeof UnauthorizedRouteRoute
-    }
   }
 }
 
@@ -369,7 +369,7 @@ interface UnauthorizedRouteRouteChildren {
   UnauthorizedForgotPasswordRoute: typeof UnauthorizedForgotPasswordRoute
   UnauthorizedLoginRoute: typeof UnauthorizedLoginRoute
   UnauthorizedRegisterRoute: typeof UnauthorizedRegisterRoute
-  UnauthorizedResetPasswordTokenRoute: typeof UnauthorizedResetPasswordTokenRoute
+  UnauthorizedResetPasswordRoute: typeof UnauthorizedResetPasswordRoute
 }
 
 const UnauthorizedRouteRouteChildren: UnauthorizedRouteRouteChildren = {
@@ -377,7 +377,7 @@ const UnauthorizedRouteRouteChildren: UnauthorizedRouteRouteChildren = {
   UnauthorizedForgotPasswordRoute: UnauthorizedForgotPasswordRoute,
   UnauthorizedLoginRoute: UnauthorizedLoginRoute,
   UnauthorizedRegisterRoute: UnauthorizedRegisterRoute,
-  UnauthorizedResetPasswordTokenRoute: UnauthorizedResetPasswordTokenRoute,
+  UnauthorizedResetPasswordRoute: UnauthorizedResetPasswordRoute,
 }
 
 const UnauthorizedRouteRouteWithChildren =

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -15,9 +15,8 @@ import { Route as AuthorizedRouteRouteImport } from './routes/_authorized/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ProfilesUsernameRouteImport } from './routes/profiles.$username'
 import { Route as UnauthorizedRegisterRouteImport } from './routes/_unauthorized/register'
-import { Route as UnauthorizedResetPasswordTokenRouteImport } from './routes/_unauthorized/reset-password.$token'
-import { Route as UnauthorizedForgotPasswordRouteImport } from './routes/_unauthorized/forgot-password'
 import { Route as UnauthorizedLoginRouteImport } from './routes/_unauthorized/login'
+import { Route as UnauthorizedForgotPasswordRouteImport } from './routes/_unauthorized/forgot-password'
 import { Route as UnauthorizedAboutRouteImport } from './routes/_unauthorized/about'
 import { Route as OnBoardingGettingToKnowYouRouteImport } from './routes/_onBoarding/gettingToKnowYou'
 import { Route as AuthorizedScheduleRouteImport } from './routes/_authorized/schedule'
@@ -25,6 +24,7 @@ import { Route as AuthorizedMessagesRouteImport } from './routes/_authorized/mes
 import { Route as AuthorizedDiscoverRouteImport } from './routes/_authorized/discover'
 import { Route as AuthorizedDashboardRouteImport } from './routes/_authorized/dashboard'
 import { Route as AuthorizedConnectionsRouteImport } from './routes/_authorized/connections'
+import { Route as UnauthorizedResetPasswordTokenRouteImport } from './routes/_unauthorized/reset-password.$token'
 
 const UnauthorizedRouteRoute = UnauthorizedRouteRouteImport.update({
   id: '/_unauthorized',
@@ -53,23 +53,17 @@ const UnauthorizedRegisterRoute = UnauthorizedRegisterRouteImport.update({
   path: '/register',
   getParentRoute: () => UnauthorizedRouteRoute,
 } as any)
-const UnauthorizedResetPasswordTokenRoute =
-  UnauthorizedResetPasswordTokenRouteImport.update({
-    id: '/reset-password/$token',
-    path: '/reset-password/$token',
-    getParentRoute: () => UnauthorizedRouteRoute,
-  } as any)
+const UnauthorizedLoginRoute = UnauthorizedLoginRouteImport.update({
+  id: '/login',
+  path: '/login',
+  getParentRoute: () => UnauthorizedRouteRoute,
+} as any)
 const UnauthorizedForgotPasswordRoute =
   UnauthorizedForgotPasswordRouteImport.update({
     id: '/forgot-password',
     path: '/forgot-password',
     getParentRoute: () => UnauthorizedRouteRoute,
   } as any)
-const UnauthorizedLoginRoute = UnauthorizedLoginRouteImport.update({
-  id: '/login',
-  path: '/login',
-  getParentRoute: () => UnauthorizedRouteRoute,
-} as any)
 const UnauthorizedAboutRoute = UnauthorizedAboutRouteImport.update({
   id: '/about',
   path: '/about',
@@ -106,6 +100,12 @@ const AuthorizedConnectionsRoute = AuthorizedConnectionsRouteImport.update({
   path: '/connections',
   getParentRoute: () => AuthorizedRouteRoute,
 } as any)
+const UnauthorizedResetPasswordTokenRoute =
+  UnauthorizedResetPasswordTokenRouteImport.update({
+    id: '/reset-password/$token',
+    path: '/reset-password/$token',
+    getParentRoute: () => UnauthorizedRouteRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -116,11 +116,11 @@ export interface FileRoutesByFullPath {
   '/schedule': typeof AuthorizedScheduleRoute
   '/gettingToKnowYou': typeof OnBoardingGettingToKnowYouRoute
   '/about': typeof UnauthorizedAboutRoute
-  '/login': typeof UnauthorizedLoginRoute
   '/forgot-password': typeof UnauthorizedForgotPasswordRoute
-  '/reset-password/$token': typeof UnauthorizedResetPasswordTokenRoute
+  '/login': typeof UnauthorizedLoginRoute
   '/register': typeof UnauthorizedRegisterRoute
   '/profiles/$username': typeof ProfilesUsernameRoute
+  '/reset-password/$token': typeof UnauthorizedResetPasswordTokenRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -131,11 +131,11 @@ export interface FileRoutesByTo {
   '/schedule': typeof AuthorizedScheduleRoute
   '/gettingToKnowYou': typeof OnBoardingGettingToKnowYouRoute
   '/about': typeof UnauthorizedAboutRoute
-  '/login': typeof UnauthorizedLoginRoute
   '/forgot-password': typeof UnauthorizedForgotPasswordRoute
-  '/reset-password/$token': typeof UnauthorizedResetPasswordTokenRoute
+  '/login': typeof UnauthorizedLoginRoute
   '/register': typeof UnauthorizedRegisterRoute
   '/profiles/$username': typeof ProfilesUsernameRoute
+  '/reset-password/$token': typeof UnauthorizedResetPasswordTokenRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -150,11 +150,11 @@ export interface FileRoutesById {
   '/_authorized/schedule': typeof AuthorizedScheduleRoute
   '/_onBoarding/gettingToKnowYou': typeof OnBoardingGettingToKnowYouRoute
   '/_unauthorized/about': typeof UnauthorizedAboutRoute
-  '/_unauthorized/login': typeof UnauthorizedLoginRoute
   '/_unauthorized/forgot-password': typeof UnauthorizedForgotPasswordRoute
-  '/_unauthorized/reset-password/$token': typeof UnauthorizedResetPasswordTokenRoute
+  '/_unauthorized/login': typeof UnauthorizedLoginRoute
   '/_unauthorized/register': typeof UnauthorizedRegisterRoute
   '/profiles/$username': typeof ProfilesUsernameRoute
+  '/_unauthorized/reset-password/$token': typeof UnauthorizedResetPasswordTokenRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -167,11 +167,11 @@ export interface FileRouteTypes {
     | '/schedule'
     | '/gettingToKnowYou'
     | '/about'
-    | '/login'
     | '/forgot-password'
-    | '/reset-password/$token'
+    | '/login'
     | '/register'
     | '/profiles/$username'
+    | '/reset-password/$token'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -182,11 +182,11 @@ export interface FileRouteTypes {
     | '/schedule'
     | '/gettingToKnowYou'
     | '/about'
-    | '/login'
     | '/forgot-password'
-    | '/reset-password/$token'
+    | '/login'
     | '/register'
     | '/profiles/$username'
+    | '/reset-password/$token'
   id:
     | '__root__'
     | '/'
@@ -200,11 +200,11 @@ export interface FileRouteTypes {
     | '/_authorized/schedule'
     | '/_onBoarding/gettingToKnowYou'
     | '/_unauthorized/about'
-    | '/_unauthorized/login'
     | '/_unauthorized/forgot-password'
-    | '/_unauthorized/reset-password/$token'
+    | '/_unauthorized/login'
     | '/_unauthorized/register'
     | '/profiles/$username'
+    | '/_unauthorized/reset-password/$token'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -259,25 +259,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof UnauthorizedRegisterRouteImport
       parentRoute: typeof UnauthorizedRouteRoute
     }
-    '/_unauthorized/forgot-password': {
-      id: '/_unauthorized/forgot-password'
-      path: '/forgot-password'
-      fullPath: '/forgot-password'
-      preLoaderRoute: typeof UnauthorizedForgotPasswordRouteImport
-      parentRoute: typeof UnauthorizedRouteRoute
-    }
-    '/_unauthorized/reset-password/$token': {
-      id: '/_unauthorized/reset-password/$token'
-      path: '/reset-password/$token'
-      fullPath: '/reset-password/$token'
-      preLoaderRoute: typeof UnauthorizedResetPasswordTokenRouteImport
-      parentRoute: typeof UnauthorizedRouteRoute
-    }
     '/_unauthorized/login': {
       id: '/_unauthorized/login'
       path: '/login'
       fullPath: '/login'
       preLoaderRoute: typeof UnauthorizedLoginRouteImport
+      parentRoute: typeof UnauthorizedRouteRoute
+    }
+    '/_unauthorized/forgot-password': {
+      id: '/_unauthorized/forgot-password'
+      path: '/forgot-password'
+      fullPath: '/forgot-password'
+      preLoaderRoute: typeof UnauthorizedForgotPasswordRouteImport
       parentRoute: typeof UnauthorizedRouteRoute
     }
     '/_unauthorized/about': {
@@ -329,6 +322,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthorizedConnectionsRouteImport
       parentRoute: typeof AuthorizedRouteRoute
     }
+    '/_unauthorized/reset-password/$token': {
+      id: '/_unauthorized/reset-password/$token'
+      path: '/reset-password/$token'
+      fullPath: '/reset-password/$token'
+      preLoaderRoute: typeof UnauthorizedResetPasswordTokenRouteImport
+      parentRoute: typeof UnauthorizedRouteRoute
+    }
   }
 }
 
@@ -366,18 +366,18 @@ const OnBoardingRouteRouteWithChildren = OnBoardingRouteRoute._addFileChildren(
 
 interface UnauthorizedRouteRouteChildren {
   UnauthorizedAboutRoute: typeof UnauthorizedAboutRoute
-  UnauthorizedLoginRoute: typeof UnauthorizedLoginRoute
   UnauthorizedForgotPasswordRoute: typeof UnauthorizedForgotPasswordRoute
-  UnauthorizedResetPasswordTokenRoute: typeof UnauthorizedResetPasswordTokenRoute
+  UnauthorizedLoginRoute: typeof UnauthorizedLoginRoute
   UnauthorizedRegisterRoute: typeof UnauthorizedRegisterRoute
+  UnauthorizedResetPasswordTokenRoute: typeof UnauthorizedResetPasswordTokenRoute
 }
 
 const UnauthorizedRouteRouteChildren: UnauthorizedRouteRouteChildren = {
   UnauthorizedAboutRoute: UnauthorizedAboutRoute,
-  UnauthorizedLoginRoute: UnauthorizedLoginRoute,
   UnauthorizedForgotPasswordRoute: UnauthorizedForgotPasswordRoute,
-  UnauthorizedResetPasswordTokenRoute: UnauthorizedResetPasswordTokenRoute,
+  UnauthorizedLoginRoute: UnauthorizedLoginRoute,
   UnauthorizedRegisterRoute: UnauthorizedRegisterRoute,
+  UnauthorizedResetPasswordTokenRoute: UnauthorizedResetPasswordTokenRoute,
 }
 
 const UnauthorizedRouteRouteWithChildren =

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -15,6 +15,8 @@ import { Route as AuthorizedRouteRouteImport } from './routes/_authorized/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ProfilesUsernameRouteImport } from './routes/profiles.$username'
 import { Route as UnauthorizedRegisterRouteImport } from './routes/_unauthorized/register'
+import { Route as UnauthorizedResetPasswordTokenRouteImport } from './routes/_unauthorized/reset-password.$token'
+import { Route as UnauthorizedForgotPasswordRouteImport } from './routes/_unauthorized/forgot-password'
 import { Route as UnauthorizedLoginRouteImport } from './routes/_unauthorized/login'
 import { Route as UnauthorizedAboutRouteImport } from './routes/_unauthorized/about'
 import { Route as OnBoardingGettingToKnowYouRouteImport } from './routes/_onBoarding/gettingToKnowYou'
@@ -51,6 +53,18 @@ const UnauthorizedRegisterRoute = UnauthorizedRegisterRouteImport.update({
   path: '/register',
   getParentRoute: () => UnauthorizedRouteRoute,
 } as any)
+const UnauthorizedResetPasswordTokenRoute =
+  UnauthorizedResetPasswordTokenRouteImport.update({
+    id: '/reset-password/$token',
+    path: '/reset-password/$token',
+    getParentRoute: () => UnauthorizedRouteRoute,
+  } as any)
+const UnauthorizedForgotPasswordRoute =
+  UnauthorizedForgotPasswordRouteImport.update({
+    id: '/forgot-password',
+    path: '/forgot-password',
+    getParentRoute: () => UnauthorizedRouteRoute,
+  } as any)
 const UnauthorizedLoginRoute = UnauthorizedLoginRouteImport.update({
   id: '/login',
   path: '/login',
@@ -103,6 +117,8 @@ export interface FileRoutesByFullPath {
   '/gettingToKnowYou': typeof OnBoardingGettingToKnowYouRoute
   '/about': typeof UnauthorizedAboutRoute
   '/login': typeof UnauthorizedLoginRoute
+  '/forgot-password': typeof UnauthorizedForgotPasswordRoute
+  '/reset-password/$token': typeof UnauthorizedResetPasswordTokenRoute
   '/register': typeof UnauthorizedRegisterRoute
   '/profiles/$username': typeof ProfilesUsernameRoute
 }
@@ -116,6 +132,8 @@ export interface FileRoutesByTo {
   '/gettingToKnowYou': typeof OnBoardingGettingToKnowYouRoute
   '/about': typeof UnauthorizedAboutRoute
   '/login': typeof UnauthorizedLoginRoute
+  '/forgot-password': typeof UnauthorizedForgotPasswordRoute
+  '/reset-password/$token': typeof UnauthorizedResetPasswordTokenRoute
   '/register': typeof UnauthorizedRegisterRoute
   '/profiles/$username': typeof ProfilesUsernameRoute
 }
@@ -133,6 +151,8 @@ export interface FileRoutesById {
   '/_onBoarding/gettingToKnowYou': typeof OnBoardingGettingToKnowYouRoute
   '/_unauthorized/about': typeof UnauthorizedAboutRoute
   '/_unauthorized/login': typeof UnauthorizedLoginRoute
+  '/_unauthorized/forgot-password': typeof UnauthorizedForgotPasswordRoute
+  '/_unauthorized/reset-password/$token': typeof UnauthorizedResetPasswordTokenRoute
   '/_unauthorized/register': typeof UnauthorizedRegisterRoute
   '/profiles/$username': typeof ProfilesUsernameRoute
 }
@@ -148,6 +168,8 @@ export interface FileRouteTypes {
     | '/gettingToKnowYou'
     | '/about'
     | '/login'
+    | '/forgot-password'
+    | '/reset-password/$token'
     | '/register'
     | '/profiles/$username'
   fileRoutesByTo: FileRoutesByTo
@@ -161,6 +183,8 @@ export interface FileRouteTypes {
     | '/gettingToKnowYou'
     | '/about'
     | '/login'
+    | '/forgot-password'
+    | '/reset-password/$token'
     | '/register'
     | '/profiles/$username'
   id:
@@ -177,6 +201,8 @@ export interface FileRouteTypes {
     | '/_onBoarding/gettingToKnowYou'
     | '/_unauthorized/about'
     | '/_unauthorized/login'
+    | '/_unauthorized/forgot-password'
+    | '/_unauthorized/reset-password/$token'
     | '/_unauthorized/register'
     | '/profiles/$username'
   fileRoutesById: FileRoutesById
@@ -231,6 +257,20 @@ declare module '@tanstack/react-router' {
       path: '/register'
       fullPath: '/register'
       preLoaderRoute: typeof UnauthorizedRegisterRouteImport
+      parentRoute: typeof UnauthorizedRouteRoute
+    }
+    '/_unauthorized/forgot-password': {
+      id: '/_unauthorized/forgot-password'
+      path: '/forgot-password'
+      fullPath: '/forgot-password'
+      preLoaderRoute: typeof UnauthorizedForgotPasswordRouteImport
+      parentRoute: typeof UnauthorizedRouteRoute
+    }
+    '/_unauthorized/reset-password/$token': {
+      id: '/_unauthorized/reset-password/$token'
+      path: '/reset-password/$token'
+      fullPath: '/reset-password/$token'
+      preLoaderRoute: typeof UnauthorizedResetPasswordTokenRouteImport
       parentRoute: typeof UnauthorizedRouteRoute
     }
     '/_unauthorized/login': {
@@ -327,12 +367,16 @@ const OnBoardingRouteRouteWithChildren = OnBoardingRouteRoute._addFileChildren(
 interface UnauthorizedRouteRouteChildren {
   UnauthorizedAboutRoute: typeof UnauthorizedAboutRoute
   UnauthorizedLoginRoute: typeof UnauthorizedLoginRoute
+  UnauthorizedForgotPasswordRoute: typeof UnauthorizedForgotPasswordRoute
+  UnauthorizedResetPasswordTokenRoute: typeof UnauthorizedResetPasswordTokenRoute
   UnauthorizedRegisterRoute: typeof UnauthorizedRegisterRoute
 }
 
 const UnauthorizedRouteRouteChildren: UnauthorizedRouteRouteChildren = {
   UnauthorizedAboutRoute: UnauthorizedAboutRoute,
   UnauthorizedLoginRoute: UnauthorizedLoginRoute,
+  UnauthorizedForgotPasswordRoute: UnauthorizedForgotPasswordRoute,
+  UnauthorizedResetPasswordTokenRoute: UnauthorizedResetPasswordTokenRoute,
   UnauthorizedRegisterRoute: UnauthorizedRegisterRoute,
 }
 

--- a/web/src/routes/_unauthorized/forgot-password.tsx
+++ b/web/src/routes/_unauthorized/forgot-password.tsx
@@ -25,7 +25,7 @@ export function ForgotPasswordPage() {
         },
     })
 
-    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    const handleSubmit = (e: React.SyntheticEvent<HTMLFormElement>) => {
         e.preventDefault()
         forgotPassword.mutate({ email })
     }

--- a/web/src/routes/_unauthorized/forgot-password.tsx
+++ b/web/src/routes/_unauthorized/forgot-password.tsx
@@ -1,0 +1,140 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { useState } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import { ArrowLeft, CheckCircle, Mail } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Card, CardContent, CardFooter, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { Display, Heading, Body, Muted } from '@/components/Typography'
+import { forgotPasswordFn } from '#/lib/queries/AuthQueries.ts'
+
+export const Route = createFileRoute('/_unauthorized/forgot-password')({
+    component: ForgotPasswordPage,
+})
+
+export function ForgotPasswordPage() {
+    const [email, setEmail] = useState('')
+    const [submitted, setSubmitted] = useState(false)
+
+    const forgotPassword = useMutation({
+        mutationFn: forgotPasswordFn,
+        onSettled: () => {
+            // Always show success regardless of outcome — prevent account enumeration
+            setSubmitted(true)
+        },
+    })
+
+    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault()
+        forgotPassword.mutate({ email })
+    }
+
+    return (
+        <div className="grid min-h-screen lg:grid-cols-[5fr_4fr]">
+            <aside className="hidden lg:flex flex-col px-14 py-12 bg-petal border-r border-line">
+                <Display className="mb-10">Campus Tutor</Display>
+                <div className="island-shell rounded-2xl px-8 py-10 space-y-6 min-h-3/4 rise-in">
+                    <Body className="island-kicker">Account Recovery</Body>
+                    <Display as="h2" className="leading-[1.2] max-w-xs">
+                        Locked out?<br />We've got you.
+                    </Display>
+                    <Body className="text-ink-soft max-w-90">
+                        Enter your email address and we'll send you a secure link to
+                        reset your password. The link expires in 30 minutes.
+                    </Body>
+                    <div className="flex items-start gap-3 pt-4">
+                        <span className="w-12 h-12 rounded-lg bg-accent-muted flex items-center justify-center shrink-0">
+                            <Mail className="w-6 h-6 text-accent" strokeWidth={2.5} />
+                        </span>
+                        <div>
+                            <Body className="font-medium text-ink">Check your inbox</Body>
+                            <Muted className="text-ink-soft">
+                                The reset link will arrive within a few minutes.
+                            </Muted>
+                        </div>
+                    </div>
+                </div>
+            </aside>
+
+            <main className="flex flex-col justify-start items-center px-6 py-16 sm:px-12">
+                <div className="w-full max-w-lg rise-in">
+                    <div className="mb-6 px-1">
+                        <Link
+                            to="/login"
+                            className="inline-flex items-center gap-2 text-ink-soft hover:text-accent transition-colors mb-8 group"
+                        >
+                            <ArrowLeft className="w-4 h-4 group-hover:-translate-x-1 transition-transform" />
+                            <span className="text-sm font-medium uppercase tracking-wider">Back to Login</span>
+                        </Link>
+                        <Heading as="h2" className="mb-2 mt-6">Forgot Password</Heading>
+                        <Muted className="text-ink-soft">
+                            Enter your email address and we'll send you a secure link to reset your password.
+                        </Muted>
+                    </div>
+
+                    <Card className="w-full island-shell border-line">
+                        <CardHeader>
+                            <CardTitle>Reset your password</CardTitle>
+                            <CardDescription>
+                                We'll email you a link that expires in 30 minutes.
+                            </CardDescription>
+                        </CardHeader>
+
+                        <CardContent>
+                            {submitted ? (
+                                <div className="flex items-start gap-3 p-4 rounded-lg bg-accent-muted border border-accent/20">
+                                    <CheckCircle className="w-5 h-5 text-accent shrink-0 mt-0.5" />
+                                    <p className="text-sm text-ink">
+                                        If an account exists for that email, a reset link has been sent to your inbox.
+                                        Please check your spam folder if you don't see it.
+                                    </p>
+                                </div>
+                            ) : (
+                                <form
+                                    id="forgot-password-form"
+                                    className="flex flex-col gap-5"
+                                    onSubmit={handleSubmit}
+                                >
+                                    <div className="grid gap-1.5">
+                                        <Label htmlFor="email">Email</Label>
+                                        <Input
+                                            id="email"
+                                            type="email"
+                                            value={email}
+                                            onChange={(e) => setEmail(e.target.value)}
+                                            placeholder="you@university.edu"
+                                            required
+                                        />
+                                    </div>
+                                </form>
+                            )}
+                        </CardContent>
+
+                        <CardFooter className="flex-col gap-3">
+                            {!submitted && (
+                                <Button
+                                    type="submit"
+                                    form="forgot-password-form"
+                                    className="w-full"
+                                    disabled={forgotPassword.isPending}
+                                >
+                                    {forgotPassword.isPending ? 'Sending...' : 'Send Reset Link'}
+                                </Button>
+                            )}
+                            <Muted className="text-xs text-center w-full">
+                                Remembered your password?{' '}
+                                <Link
+                                    to="/login"
+                                    className="font-medium text-accent-light underline-offset-4 hover:underline hover:text-accent transition-colors"
+                                >
+                                    Sign in
+                                </Link>
+                            </Muted>
+                        </CardFooter>
+                    </Card>
+                </div>
+            </main>
+        </div>
+    )
+}

--- a/web/src/routes/_unauthorized/forgot-password.tsx
+++ b/web/src/routes/_unauthorized/forgot-password.tsx
@@ -16,17 +16,24 @@ export const Route = createFileRoute('/_unauthorized/forgot-password')({
 export function ForgotPasswordPage() {
     const [email, setEmail] = useState('')
     const [submitted, setSubmitted] = useState(false)
+    const [networkError, setNetworkError] = useState(false)
 
     const forgotPassword = useMutation({
         mutationFn: forgotPasswordFn,
-        onSettled: () => {
-            // Always show success regardless of outcome — prevent account enumeration
+        onSuccess: () => {
+            // Show success regardless of whether the email exists — prevent account enumeration
+            setNetworkError(false)
             setSubmitted(true)
+        },
+        onError: () => {
+            // Network/server failure: let user retry without leaking account existence
+            setNetworkError(true)
         },
     })
 
     const handleSubmit = (e: React.SyntheticEvent<HTMLFormElement>) => {
         e.preventDefault()
+        setNetworkError(false)
         forgotPassword.mutate({ email })
     }
 
@@ -82,6 +89,13 @@ export function ForgotPasswordPage() {
                         </CardHeader>
 
                         <CardContent>
+                            {networkError && (
+                                <div className="flex items-start gap-3 p-4 mb-4 rounded-lg bg-destructive/10 border border-destructive/20">
+                                    <p className="text-sm text-destructive">
+                                        Something went wrong. Please check your connection and try again.
+                                    </p>
+                                </div>
+                            )}
                             {submitted ? (
                                 <div className="flex items-start gap-3 p-4 rounded-lg bg-accent-muted border border-accent/20">
                                     <CheckCircle className="w-5 h-5 text-accent shrink-0 mt-0.5" />

--- a/web/src/routes/_unauthorized/login.tsx
+++ b/web/src/routes/_unauthorized/login.tsx
@@ -140,12 +140,12 @@ export function LoginPage() {
                                 <div className="grid gap-1.5">
                                     <div className="flex items-center justify-between">
                                         <Label htmlFor="password">Password</Label>
-                                        <a
-                                            href="#"
+                                        <Link
+                                            to="/forgot-password"
                                             className="text-xs text-accent-light underline-offset-4 hover:underline hover:text-accent transition-colors"
                                         >
                                             Forgot your password?
-                                        </a>
+                                        </Link>
                                     </div>
                                     <Input
                                         id="password"

--- a/web/src/routes/_unauthorized/reset-password.$token.tsx
+++ b/web/src/routes/_unauthorized/reset-password.$token.tsx
@@ -1,0 +1,189 @@
+import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
+import { useState } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import { ArrowLeft, CheckCircle, KeyRound, XCircle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Card, CardContent, CardFooter, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { Display, Heading, Body, Muted } from '@/components/Typography'
+import { resetPasswordFn, clearAuthState } from '#/lib/queries/AuthQueries.ts'
+
+export const Route = createFileRoute('/_unauthorized/reset-password/$token')({
+    component: ResetPasswordPage,
+})
+
+export function ResetPasswordPage() {
+    const { token } = Route.useParams()
+    const router = useRouter()
+    const [password, setPassword] = useState('')
+    const [confirmPassword, setConfirmPassword] = useState('')
+    const [validationError, setValidationError] = useState<string | null>(null)
+
+    const resetPassword = useMutation({
+        mutationFn: resetPasswordFn,
+        onSuccess: () => {
+            clearAuthState()
+            setTimeout(() => router.navigate({ to: '/login' }), 2000)
+        },
+    })
+
+    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault()
+        setValidationError(null)
+
+        if (password.length < 8) {
+            setValidationError('Password must be at least 8 characters.')
+            return
+        }
+        if (password !== confirmPassword) {
+            setValidationError('Passwords do not match.')
+            return
+        }
+
+        resetPassword.mutate({ token, password })
+    }
+
+    return (
+        <div className="grid min-h-screen lg:grid-cols-[5fr_4fr]">
+            <aside className="hidden lg:flex flex-col px-14 py-12 bg-petal border-r border-line">
+                <Display className="mb-10">Campus Tutor</Display>
+                <div className="island-shell rounded-2xl px-8 py-10 space-y-6 min-h-3/4 rise-in">
+                    <Body className="island-kicker">Account Recovery</Body>
+                    <Display as="h2" className="leading-[1.2] max-w-xs">
+                        Create a new<br />password.
+                    </Display>
+                    <Body className="text-ink-soft max-w-90">
+                        Choose a strong password that you haven't used before.
+                        For your security, all active sessions will be signed out.
+                    </Body>
+                    <div className="flex items-start gap-3 pt-4">
+                        <span className="w-12 h-12 rounded-lg bg-accent-muted flex items-center justify-center shrink-0">
+                            <KeyRound className="w-6 h-6 text-accent" strokeWidth={2.5} />
+                        </span>
+                        <div>
+                            <Body className="font-medium text-ink">Sessions will be cleared</Body>
+                            <Muted className="text-ink-soft">
+                                All existing sessions are signed out after a successful reset.
+                            </Muted>
+                        </div>
+                    </div>
+                </div>
+            </aside>
+
+            <main className="flex flex-col justify-start items-center px-6 py-16 sm:px-12">
+                <div className="w-full max-w-lg rise-in">
+                    <div className="mb-6 px-1">
+                        <Link
+                            to="/login"
+                            className="inline-flex items-center gap-2 text-ink-soft hover:text-accent transition-colors mb-8 group"
+                        >
+                            <ArrowLeft className="w-4 h-4 group-hover:-translate-x-1 transition-transform" />
+                            <span className="text-sm font-medium uppercase tracking-wider">Back to Login</span>
+                        </Link>
+                        <Heading as="h2" className="mb-2 mt-6">Reset Password</Heading>
+                        <Muted className="text-ink-soft">
+                            Enter and confirm your new password below.
+                        </Muted>
+                    </div>
+
+                    <Card className="w-full island-shell border-line">
+                        <CardHeader>
+                            <CardTitle>Choose a new password</CardTitle>
+                            <CardDescription>
+                                Must be at least 8 characters. All active sessions will be signed out.
+                            </CardDescription>
+                        </CardHeader>
+
+                        <CardContent>
+                            {resetPassword.isSuccess ? (
+                                <div className="flex items-start gap-3 p-4 rounded-lg bg-accent-muted border border-accent/20">
+                                    <CheckCircle className="w-5 h-5 text-accent shrink-0 mt-0.5" />
+                                    <p className="text-sm text-ink">
+                                        Password reset successfully. Redirecting you to the login page…
+                                    </p>
+                                </div>
+                            ) : (
+                                <form
+                                    id="reset-password-form"
+                                    className="flex flex-col gap-5"
+                                    onSubmit={handleSubmit}
+                                >
+                                    <div className="grid gap-1.5">
+                                        <Label htmlFor="password">New Password</Label>
+                                        <Input
+                                            id="password"
+                                            type="password"
+                                            value={password}
+                                            onChange={(e) => setPassword(e.target.value)}
+                                            placeholder="••••••••"
+                                            required
+                                            minLength={8}
+                                        />
+                                    </div>
+
+                                    <div className="grid gap-1.5">
+                                        <Label htmlFor="confirm-password">Confirm New Password</Label>
+                                        <Input
+                                            id="confirm-password"
+                                            type="password"
+                                            value={confirmPassword}
+                                            onChange={(e) => setConfirmPassword(e.target.value)}
+                                            placeholder="••••••••"
+                                            required
+                                        />
+                                    </div>
+
+                                    {validationError && (
+                                        <p className="text-xs text-destructive">{validationError}</p>
+                                    )}
+                                </form>
+                            )}
+
+                            {resetPassword.isError && !resetPassword.isSuccess && (
+                                <div className="flex items-start gap-3 p-4 rounded-lg bg-destructive/10 border border-destructive/20 mt-4">
+                                    <XCircle className="w-5 h-5 text-destructive shrink-0 mt-0.5" />
+                                    <div className="text-sm text-destructive">
+                                        <p className="font-medium">Link expired or already used.</p>
+                                        <p className="mt-0.5 text-xs">
+                                            Please{' '}
+                                            <Link
+                                                to="/forgot-password"
+                                                className="underline underline-offset-4 hover:text-destructive/80 transition-colors"
+                                            >
+                                                request a new reset link
+                                            </Link>
+                                            .
+                                        </p>
+                                    </div>
+                                </div>
+                            )}
+                        </CardContent>
+
+                        <CardFooter className="flex-col gap-3">
+                            {!resetPassword.isSuccess && (
+                                <Button
+                                    type="submit"
+                                    form="reset-password-form"
+                                    className="w-full"
+                                    disabled={resetPassword.isPending}
+                                >
+                                    {resetPassword.isPending ? 'Resetting…' : 'Reset Password'}
+                                </Button>
+                            )}
+                            <Muted className="text-xs text-center w-full">
+                                Remembered your password?{' '}
+                                <Link
+                                    to="/login"
+                                    className="font-medium text-accent-light underline-offset-4 hover:underline hover:text-accent transition-colors"
+                                >
+                                    Sign in
+                                </Link>
+                            </Muted>
+                        </CardFooter>
+                    </Card>
+                </div>
+            </main>
+        </div>
+    )
+}

--- a/web/src/routes/_unauthorized/reset-password.tsx
+++ b/web/src/routes/_unauthorized/reset-password.tsx
@@ -2,7 +2,6 @@ import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
 import { useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import { ArrowLeft, CheckCircle, KeyRound, XCircle } from 'lucide-react'
-import { z } from 'zod'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -10,17 +9,15 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle, CardDescription }
 import { Display, Heading, Body, Muted } from '@/components/Typography'
 import { resetPasswordFn, clearAuthState } from '#/lib/queries/AuthQueries.ts'
 
-const searchSchema = z.object({
-    token: z.string().catch(''),
-})
-
 export const Route = createFileRoute('/_unauthorized/reset-password')({
-    validateSearch: searchSchema,
     component: ResetPasswordPage,
 })
 
 export function ResetPasswordPage() {
-    const { token } = Route.useSearch()
+    // URLSearchParams correctly handles `=` padding characters inside the token value.
+    // TanStack Router's default search parser splits on every `=`, truncating base64 tokens.
+    const token = new URLSearchParams(globalThis.location.search).get('token') ?? ''
+    console.debug('[reset-password] token from URL:', token)
     const router = useRouter()
     const [password, setPassword] = useState('')
     const [confirmPassword, setConfirmPassword] = useState('')
@@ -167,17 +164,19 @@ export function ResetPasswordPage() {
                                 <div className="flex items-start gap-3 p-4 rounded-lg bg-destructive/10 border border-destructive/20 mt-4">
                                     <XCircle className="w-5 h-5 text-destructive shrink-0 mt-0.5" />
                                     <div className="text-sm text-destructive">
-                                        <p className="font-medium">Link expired or already used.</p>
-                                        <p className="mt-0.5 text-xs">
-                                            Please{' '}
-                                            <Link
-                                                to="/forgot-password"
-                                                className="underline underline-offset-4 hover:text-destructive/80 transition-colors"
-                                            >
-                                                request a new reset link
-                                            </Link>
-                                            .
-                                        </p>
+                                        <p className="font-medium">{resetPassword.error?.message ?? 'Something went wrong.'}</p>
+                                        {resetPassword.error?.message?.toLowerCase().includes('token') && (
+                                            <p className="mt-0.5 text-xs">
+                                                Please{' '}
+                                                <Link
+                                                    to="/forgot-password"
+                                                    className="underline underline-offset-4 hover:text-destructive/80 transition-colors"
+                                                >
+                                                    request a new reset link
+                                                </Link>
+                                                .
+                                            </p>
+                                        )}
                                     </div>
                                 </div>
                             )}

--- a/web/src/routes/_unauthorized/reset-password.tsx
+++ b/web/src/routes/_unauthorized/reset-password.tsx
@@ -39,9 +39,9 @@ export function ResetPasswordPage() {
                     <Muted className="text-ink-soft">
                         This link is missing a reset token. Please request a new one.
                     </Muted>
-                    <Link to="/forgot-password">
-                        <Button className="mt-2">Request New Link</Button>
-                    </Link>
+                    <Button asChild className="mt-2">
+                        <Link to="/forgot-password">Request New Link</Link>
+                    </Button>
                 </div>
             </div>
         )

--- a/web/src/routes/_unauthorized/reset-password.tsx
+++ b/web/src/routes/_unauthorized/reset-password.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
 import { useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import { ArrowLeft, CheckCircle, KeyRound, XCircle } from 'lucide-react'
+import { z } from 'zod'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -9,12 +10,17 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle, CardDescription }
 import { Display, Heading, Body, Muted } from '@/components/Typography'
 import { resetPasswordFn, clearAuthState } from '#/lib/queries/AuthQueries.ts'
 
-export const Route = createFileRoute('/_unauthorized/reset-password/$token')({
+const searchSchema = z.object({
+    token: z.string().catch(''),
+})
+
+export const Route = createFileRoute('/_unauthorized/reset-password')({
+    validateSearch: searchSchema,
     component: ResetPasswordPage,
 })
 
 export function ResetPasswordPage() {
-    const { token } = Route.useParams()
+    const { token } = Route.useSearch()
     const router = useRouter()
     const [password, setPassword] = useState('')
     const [confirmPassword, setConfirmPassword] = useState('')
@@ -27,6 +33,23 @@ export function ResetPasswordPage() {
             setTimeout(() => router.navigate({ to: '/login' }), 2000)
         },
     })
+
+    if (!token) {
+        return (
+            <div className="flex min-h-screen items-center justify-center px-6">
+                <div className="w-full max-w-md text-center space-y-4">
+                    <XCircle className="w-12 h-12 text-destructive mx-auto" />
+                    <Heading as="h2">Invalid Reset Link</Heading>
+                    <Muted className="text-ink-soft">
+                        This link is missing a reset token. Please request a new one.
+                    </Muted>
+                    <Link to="/forgot-password">
+                        <Button className="mt-2">Request New Link</Button>
+                    </Link>
+                </div>
+            </div>
+        )
+    }
 
     const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault()
@@ -41,7 +64,7 @@ export function ResetPasswordPage() {
             return
         }
 
-        resetPassword.mutate({ token, password })
+        resetPassword.mutate({ token, new_password: password, confirm_password: confirmPassword })
     }
 
     return (

--- a/web/src/routes/_unauthorized/reset-password.tsx
+++ b/web/src/routes/_unauthorized/reset-password.tsx
@@ -17,7 +17,6 @@ export function ResetPasswordPage() {
     // URLSearchParams correctly handles `=` padding characters inside the token value.
     // TanStack Router's default search parser splits on every `=`, truncating base64 tokens.
     const token = new URLSearchParams(globalThis.location.search).get('token') ?? ''
-    console.debug('[reset-password] token from URL:', token)
     const router = useRouter()
     const [password, setPassword] = useState('')
     const [confirmPassword, setConfirmPassword] = useState('')
@@ -48,7 +47,7 @@ export function ResetPasswordPage() {
         )
     }
 
-    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    const handleSubmit = (e: React.SyntheticEvent<HTMLFormElement>) => {
         e.preventDefault()
         setValidationError(null)
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -82,7 +82,7 @@
   --card-foreground:      oklch(0.20  0.015  80);
   --popover:              oklch(1     0       0);
   --popover-foreground:   oklch(0.20  0.015  80);
-  --primary:              oklch(0.50  0.07  175);
+  --primary:              oklch(0.44  0.05  175);
   --primary-foreground:   oklch(0.99  0.005  80);
   --secondary:            oklch(0.96  0.010  85);
   --secondary-foreground: oklch(0.28  0.015  80);


### PR DESCRIPTION
 ## Related Issue                                                                                                         
                                                                                                                           
  Closes #448 
                                                                                                                           
  ## Description
                                                                                                                           
  Adds the forgot password and reset password flows to the web frontend. Users can now request a password reset link from  
  the login page, and follow the emailed link to set a new password.
                                                                                                                           
  - **Forgot password page** (`/forgot-password`): accepts an email address and calls the backend `forgot-password`
  endpoint. Always shows a success message regardless of whether the account exists, preventing account enumeration.
  - **Reset password page** (`/reset-password?token=...`): reads the reset token from the URL query parameter (using
  `URLSearchParams` directly to avoid TanStack Router's default parser truncating base64 `=` padding). Validates password length (≥ 8 chars) and confirmation match client-side, then calls the reset endpoint. On success, clears local auth state and redirects to `/login` after 2 seconds. Shows actionable error UI for expired/invalid tokens.                        
  - Both pages are wired into the TanStack Router route tree under `_unauthorized` and linked from the login page.
  - `AuthQueries.ts` exposes `forgotPasswordFn`, `resetPasswordFn`, and `clearAuthState` for use by the mutation hooks.    
                                                                                                                           
  ## Type of Change                                                                                                        
                                                                                                                           
  - [x] New feature

  ## Checklist

  - [x] I have tested my changes locally
  - [x] My code builds without errors
  - [ ] I have written or updated tests where applicable
  - [x] I have performed a self-review of my code                                                                          
   
  ## Notes                                                                                                                 
                  
  The token is extracted via `new URLSearchParams(globalThis.location.search)` rather than TanStack Router's search params because the router's default parser splits on every `=`, which truncates base64-encoded tokens that contain padding characters.  