### PR TITLE
fix: remove duplicate operation_id

### DIFF
--- a/backend/messaging/views.py
+++ b/backend/messaging/views.py
@@ -74,7 +74,6 @@ class ConversationDetailAPIView(APIView):
             "List messages in a private conversation."
             "Supports pagination via `page` and `pageSize` query params."
         ),
-        operation_id="messages_conversations_retrieve",
         tags=["Messages"],
         operation_id="messages_conversation_messages_list",
     )


### PR DESCRIPTION
## Description
Fixes a `SyntaxError` in the messaging backend where a duplicate `operation_id` keyword argument was present in the `ConversationDetailAPIView` schema definition. This was preventing the backend container from starting correctly.

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have performed a self-review of my code