### PR TITLE
feat: CoP returns tagged user

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -107,6 +107,9 @@ MAX_POST_MEDIA_SIZE_MB = 10
 MAX_POST_MEDIA_SIZE_BYTES = MAX_POST_MEDIA_SIZE_MB * 1024 * 1024
 POST_MEDIA_MAX_DIMENSION = 1920  # px — longest side after resize
 
+# Community Post (CoP) tagging settings
+COP_MAX_TAGS = 5  # Maximum number of users that can be tagged in a CoP
+
 SIMPLE_JWT = {
     "ACCESS_TOKEN_LIFETIME": timedelta(minutes=1440),
     "REFRESH_TOKEN_LIFETIME": timedelta(days=7),

--- a/backend/profiles/serializers.py
+++ b/backend/profiles/serializers.py
@@ -952,7 +952,7 @@ class CoPCreateSerializer(serializers.Serializer):
         return super().to_internal_value(data)
 
     def validate_tagged_users(self, value: list) -> list:
-        """Validate tagged_users field (user IDs as strings)."""
+        """Validate tagged_users field (usernames as strings)."""
         # Validation logic will be handled in the view/service layer
         # where we have access to author and community context
         return value
@@ -981,7 +981,7 @@ class CoPUpdateSerializer(serializers.Serializer):
     )
 
     def validate_tagged_users(self, value: list) -> list:
-        """Validate tagged_users field (user IDs as strings)."""
+        """Validate tagged_users field (usernames as strings)."""
         # Validation logic will be handled in the view/service layer
         # where we have access to author and community context
         return value

--- a/backend/profiles/serializers.py
+++ b/backend/profiles/serializers.py
@@ -699,9 +699,11 @@ class ProfilePostListQueryParamsSerializer(serializers.Serializer):
 class ProfilePostSerializer(serializers.Serializer):
     """Read serializer for profile feed items (PrP, visible MCTE, and visible CoP).
 
-    ``community_id`` and ``community_name`` are populated only for CoP posts.
-    ``community_name`` is fetched live; if the community has been deleted it falls back
-    to the name snapshotted in ``payload`` at creation time.
+    ``community_id``, ``community_name``, and ``tagged_users`` are populated only for
+    CoP posts. ``community_name`` is fetched live; if the community has been deleted it
+    falls back to the name snapshotted in ``payload`` at creation time. ``tagged_users``
+    is a list of ``{user_id, username}`` dicts; usernames are snapshots captured at
+    tag-time and fall back to the stored snapshot if a user was later deleted.
     ``mentorship_partner`` is populated only for MCTE posts and contains the username of
     the mentorship partner (mentor or mentee, depending on the author's role).
     Clients can use ``community_id`` to navigate to ``/api/profiles/tags/{community_id}/`` or link
@@ -720,6 +722,7 @@ class ProfilePostSerializer(serializers.Serializer):
     show_on_profile = serializers.BooleanField(read_only=True)
     community_id = serializers.UUIDField(read_only=True, allow_null=True)
     community_name = serializers.SerializerMethodField()
+    tagged_users = serializers.SerializerMethodField()
     actor_role = serializers.CharField(read_only=True)
     mentorship_partner = serializers.SerializerMethodField()
     author = ProfilePostAuthorSerializer(read_only=True)
@@ -741,6 +744,36 @@ class ProfilePostSerializer(serializers.Serializer):
         # Community was deleted — fall back to snapshot stored at creation time
         payload = obj.payload or {}
         return payload.get("community_name")
+
+    @extend_schema_field(
+        {
+            "type": "array",
+            "nullable": True,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "user_id": {"type": "string", "format": "uuid"},
+                    "username": {"type": "string"},
+                },
+            },
+        }
+    )
+    def get_tagged_users(self, obj: TimelineEvent) -> list[dict[str, str]] | None:
+        """Return tagged users for CoP events.
+
+        Returns a list of ``{user_id, username}`` dicts extracted from the event
+        payload. Usernames are captured as snapshots at tag-time; if a tagged user
+        has since been deleted, the stored snapshot username is returned.
+        Returns ``None`` for non-CoP events.
+        """
+        if obj.category != TimelineEvent.Category.COP:
+            return None
+
+        payload = obj.payload or {}
+        tagged_users_list = payload.get("tagged_users", [])
+        return [
+            {"user_id": tag["user_id"], "username": tag["username"]} for tag in tagged_users_list
+        ]
 
     @extend_schema_field({"type": "string", "nullable": True})
     def get_mentorship_partner(self, obj: TimelineEvent) -> str | None:
@@ -1002,8 +1035,7 @@ class CommunityPostSerializer(serializers.Serializer):
         tagged_users_list = payload.get("tagged_users", [])
 
         return [
-            {"user_id": tag["user_id"], "username": tag["username"]}
-            for tag in tagged_users_list
+            {"user_id": tag["user_id"], "username": tag["username"]} for tag in tagged_users_list
         ]
 
 

--- a/backend/profiles/serializers.py
+++ b/backend/profiles/serializers.py
@@ -925,6 +925,20 @@ class CommunityTagListResponseSerializer(serializers.Serializer):
     results = CommunityTagListSerializer(many=True)
 
 
+class TaggableUserSerializer(serializers.Serializer):
+    """Response item for a user taggable in a community post."""
+
+    username = serializers.CharField(read_only=True)
+    display_name = serializers.CharField(read_only=True)
+
+
+class TaggableUsersResponseSerializer(serializers.Serializer):
+    """Response wrapper for taggable users in a community."""
+
+    count = serializers.IntegerField(read_only=True)
+    results = TaggableUserSerializer(many=True, read_only=True)
+
+
 # ---------------------------------------------------------------------------
 # Community Posts (CoP)
 # ---------------------------------------------------------------------------

--- a/backend/profiles/serializers.py
+++ b/backend/profiles/serializers.py
@@ -905,12 +905,24 @@ class CoPCreateSerializer(serializers.Serializer):
     media_url = serializers.URLField(required=False, allow_null=True, default=None)
     show_on_profile = serializers.BooleanField(required=False, default=False)
     timestamp = serializers.DateTimeField(required=False, allow_null=True, default=None)
+    tagged_users = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        allow_empty=True,
+        default=list,
+    )
 
     def to_internal_value(self, data: Any) -> dict:
         """Normalize empty timestamp values to null so fallback logic can be applied."""
         if isinstance(data, dict) and data.get("timestamp") == "":
             data = {**data, "timestamp": None}
         return super().to_internal_value(data)
+
+    def validate_tagged_users(self, value: list) -> list:
+        """Validate tagged_users field (user IDs as strings)."""
+        # Validation logic will be handled in the view/service layer
+        # where we have access to author and community context
+        return value
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         """Reject timestamps more than 1 day in the future when provided."""
@@ -929,13 +941,24 @@ class CoPUpdateSerializer(serializers.Serializer):
     event_type = serializers.ChoiceField(choices=_PROFILE_POST_EVENT_TYPE_CHOICES, required=False)
     media_url = serializers.URLField(required=False, allow_null=True)
     show_on_profile = serializers.BooleanField(required=False)
+    tagged_users = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        allow_empty=True,
+    )
+
+    def validate_tagged_users(self, value: list) -> list:
+        """Validate tagged_users field (user IDs as strings)."""
+        # Validation logic will be handled in the view/service layer
+        # where we have access to author and community context
+        return value
 
     def validate(self, attrs: dict) -> dict:
         """Require at least one editable field to be provided."""
         if not attrs:
             raise serializers.ValidationError(
-                "At least one of 'content', 'event_type', 'media_url', or "
-                "'show_on_profile' must be provided."
+                "At least one of 'content', 'event_type', 'media_url', "
+                "'show_on_profile', or 'tagged_users' must be provided."
             )
         return attrs
 
@@ -968,6 +991,20 @@ class CommunityPostSerializer(serializers.Serializer):
     show_on_profile = serializers.BooleanField(read_only=True)
     community_id = serializers.UUIDField(read_only=True)
     author = ProfilePostAuthorSerializer(read_only=True)
+    tagged_users = serializers.SerializerMethodField()
+
+    def get_tagged_users(self, obj: Any) -> list[dict[str, str]]:
+        """Extract and return tagged users from payload.
+
+        Returns only user_id and username fields for each tagged user.
+        """
+        payload = obj.payload or {}
+        tagged_users_list = payload.get("tagged_users", [])
+
+        return [
+            {"user_id": tag["user_id"], "username": tag["username"]}
+            for tag in tagged_users_list
+        ]
 
 
 class CommunityPostFeedSerializer(serializers.Serializer):

--- a/backend/profiles/services.py
+++ b/backend/profiles/services.py
@@ -3,6 +3,8 @@
 import uuid
 from typing import Any
 
+from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models import Q
 from django.db.models.functions import Coalesce
@@ -43,6 +45,174 @@ class InvalidPrPEventTypeError(Exception):
 
 class InvalidCoPEventTypeError(Exception):
     """Raised when an unsupported event_type is supplied for a community post."""
+
+
+# ============================================================================
+# CoP Tagging Utilities
+# ============================================================================
+
+
+def get_taggable_users(author_profile: Profile) -> Any:
+    """Get users who can be tagged in a CoP by the given author.
+
+    Taggable users are active mentorship connections (both directions).
+    Community members are resolved separately in validate_tagged_users_list.
+
+    Args:
+        author_profile: The Profile of the CoP author.
+
+    Returns:
+        A QuerySet of Profile objects that can be tagged via mentorship.
+    """
+    # Get all active mentorship connections (bidirectional) via ORM related names.
+    # mentor_matches / mentee_matches are defined on the Match model.
+    mentorship_connections = Profile.objects.filter(
+        Q(mentor_matches__is_active=True, mentor_matches__mentee=author_profile)
+        | Q(mentee_matches__is_active=True, mentee_matches__mentor=author_profile)
+    ).distinct()
+
+    return mentorship_connections.exclude(id=author_profile.id)
+
+
+def get_tagged_user_info(user_id: str, username_snapshot: str | None = None) -> dict[str, str]:
+    """Get or construct tagged user information.
+
+    If user exists, returns the current username. If user was deleted, uses the
+    provided username_snapshot (from when the tag was created).
+
+    Args:
+        user_id: UUID of the user to tag.
+        username_snapshot: Username at tag-time (used if user was deleted).
+
+    Returns:
+        Dict with 'user_id' and 'username' keys.
+
+    Raises:
+        Profile.DoesNotExist: If user doesn't exist and no snapshot provided.
+    """
+    try:
+        user = Profile.objects.only("id", "username").get(id=user_id)
+        return {
+            "user_id": str(user_id),
+            "username": user.username,
+        }
+    except Profile.DoesNotExist:
+        if username_snapshot is None:
+            raise
+        # Fallback to snapshot if user was deleted
+        return {
+            "user_id": str(user_id),
+            "username": username_snapshot,
+        }
+
+
+def validate_tagged_users_list(
+    author: Profile,
+    tagged_user_ids: list[str] | None,
+    community_id: str | None,
+    previous_tagged_user_ids: list[str] | None = None,
+) -> list[dict[str, str]]:
+    """Validate and build tagged users list for a CoP.
+
+    Validation rules:
+    - No more than COP_MAX_TAGS users (default 5).
+    - All tagged users must exist.
+    - Tagged users must be either mentorship connections or community members.
+    - Author cannot tag themselves.
+    - During editing, users who were previously tagged but are now untaggable
+      are preserved if they are NOT in the new tagged_user_ids list (merge logic).
+      If re-added to the new list, they are rejected.
+
+    Args:
+        author: The Profile of the CoP author.
+        tagged_user_ids: List of user IDs to tag (can be None/empty for new posts).
+        community_id: UUID of the community where the CoP is posted.
+        previous_tagged_user_ids: List of previously tagged user IDs (for editing).
+
+    Returns:
+        List of dicts with 'user_id' and 'username' keys (snapshot at tag-time).
+
+    Raises:
+        ValidationError: If validation fails.
+    """
+    from .models import CommunityTag, CommunityTagMembership
+
+    max_tags = getattr(settings, "COP_MAX_TAGS", 5)
+    tagged_user_ids = tagged_user_ids or []
+    previous_tagged_user_ids = previous_tagged_user_ids or []
+
+    # --- Basic Constraints --------------------------------------------------
+
+    if len(tagged_user_ids) > max_tags:
+        raise ValidationError(
+            f"Cannot tag more than {max_tags} users. Got {len(tagged_user_ids)}."
+        )
+
+    if str(author.id) in [str(uid) for uid in tagged_user_ids]:
+        raise ValidationError("You cannot tag yourself.")
+
+    # Convert to sets of UUIDs for set operations
+    new_tagged_ids = {
+        uuid.UUID(uid) if isinstance(uid, str) else uid for uid in tagged_user_ids
+    }
+    prev_tagged_ids = {
+        uuid.UUID(uid) if isinstance(uid, str) else uid for uid in previous_tagged_user_ids
+    }
+
+    # --- Determine Currently Taggable Users ---------------------------------
+
+    taggable_by_mentorship = set(get_taggable_users(author).values_list("id", flat=True))
+
+    taggable_by_community: set = set()
+    if community_id:
+        try:
+            community = CommunityTag.objects.only("id").get(id=community_id)
+            taggable_by_community = set(
+                CommunityTagMembership.objects.filter(tag=community).values_list(
+                    "profile__id", flat=True
+                )
+            )
+        except CommunityTag.DoesNotExist:
+            raise ValidationError(f"Community with ID {community_id} does not exist.")
+
+    currently_taggable = taggable_by_mentorship | taggable_by_community
+
+    # --- Enforce Permissions (with Merge Logic) -----------------------------
+
+    # Only validate NEWLY added tags (users not previously tagged).
+    # Previously tagged users can remain in the list even if now untaggable,
+    # because the editor is explicitly choosing to keep them (by including them
+    # in the submitted list). Users not in the submitted list are removed.
+    # This means: if the editor wants to keep a now-untaggable user, they must
+    # include them in the new list; if they omit them, they are removed.
+    # Once removed, a now-untaggable user cannot be re-added.
+    newly_tagged = new_tagged_ids - prev_tagged_ids
+    unallowed_new_tags = newly_tagged - currently_taggable
+
+    if unallowed_new_tags:
+        unallowed_names = ", ".join(str(uid) for uid in unallowed_new_tags)
+        raise ValidationError(
+            f"Cannot tag users: {unallowed_names}. "
+            f"They are not in your mentorship connections or the community."
+        )
+
+    # Final state = exactly what the editor submitted (after validation).
+    # No auto-preservation: omitting a user removes them.
+    final_tagged_ids = new_tagged_ids
+
+    # --- Build Snapshot List ------------------------------------------------
+
+    tagged_users_list = []
+    for user_id in final_tagged_ids:
+        try:
+            user_info = get_tagged_user_info(str(user_id))
+            tagged_users_list.append(user_info)
+        except Profile.DoesNotExist:
+            raise ValidationError(
+                f"User with ID {user_id} does not exist and cannot be tagged."
+            )
+
+    return tagged_users_list
 
 
 def book_availability_slot(*, profile: Profile, slot_id, actor) -> AvailabilitySlot:
@@ -292,10 +462,28 @@ def create_cop_event(
     media_url: str | None = None,
     show_on_profile: bool = False,
     timestamp: Any | None = None,
+    tagged_users: list[str] | None = None,
 ) -> Any:
     """Create and persist a community post (CoP).
 
     If timestamp is omitted, event timestamp is aligned with created_at.
+
+    Args:
+        author_profile: The Profile of the CoP author.
+        community_tag: The CommunityTag where the CoP is posted.
+        event_type: Type of event (must be valid TimelineEvent.MCTEEventType).
+        content: The post content text.
+        media_url: Optional URL to media associated with the post.
+        show_on_profile: Whether to show this CoP on the author's profile.
+        timestamp: Optional custom timestamp (defaults to creation time).
+        tagged_users: List of user IDs to tag (will be validated and stored with snapshots).
+
+    Returns:
+        The created TimelineEvent object.
+
+    Raises:
+        InvalidCoPEventTypeError: If event_type is invalid.
+        ValidationError: If tagged_users validation fails.
     """
     from timeline.models import TimelineEvent
 
@@ -304,6 +492,20 @@ def create_cop_event(
             f"Invalid CoP event_type: '{event_type}'. "
             f"Must be one of {TimelineEvent.MCTEEventType.values}."
         )
+
+    # Validate and build tagged users list
+    validated_tagged_users = validate_tagged_users_list(
+        author=author_profile,
+        tagged_user_ids=tagged_users,
+        community_id=str(community_tag.id),
+        previous_tagged_user_ids=None,
+    )
+
+    # Build payload with community name and tagged users
+    payload = {
+        "community_name": community_tag.name,
+        "tagged_users": validated_tagged_users,
+    }
 
     event = TimelineEvent.objects.create(
         source_id=f"cop:{uuid.uuid4()}",
@@ -315,7 +517,7 @@ def create_cop_event(
         media_url=media_url,
         show_on_profile=show_on_profile,
         timestamp=timestamp if timestamp is not None else timezone.now(),
-        payload={"community_name": community_tag.name},
+        payload=payload,
     )
 
     if timestamp is None:
@@ -333,8 +535,31 @@ def edit_cop_event(
     media_url: str | None = None,
     show_on_profile: bool | None = None,
     update_media_url: bool = False,
+    tagged_users: list[str] | None = None,
 ) -> Any:
-    """Partially update a community post and set last_edited."""
+    """Partially update a community post and set last_edited.
+
+    When tagged_users is provided, applies merge logic:
+    - New tags must be currently allowed (mentorship/community member)
+    - Previously tagged users remain tagged even if now unallowed
+    - (per requirements for backward compatibility)
+
+    Args:
+        event: The TimelineEvent to update.
+        content: New content text (if provided).
+        event_type: New event type (if provided).
+        media_url: New media URL (if provided).
+        show_on_profile: New visibility setting (if provided).
+        update_media_url: Whether to actually update media_url.
+        tagged_users: New list of user IDs to tag (None = don't change).
+
+    Returns:
+        The updated TimelineEvent object.
+
+    Raises:
+        InvalidCoPEventTypeError: If event_type is invalid.
+        ValidationError: If tagged_users validation fails.
+    """
     from timeline.models import TimelineEvent
 
     if event_type is not None and event_type not in TimelineEvent.MCTEEventType.values:
@@ -360,6 +585,27 @@ def edit_cop_event(
     if show_on_profile is not None:
         event.show_on_profile = show_on_profile
         update_fields.append("show_on_profile")
+
+    # Handle tagged_users with merge logic
+    if tagged_users is not None:
+        # Get previous tagged users from payload
+        previous_payload = event.payload or {}
+        previous_tagged_users = previous_payload.get("tagged_users", [])
+        previous_tagged_user_ids = [tag["user_id"] for tag in previous_tagged_users]
+
+        # Validate and build new tagged users list (with merge logic)
+        validated_tagged_users = validate_tagged_users_list(
+            author=event.author,
+            tagged_user_ids=tagged_users,
+            community_id=str(event.community_id) if event.community_id else None,
+            previous_tagged_user_ids=previous_tagged_user_ids,
+        )
+
+        # Update payload with new tagged_users
+        if event.payload is None:
+            event.payload = {}
+        event.payload["tagged_users"] = validated_tagged_users
+        update_fields.append("payload")
 
     event.last_edited = timezone.now()
     event.save(update_fields=update_fields)

--- a/backend/profiles/services.py
+++ b/backend/profiles/services.py
@@ -106,60 +106,44 @@ def get_tagged_user_info(user_id: str, username_snapshot: str | None = None) -> 
         }
 
 
-def validate_tagged_users_list(
+def _build_previous_tag_maps(
+    previous_tagged_users: list[dict[str, str]],
+) -> tuple[dict[str, dict[str, str]], set[uuid.UUID]]:
+    """Build lookup maps from previously stored tag snapshots."""
+    prev_tagged_by_username: dict[str, dict[str, str]] = {}
+    prev_tagged_ids: set[uuid.UUID] = set()
+
+    for tag in previous_tagged_users:
+        username = str(tag.get("username", "")).strip().lower()
+        user_id = str(tag.get("user_id", "")).strip()
+        if not username or not user_id:
+            continue
+
+        try:
+            parsed_id = uuid.UUID(user_id)
+        except (ValueError, TypeError):
+            continue
+
+        prev_tagged_by_username[username] = {
+            "user_id": str(parsed_id),
+            "username": str(tag.get("username", "")),
+        }
+        prev_tagged_ids.add(parsed_id)
+
+    return prev_tagged_by_username, prev_tagged_ids
+
+
+def _get_currently_taggable_maps(
+    *,
     author: Profile,
-    tagged_user_ids: list[str] | None,
     community_id: str | None,
-    previous_tagged_user_ids: list[str] | None = None,
-) -> list[dict[str, str]]:
-    """Validate and build tagged users list for a CoP.
-
-    Validation rules:
-    - No more than COP_MAX_TAGS users (default 5).
-    - All tagged users must exist.
-    - Tagged users must be either mentorship connections or community members.
-    - Author cannot tag themselves.
-    - During editing, users who were previously tagged but are now untaggable
-      are preserved if they are NOT in the new tagged_user_ids list (merge logic).
-      If re-added to the new list, they are rejected.
-
-    Args:
-        author: The Profile of the CoP author.
-        tagged_user_ids: List of user IDs to tag (can be None/empty for new posts).
-        community_id: UUID of the community where the CoP is posted.
-        previous_tagged_user_ids: List of previously tagged user IDs (for editing).
-
-    Returns:
-        List of dicts with 'user_id' and 'username' keys (snapshot at tag-time).
-
-    Raises:
-        ValidationError: If validation fails.
-    """
+) -> tuple[set[uuid.UUID], dict[str, Profile]]:
+    """Return currently taggable IDs and case-insensitive username lookup."""
     from .models import CommunityTag, CommunityTagMembership
-
-    max_tags = getattr(settings, "COP_MAX_TAGS", 5)
-    tagged_user_ids = tagged_user_ids or []
-    previous_tagged_user_ids = previous_tagged_user_ids or []
-
-    # --- Basic Constraints --------------------------------------------------
-
-    if len(tagged_user_ids) > max_tags:
-        raise ValidationError(f"Cannot tag more than {max_tags} users. Got {len(tagged_user_ids)}.")
-
-    if str(author.id) in [str(uid) for uid in tagged_user_ids]:
-        raise ValidationError("You cannot tag yourself.")
-
-    # Convert to sets of UUIDs for set operations
-    new_tagged_ids = {uuid.UUID(uid) if isinstance(uid, str) else uid for uid in tagged_user_ids}
-    prev_tagged_ids = {
-        uuid.UUID(uid) if isinstance(uid, str) else uid for uid in previous_tagged_user_ids
-    }
-
-    # --- Determine Currently Taggable Users ---------------------------------
 
     taggable_by_mentorship = set(get_taggable_users(author).values_list("id", flat=True))
 
-    taggable_by_community: set = set()
+    taggable_by_community: set[uuid.UUID] = set()
     if community_id:
         try:
             community = CommunityTag.objects.only("id").get(id=community_id)
@@ -172,6 +156,117 @@ def validate_tagged_users_list(
             raise ValidationError(f"Community with ID {community_id} does not exist.")
 
     currently_taggable = taggable_by_mentorship | taggable_by_community
+    currently_taggable_profiles = Profile.objects.filter(id__in=currently_taggable).only(
+        "id", "username"
+    )
+    currently_taggable_by_username = {
+        profile.username.strip().lower(): profile for profile in currently_taggable_profiles
+    }
+    return currently_taggable, currently_taggable_by_username
+
+
+def _resolve_tagged_usernames(
+    *,
+    tagged_usernames: list[str],
+    currently_taggable_by_username: dict[str, Profile],
+    prev_tagged_by_username: dict[str, dict[str, str]],
+) -> tuple[set[uuid.UUID], dict[uuid.UUID, str], list[str]]:
+    """Resolve submitted usernames to user IDs with snapshot usernames."""
+    resolved_tagged_ids: set[uuid.UUID] = set()
+    tagged_id_to_snapshot_username: dict[uuid.UUID, str] = {}
+    unresolved_usernames: list[str] = []
+
+    for raw_username in tagged_usernames:
+        normalized_username = raw_username.strip().lower()
+        if not normalized_username:
+            unresolved_usernames.append(raw_username)
+            continue
+
+        profile = currently_taggable_by_username.get(normalized_username)
+        if profile is not None:
+            resolved_tagged_ids.add(profile.id)
+            tagged_id_to_snapshot_username[profile.id] = profile.username
+            continue
+
+        previous_tag = prev_tagged_by_username.get(normalized_username)
+        if previous_tag is not None:
+            previous_id = uuid.UUID(previous_tag["user_id"])
+            resolved_tagged_ids.add(previous_id)
+            tagged_id_to_snapshot_username[previous_id] = previous_tag["username"]
+            continue
+
+        unresolved_usernames.append(raw_username)
+
+    return resolved_tagged_ids, tagged_id_to_snapshot_username, unresolved_usernames
+
+
+def validate_tagged_users_list(
+    author: Profile,
+    tagged_usernames: list[str] | None,
+    community_id: str | None,
+    previous_tagged_users: list[dict[str, str]] | None = None,
+) -> list[dict[str, str]]:
+    """Validate and build tagged users list for a CoP.
+
+    Validation rules:
+    - No more than COP_MAX_TAGS users (default 5).
+    - All tagged users must exist.
+    - Tagged users must be either mentorship connections or community members.
+    - Author cannot tag themselves.
+        - During editing, newly-added users must still be currently taggable.
+            Previously tagged users can remain tagged if submitted again by username,
+            even if they are no longer currently taggable.
+
+    Args:
+        author: The Profile of the CoP author.
+        tagged_usernames: List of usernames to tag (can be None/empty for new posts).
+        community_id: UUID of the community where the CoP is posted.
+        previous_tagged_users: Previously tagged user snapshots from payload (for editing).
+
+    Returns:
+        List of dicts with 'user_id' and 'username' keys (snapshot at tag-time).
+
+    Raises:
+        ValidationError: If validation fails.
+    """
+    max_tags = getattr(settings, "COP_MAX_TAGS", 5)
+    tagged_usernames = tagged_usernames or []
+    previous_tagged_users = previous_tagged_users or []
+
+    # --- Basic Constraints --------------------------------------------------
+
+    if len(tagged_usernames) > max_tags:
+        raise ValidationError(
+            f"Cannot tag more than {max_tags} users. Got {len(tagged_usernames)}."
+        )
+
+    normalized_author_username = author.username.strip().lower()
+    normalized_input_usernames = [username.strip().lower() for username in tagged_usernames]
+    if normalized_author_username in normalized_input_usernames:
+        raise ValidationError("You cannot tag yourself.")
+
+    prev_tagged_by_username, prev_tagged_ids = _build_previous_tag_maps(previous_tagged_users)
+
+    # --- Determine Currently Taggable Users ---------------------------------
+
+    currently_taggable, currently_taggable_by_username = _get_currently_taggable_maps(
+        author=author,
+        community_id=community_id,
+    )
+    resolved_tagged_ids, tagged_id_to_snapshot_username, unresolved_usernames = (
+        _resolve_tagged_usernames(
+            tagged_usernames=tagged_usernames,
+            currently_taggable_by_username=currently_taggable_by_username,
+            prev_tagged_by_username=prev_tagged_by_username,
+        )
+    )
+
+    if unresolved_usernames:
+        unresolved = ", ".join(unresolved_usernames)
+        raise ValidationError(
+            f"Cannot tag users: {unresolved}. "
+            f"They are not in your mentorship connections or the community."
+        )
 
     # --- Enforce Permissions (with Merge Logic) -----------------------------
 
@@ -182,7 +277,7 @@ def validate_tagged_users_list(
     # This means: if the editor wants to keep a now-untaggable user, they must
     # include them in the new list; if they omit them, they are removed.
     # Once removed, a now-untaggable user cannot be re-added.
-    newly_tagged = new_tagged_ids - prev_tagged_ids
+    newly_tagged = resolved_tagged_ids - prev_tagged_ids
     unallowed_new_tags = newly_tagged - currently_taggable
 
     if unallowed_new_tags:
@@ -194,14 +289,17 @@ def validate_tagged_users_list(
 
     # Final state = exactly what the editor submitted (after validation).
     # No auto-preservation: omitting a user removes them.
-    final_tagged_ids = new_tagged_ids
+    final_tagged_ids = resolved_tagged_ids
 
     # --- Build Snapshot List ------------------------------------------------
 
     tagged_users_list = []
     for user_id in final_tagged_ids:
         try:
-            user_info = get_tagged_user_info(str(user_id))
+            user_info = get_tagged_user_info(
+                str(user_id),
+                username_snapshot=tagged_id_to_snapshot_username.get(user_id),
+            )
             tagged_users_list.append(user_info)
         except Profile.DoesNotExist:
             raise ValidationError(f"User with ID {user_id} does not exist and cannot be tagged.")
@@ -470,7 +568,7 @@ def create_cop_event(
         media_url: Optional URL to media associated with the post.
         show_on_profile: Whether to show this CoP on the author's profile.
         timestamp: Optional custom timestamp (defaults to creation time).
-        tagged_users: List of user IDs to tag (will be validated and stored with snapshots).
+        tagged_users: List of usernames to tag (will be validated and stored with snapshots).
 
     Returns:
         The created TimelineEvent object.
@@ -490,9 +588,9 @@ def create_cop_event(
     # Validate and build tagged users list
     validated_tagged_users = validate_tagged_users_list(
         author=author_profile,
-        tagged_user_ids=tagged_users,
+        tagged_usernames=tagged_users,
         community_id=str(community_tag.id),
-        previous_tagged_user_ids=None,
+        previous_tagged_users=None,
     )
 
     # Build payload with community name and tagged users
@@ -545,7 +643,7 @@ def edit_cop_event(
         media_url: New media URL (if provided).
         show_on_profile: New visibility setting (if provided).
         update_media_url: Whether to actually update media_url.
-        tagged_users: New list of user IDs to tag (None = don't change).
+        tagged_users: New list of usernames to tag (None = don't change).
 
     Returns:
         The updated TimelineEvent object.
@@ -585,14 +683,13 @@ def edit_cop_event(
         # Get previous tagged users from payload
         previous_payload = event.payload or {}
         previous_tagged_users = previous_payload.get("tagged_users", [])
-        previous_tagged_user_ids = [tag["user_id"] for tag in previous_tagged_users]
 
         # Validate and build new tagged users list (with merge logic)
         validated_tagged_users = validate_tagged_users_list(
             author=event.author,
-            tagged_user_ids=tagged_users,
+            tagged_usernames=tagged_users,
             community_id=str(event.community_id) if event.community_id else None,
-            previous_tagged_user_ids=previous_tagged_user_ids,
+            previous_tagged_users=previous_tagged_users,
         )
 
         # Update payload with new tagged_users

--- a/backend/profiles/services.py
+++ b/backend/profiles/services.py
@@ -74,6 +74,39 @@ def get_taggable_users(author_profile: Profile) -> Any:
     return mentorship_connections.exclude(id=author_profile.id)
 
 
+def get_taggable_users_for_community(author_profile: Profile, community_id: str) -> Any:
+    """Get taggable users for an author in a given community.
+
+    A user is taggable when they are either an active mentorship connection of
+    the author (bidirectional) or a member of the given community. The author
+    is always excluded from results.
+
+    Args:
+        author_profile: The profile of the CoP author.
+        community_id: Community UUID where tagging is being performed.
+
+    Returns:
+        QuerySet of Profile objects taggable by username.
+
+    Raises:
+        ValidationError: If community does not exist.
+    """
+    from .models import CommunityTag, CommunityTagMembership
+
+    try:
+        community = CommunityTag.objects.only("id").get(id=community_id)
+    except CommunityTag.DoesNotExist:
+        raise ValidationError(f"Community with ID {community_id} does not exist.")
+
+    mentorship_ids = set(get_taggable_users(author_profile).values_list("id", flat=True))
+    community_member_ids = set(
+        CommunityTagMembership.objects.filter(tag=community).values_list("profile_id", flat=True)
+    )
+
+    taggable_ids = mentorship_ids | community_member_ids
+    return Profile.objects.filter(id__in=taggable_ids).exclude(id=author_profile.id)
+
+
 def get_tagged_user_info(user_id: str, username_snapshot: str | None = None) -> dict[str, str]:
     """Get or construct tagged user information.
 

--- a/backend/profiles/services.py
+++ b/backend/profiles/services.py
@@ -144,17 +144,13 @@ def validate_tagged_users_list(
     # --- Basic Constraints --------------------------------------------------
 
     if len(tagged_user_ids) > max_tags:
-        raise ValidationError(
-            f"Cannot tag more than {max_tags} users. Got {len(tagged_user_ids)}."
-        )
+        raise ValidationError(f"Cannot tag more than {max_tags} users. Got {len(tagged_user_ids)}.")
 
     if str(author.id) in [str(uid) for uid in tagged_user_ids]:
         raise ValidationError("You cannot tag yourself.")
 
     # Convert to sets of UUIDs for set operations
-    new_tagged_ids = {
-        uuid.UUID(uid) if isinstance(uid, str) else uid for uid in tagged_user_ids
-    }
+    new_tagged_ids = {uuid.UUID(uid) if isinstance(uid, str) else uid for uid in tagged_user_ids}
     prev_tagged_ids = {
         uuid.UUID(uid) if isinstance(uid, str) else uid for uid in previous_tagged_user_ids
     }
@@ -208,9 +204,7 @@ def validate_tagged_users_list(
             user_info = get_tagged_user_info(str(user_id))
             tagged_users_list.append(user_info)
         except Profile.DoesNotExist:
-            raise ValidationError(
-                f"User with ID {user_id} does not exist and cannot be tagged."
-            )
+            raise ValidationError(f"User with ID {user_id} does not exist and cannot be tagged.")
 
     return tagged_users_list
 

--- a/backend/profiles/tests.py
+++ b/backend/profiles/tests.py
@@ -4867,3 +4867,512 @@ class ProfileFeedDeletionScenarioTests(TestCase):
             item for item in response.data["results"] if item["source_id"] == event.source_id
         )
         self.assertEqual(result["community_name"], "Renamed Community")
+
+
+class CoPTaggingTests(TestCase):
+    """Tests for CoP user tagging feature."""
+
+    def setUp(self) -> None:
+        self.api_client: Any = APIClient()
+
+        # Author of the CoP
+        self.author_user = User.objects.create_user(
+            email="cop-author@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTOR,
+        )
+        self.author_profile = Profile.objects.create(
+            user=self.author_user,
+            username="cop_author_tag",
+            display_name="CoP Author",
+        )
+
+        # User connected via mentorship (as mentee)
+        self.mentorship_user = User.objects.create_user(
+            email="mentorship-user@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTEE,
+        )
+        self.mentorship_profile = Profile.objects.create(
+            user=self.mentorship_user,
+            username="mentorship_connection",
+            display_name="Mentorship Connection",
+        )
+
+        # User who is only a community member (no mentorship)
+        self.community_only_user = User.objects.create_user(
+            email="community-only@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTEE,
+        )
+        self.community_only_profile = Profile.objects.create(
+            user=self.community_only_user,
+            username="community_only_user",
+            display_name="Community Only",
+        )
+
+        # Unrelated user: no mentorship, not in community
+        self.unrelated_user = User.objects.create_user(
+            email="unrelated@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTEE,
+        )
+        self.unrelated_profile = Profile.objects.create(
+            user=self.unrelated_user,
+            username="unrelated_user",
+            display_name="Unrelated User",
+        )
+
+        # Community setup
+        self.community = CommunityTag.objects.create(
+            name="Tag Test Community",
+            description="Community for tagging tests",
+            created_by=self.author_profile,
+        )
+        CommunityTagMembership.objects.create(
+            profile=self.author_profile,
+            tag=self.community,
+        )
+        CommunityTagMembership.objects.create(
+            profile=self.community_only_profile,
+            tag=self.community,
+        )
+        CommunityTagMembership.objects.create(
+            profile=self.mentorship_profile,
+            tag=self.community,
+        )
+
+        # Active mentorship connection (author is mentor, mentorship_profile is mentee)
+        self.mentorship_request = MentorshipRequest.objects.create(
+            mentor=self.author_profile,
+            mentee=self.mentorship_profile,
+            status=MentorshipRequest.Status.ACCEPTED,
+        )
+        self.active_match = Match.objects.create(
+            mentor=self.author_profile,
+            mentee=self.mentorship_profile,
+            request=self.mentorship_request,
+            is_active=True,
+        )
+
+        self.author_token = str(RefreshToken.for_user(self.author_user).access_token)
+        self.create_url = f"/api/profiles/tags/{self.community.id}/posts/"
+
+    def _auth_author(self) -> None:
+        self.api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.author_token}")
+
+    def _detail_url(self, event_id: str) -> str:
+        return f"/api/profiles/tags/{self.community.id}/posts/{event_id}/"
+
+    # ------------------------------------------------------------------ service layer
+
+    def test_validate_tagged_users_accepts_community_member(self) -> None:
+        """Community members (not mentorship connection) can be tagged."""
+        from django.core.exceptions import ValidationError as DjangoValidationError
+
+        from profiles.services import validate_tagged_users_list
+
+        result = validate_tagged_users_list(
+            author=self.author_profile,
+            tagged_user_ids=[str(self.community_only_profile.id)],
+            community_id=str(self.community.id),
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["user_id"], str(self.community_only_profile.id))
+        self.assertEqual(result[0]["username"], self.community_only_profile.username)
+
+    def test_validate_tagged_users_accepts_mentorship_connection(self) -> None:
+        """Active mentorship connections can be tagged."""
+        from profiles.services import validate_tagged_users_list
+
+        result = validate_tagged_users_list(
+            author=self.author_profile,
+            tagged_user_ids=[str(self.mentorship_profile.id)],
+            community_id=str(self.community.id),
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["username"], self.mentorship_profile.username)
+
+    def test_validate_tagged_users_rejects_self_tag(self) -> None:
+        """Author cannot tag themselves."""
+        from django.core.exceptions import ValidationError as DjangoValidationError
+
+        from profiles.services import validate_tagged_users_list
+
+        with self.assertRaises(DjangoValidationError):
+            validate_tagged_users_list(
+                author=self.author_profile,
+                tagged_user_ids=[str(self.author_profile.id)],
+                community_id=str(self.community.id),
+            )
+
+    def test_validate_tagged_users_rejects_unrelated_user(self) -> None:
+        """Users not in mentorship or community cannot be tagged."""
+        from django.core.exceptions import ValidationError as DjangoValidationError
+
+        from profiles.services import validate_tagged_users_list
+
+        with self.assertRaises(DjangoValidationError):
+            validate_tagged_users_list(
+                author=self.author_profile,
+                tagged_user_ids=[str(self.unrelated_profile.id)],
+                community_id=str(self.community.id),
+            )
+
+    def test_validate_tagged_users_rejects_exceeding_max_tags(self) -> None:
+        """Tagging more than COP_MAX_TAGS users raises ValidationError."""
+        from django.core.exceptions import ValidationError as DjangoValidationError
+
+        from profiles.services import validate_tagged_users_list
+
+        # Create enough extra community members to exceed the limit
+        extra_profiles = []
+        for i in range(6):
+            u = User.objects.create_user(
+                email=f"extra-user-{i}@example.com",
+                password="SecurePass123",
+                app_usage_mode=AppUsageMode.MENTEE,
+            )
+            p = Profile.objects.create(
+                user=u, username=f"extra_user_{i}", display_name=f"Extra {i}"
+            )
+            CommunityTagMembership.objects.create(profile=p, tag=self.community)
+            extra_profiles.append(p)
+
+        # Try to tag 6 users (exceeds default limit of 5)
+        user_ids = [str(p.id) for p in extra_profiles]
+        with self.assertRaises(DjangoValidationError):
+            validate_tagged_users_list(
+                author=self.author_profile,
+                tagged_user_ids=user_ids,
+                community_id=str(self.community.id),
+            )
+
+    @override_settings(COP_MAX_TAGS=2)
+    def test_validate_tagged_users_respects_custom_max_tags(self) -> None:
+        """COP_MAX_TAGS setting is respected."""
+        from django.core.exceptions import ValidationError as DjangoValidationError
+
+        from profiles.services import validate_tagged_users_list
+
+        with self.assertRaises(DjangoValidationError):
+            validate_tagged_users_list(
+                author=self.author_profile,
+                tagged_user_ids=[
+                    str(self.community_only_profile.id),
+                    str(self.mentorship_profile.id),
+                    str(self.author_profile.id),  # 3 users, exceeds limit of 2
+                ],
+                community_id=str(self.community.id),
+            )
+
+    def test_tagged_users_stored_in_payload_on_create(self) -> None:
+        """tagged_users are stored in payload when CoP is created."""
+        event = create_cop_event(
+            author_profile=self.author_profile,
+            community_tag=self.community,
+            event_type="social",
+            content="Hello with tags",
+            tagged_users=[str(self.community_only_profile.id)],
+        )
+
+        self.assertIn("tagged_users", event.payload)
+        tagged = event.payload["tagged_users"]
+        self.assertEqual(len(tagged), 1)
+        self.assertEqual(tagged[0]["user_id"], str(self.community_only_profile.id))
+        self.assertEqual(tagged[0]["username"], self.community_only_profile.username)
+
+    def test_tagged_users_username_snapshot_used(self) -> None:
+        """Username is captured as a snapshot at tag-time."""
+        original_username = self.community_only_profile.username
+        event = create_cop_event(
+            author_profile=self.author_profile,
+            community_tag=self.community,
+            event_type="social",
+            content="Post with snapshot test",
+            tagged_users=[str(self.community_only_profile.id)],
+        )
+
+        # Simulate username change after tagging
+        self.community_only_profile.username = "changed_username"
+        self.community_only_profile.save(update_fields=["username"])
+
+        # The snapshot in the payload should still hold the old name
+        event.refresh_from_db()
+        tagged = event.payload["tagged_users"]
+        self.assertEqual(tagged[0]["username"], original_username)
+
+    def test_no_tags_creates_empty_list(self) -> None:
+        """CoP with no tagged_users has an empty list in payload."""
+        event = create_cop_event(
+            author_profile=self.author_profile,
+            community_tag=self.community,
+            event_type="social",
+            content="No tags",
+        )
+        self.assertEqual(event.payload.get("tagged_users", []), [])
+
+    def test_edit_cop_updates_tagged_users(self) -> None:
+        """Editing a CoP with a new tagged_users list replaces the tags."""
+        from profiles.services import edit_cop_event
+
+        event = create_cop_event(
+            author_profile=self.author_profile,
+            community_tag=self.community,
+            event_type="social",
+            content="Original",
+            tagged_users=[str(self.mentorship_profile.id)],
+        )
+
+        updated = edit_cop_event(
+            event=event,
+            content="Updated",
+            tagged_users=[str(self.community_only_profile.id)],
+        )
+
+        tagged_ids = [t["user_id"] for t in updated.payload["tagged_users"]]
+        self.assertIn(str(self.community_only_profile.id), tagged_ids)
+        self.assertNotIn(str(self.mentorship_profile.id), tagged_ids)
+
+    def test_edit_preserves_tag_when_mentorship_deactivated(self) -> None:
+        """Previously tagged user can remain when editor explicitly keeps them,
+        even if mentorship is deactivated (since they were already in prev tags)."""
+        from mentorship.services import deactivate_match
+        from profiles.services import edit_cop_event
+
+        event = create_cop_event(
+            author_profile=self.author_profile,
+            community_tag=self.community,
+            event_type="social",
+            content="Original",
+            tagged_users=[str(self.mentorship_profile.id)],
+        )
+
+        # Remove mentorship_profile from community so only mentorship link is relevant
+        CommunityTagMembership.objects.filter(
+            profile=self.mentorship_profile, tag=self.community
+        ).delete()
+
+        # Deactivate the mentorship
+        deactivate_match(match=self.active_match, actor_profile=self.author_profile)
+
+        # Editor explicitly includes mentorship_profile in the new list (keeping them)
+        # This is allowed because they were previously tagged.
+        updated = edit_cop_event(
+            event=event,
+            content="Edited - kept previously-tagged user",
+            tagged_users=[str(self.mentorship_profile.id)],
+        )
+
+        tagged_ids = [t["user_id"] for t in updated.payload["tagged_users"]]
+        self.assertIn(str(self.mentorship_profile.id), tagged_ids)
+
+    def test_edit_removes_tag_when_editor_omits_untaggable_user(self) -> None:
+        """When editor omits a no-longer-taggable user from new list, they are removed.
+
+        Removing them means they cannot be re-added in a subsequent edit.
+        """
+        from mentorship.services import deactivate_match
+        from profiles.services import edit_cop_event
+
+        event = create_cop_event(
+            author_profile=self.author_profile,
+            community_tag=self.community,
+            event_type="social",
+            content="Original",
+            tagged_users=[str(self.mentorship_profile.id)],
+        )
+
+        # Remove mentorship_profile from community
+        CommunityTagMembership.objects.filter(
+            profile=self.mentorship_profile, tag=self.community
+        ).delete()
+
+        # Deactivate the mentorship
+        deactivate_match(match=self.active_match, actor_profile=self.author_profile)
+
+        # Edit with a different tag list that does NOT include mentorship_profile
+        updated = edit_cop_event(
+            event=event,
+            content="Edited - only community_only tagged",
+            tagged_users=[str(self.community_only_profile.id)],
+        )
+
+        # Only community_only_profile should be tagged; mentorship_profile was omitted
+        tagged_ids = [t["user_id"] for t in updated.payload["tagged_users"]]
+        self.assertIn(str(self.community_only_profile.id), tagged_ids)
+        self.assertNotIn(str(self.mentorship_profile.id), tagged_ids)
+
+    def test_cannot_retag_previously_removed_untaggable_user(self) -> None:
+        """After removing a now-untaggable tag, re-adding them in another edit fails."""
+        from django.core.exceptions import ValidationError as DjangoValidationError
+
+        from mentorship.services import deactivate_match
+        from profiles.services import edit_cop_event
+
+        event = create_cop_event(
+            author_profile=self.author_profile,
+            community_tag=self.community,
+            event_type="social",
+            content="Original",
+            tagged_users=[str(self.mentorship_profile.id)],
+        )
+
+        # Remove mentorship_profile from community and deactivate match
+        CommunityTagMembership.objects.filter(
+            profile=self.mentorship_profile, tag=self.community
+        ).delete()
+        deactivate_match(match=self.active_match, actor_profile=self.author_profile)
+
+        # First edit: explicitly remove mentorship_profile by omitting them
+        event = edit_cop_event(
+            event=event,
+            content="Edited - removed tag",
+            tagged_users=[],
+        )
+        # Confirm tag was removed
+        self.assertEqual(event.payload.get("tagged_users", []), [])
+
+        # Second edit: try to re-add mentorship_profile - should fail
+        with self.assertRaises(DjangoValidationError):
+            edit_cop_event(
+                event=event,
+                content="Re-add attempt",
+                tagged_users=[str(self.mentorship_profile.id)],
+            )
+
+    def test_edit_allows_removing_tag(self) -> None:
+        """Editor can remove a previously tagged user who is still allowed."""
+        from profiles.services import edit_cop_event
+
+        event = create_cop_event(
+            author_profile=self.author_profile,
+            community_tag=self.community,
+            event_type="social",
+            content="Original",
+            tagged_users=[str(self.mentorship_profile.id)],
+        )
+
+        # Remove the tag by passing an empty list
+        updated = edit_cop_event(
+            event=event,
+            content="Edited - no tags",
+            tagged_users=[],
+        )
+
+        self.assertEqual(updated.payload.get("tagged_users", []), [])
+
+    # ------------------------------------------------------------------ API layer
+
+    def test_create_cop_with_tagged_user_via_api(self) -> None:
+        """POST /api/profiles/tags/{id}/posts/ accepts tagged_users."""
+        self._auth_author()
+        response = self.api_client.post(
+            self.create_url,
+            {
+                "event_type": "social",
+                "content": "API post with tags",
+                "tagged_users": [str(self.community_only_profile.id)],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertIn("tagged_users", response.data)
+        tagged = response.data["tagged_users"]
+        self.assertEqual(len(tagged), 1)
+        self.assertEqual(tagged[0]["user_id"], str(self.community_only_profile.id))
+        self.assertEqual(tagged[0]["username"], self.community_only_profile.username)
+
+    def test_create_cop_tagging_unrelated_user_returns_400(self) -> None:
+        """POST fails with 400 when trying to tag an unrelated user."""
+        self._auth_author()
+        response = self.api_client.post(
+            self.create_url,
+            {
+                "event_type": "social",
+                "content": "Bad tags",
+                "tagged_users": [str(self.unrelated_profile.id)],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_create_cop_tagging_self_returns_400(self) -> None:
+        """POST fails with 400 when author tries to tag themselves."""
+        self._auth_author()
+        response = self.api_client.post(
+            self.create_url,
+            {
+                "event_type": "social",
+                "content": "Self tag",
+                "tagged_users": [str(self.author_profile.id)],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_cop_response_includes_tagged_users_field(self) -> None:
+        """GET /api/profiles/tags/{id}/posts/ returns tagged_users in each CoP."""
+        event = create_cop_event(
+            author_profile=self.author_profile,
+            community_tag=self.community,
+            event_type="social",
+            content="Listed post with tags",
+            tagged_users=[str(self.community_only_profile.id)],
+        )
+
+        self._auth_author()
+        response = self.api_client.get(self.create_url)
+
+        self.assertEqual(response.status_code, 200)
+        result = next(
+            (item for item in response.data["results"] if item["source_id"] == event.source_id),
+            None,
+        )
+        self.assertIsNotNone(result)
+        self.assertIn("tagged_users", result)
+        tagged = result["tagged_users"]
+        self.assertEqual(len(tagged), 1)
+        self.assertEqual(tagged[0]["username"], self.community_only_profile.username)
+
+    def test_edit_cop_with_new_tags_via_api(self) -> None:
+        """PATCH /api/profiles/tags/{id}/posts/{event_id}/ updates tagged_users."""
+        event = create_cop_event(
+            author_profile=self.author_profile,
+            community_tag=self.community,
+            event_type="social",
+            content="Original with tags",
+            tagged_users=[str(self.mentorship_profile.id)],
+        )
+
+        self._auth_author()
+        response = self.api_client.patch(
+            self._detail_url(str(event.id)),
+            {
+                "content": "Updated with different tags",
+                "tagged_users": [str(self.community_only_profile.id)],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        tagged_ids = [t["user_id"] for t in response.data["tagged_users"]]
+        self.assertIn(str(self.community_only_profile.id), tagged_ids)
+        self.assertNotIn(str(self.mentorship_profile.id), tagged_ids)
+
+    def test_tagged_users_mentorship_direction_bidirectional(self) -> None:
+        """Mentee can also tag their mentor (bidirectional)."""
+        from profiles.services import validate_tagged_users_list
+
+        # author_profile is mentor; mentorship_profile is mentee
+        # Let's validate as mentee tagging the mentor
+        result = validate_tagged_users_list(
+            author=self.mentorship_profile,
+            tagged_user_ids=[str(self.author_profile.id)],
+            community_id=str(self.community.id),
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["user_id"], str(self.author_profile.id))

--- a/backend/profiles/tests.py
+++ b/backend/profiles/tests.py
@@ -5361,6 +5361,47 @@ class CoPTaggingTests(TestCase):
         self.assertIn(str(self.community_only_profile.id), tagged_ids)
         self.assertNotIn(str(self.mentorship_profile.id), tagged_ids)
 
+    def test_list_taggable_users_helper_returns_expected_users(self) -> None:
+        """GET helper returns mentorship/community taggable users by username."""
+        self._auth_author()
+        url = f"/api/profiles/tags/{self.community.id}/taggable-users/"
+
+        response = self.api_client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        usernames = [item["username"] for item in response.data["results"]]
+        self.assertIn(self.mentorship_profile.username, usernames)
+        self.assertIn(self.community_only_profile.username, usernames)
+        self.assertNotIn(self.author_profile.username, usernames)
+        self.assertNotIn(self.unrelated_profile.username, usernames)
+
+    def test_list_taggable_users_helper_requires_membership(self) -> None:
+        """GET helper returns 403 when requester is not a community member."""
+        outsider_user = User.objects.create_user(
+            email="outsider@example.com",
+            password="SecurePass123",
+            app_usage_mode=AppUsageMode.MENTEE,
+        )
+        outsider_profile = Profile.objects.create(
+            user=outsider_user,
+            username="outsider_user",
+            display_name="Outsider",
+        )
+        outsider_token = str(RefreshToken.for_user(outsider_user).access_token)
+
+        # Ensure outsider is not a member but can still be connected to exercise auth path.
+        self.assertFalse(
+            CommunityTagMembership.objects.filter(
+                profile=outsider_profile, tag=self.community
+            ).exists()
+        )
+
+        self.api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {outsider_token}")
+        url = f"/api/profiles/tags/{self.community.id}/taggable-users/"
+        response = self.api_client.get(url)
+
+        self.assertEqual(response.status_code, 403)
+
     def test_tagged_users_mentorship_direction_bidirectional(self) -> None:
         """Mentee can also tag their mentor (bidirectional)."""
         from profiles.services import validate_tagged_users_list

--- a/backend/profiles/tests.py
+++ b/backend/profiles/tests.py
@@ -4968,13 +4968,11 @@ class CoPTaggingTests(TestCase):
 
     def test_validate_tagged_users_accepts_community_member(self) -> None:
         """Community members (not mentorship connection) can be tagged."""
-        from django.core.exceptions import ValidationError as DjangoValidationError
-
         from profiles.services import validate_tagged_users_list
 
         result = validate_tagged_users_list(
             author=self.author_profile,
-            tagged_user_ids=[str(self.community_only_profile.id)],
+            tagged_usernames=[self.community_only_profile.username],
             community_id=str(self.community.id),
         )
         self.assertEqual(len(result), 1)
@@ -4987,7 +4985,7 @@ class CoPTaggingTests(TestCase):
 
         result = validate_tagged_users_list(
             author=self.author_profile,
-            tagged_user_ids=[str(self.mentorship_profile.id)],
+            tagged_usernames=[self.mentorship_profile.username],
             community_id=str(self.community.id),
         )
         self.assertEqual(len(result), 1)
@@ -5002,7 +5000,7 @@ class CoPTaggingTests(TestCase):
         with self.assertRaises(DjangoValidationError):
             validate_tagged_users_list(
                 author=self.author_profile,
-                tagged_user_ids=[str(self.author_profile.id)],
+                tagged_usernames=[self.author_profile.username],
                 community_id=str(self.community.id),
             )
 
@@ -5015,7 +5013,7 @@ class CoPTaggingTests(TestCase):
         with self.assertRaises(DjangoValidationError):
             validate_tagged_users_list(
                 author=self.author_profile,
-                tagged_user_ids=[str(self.unrelated_profile.id)],
+                tagged_usernames=[self.unrelated_profile.username],
                 community_id=str(self.community.id),
             )
 
@@ -5040,11 +5038,11 @@ class CoPTaggingTests(TestCase):
             extra_profiles.append(p)
 
         # Try to tag 6 users (exceeds default limit of 5)
-        user_ids = [str(p.id) for p in extra_profiles]
+        usernames = [p.username for p in extra_profiles]
         with self.assertRaises(DjangoValidationError):
             validate_tagged_users_list(
                 author=self.author_profile,
-                tagged_user_ids=user_ids,
+                tagged_usernames=usernames,
                 community_id=str(self.community.id),
             )
 
@@ -5058,10 +5056,10 @@ class CoPTaggingTests(TestCase):
         with self.assertRaises(DjangoValidationError):
             validate_tagged_users_list(
                 author=self.author_profile,
-                tagged_user_ids=[
-                    str(self.community_only_profile.id),
-                    str(self.mentorship_profile.id),
-                    str(self.author_profile.id),  # 3 users, exceeds limit of 2
+                tagged_usernames=[
+                    self.community_only_profile.username,
+                    self.mentorship_profile.username,
+                    self.author_profile.username,  # 3 users, exceeds limit of 2
                 ],
                 community_id=str(self.community.id),
             )
@@ -5073,7 +5071,7 @@ class CoPTaggingTests(TestCase):
             community_tag=self.community,
             event_type="social",
             content="Hello with tags",
-            tagged_users=[str(self.community_only_profile.id)],
+            tagged_users=[self.community_only_profile.username],
         )
 
         self.assertIn("tagged_users", event.payload)
@@ -5090,7 +5088,7 @@ class CoPTaggingTests(TestCase):
             community_tag=self.community,
             event_type="social",
             content="Post with snapshot test",
-            tagged_users=[str(self.community_only_profile.id)],
+            tagged_users=[self.community_only_profile.username],
         )
 
         # Simulate username change after tagging
@@ -5121,13 +5119,13 @@ class CoPTaggingTests(TestCase):
             community_tag=self.community,
             event_type="social",
             content="Original",
-            tagged_users=[str(self.mentorship_profile.id)],
+            tagged_users=[self.mentorship_profile.username],
         )
 
         updated = edit_cop_event(
             event=event,
             content="Updated",
-            tagged_users=[str(self.community_only_profile.id)],
+            tagged_users=[self.community_only_profile.username],
         )
 
         tagged_ids = [t["user_id"] for t in updated.payload["tagged_users"]]
@@ -5145,7 +5143,7 @@ class CoPTaggingTests(TestCase):
             community_tag=self.community,
             event_type="social",
             content="Original",
-            tagged_users=[str(self.mentorship_profile.id)],
+            tagged_users=[self.mentorship_profile.username],
         )
 
         # Remove mentorship_profile from community so only mentorship link is relevant
@@ -5161,7 +5159,7 @@ class CoPTaggingTests(TestCase):
         updated = edit_cop_event(
             event=event,
             content="Edited - kept previously-tagged user",
-            tagged_users=[str(self.mentorship_profile.id)],
+            tagged_users=[self.mentorship_profile.username],
         )
 
         tagged_ids = [t["user_id"] for t in updated.payload["tagged_users"]]
@@ -5180,7 +5178,7 @@ class CoPTaggingTests(TestCase):
             community_tag=self.community,
             event_type="social",
             content="Original",
-            tagged_users=[str(self.mentorship_profile.id)],
+            tagged_users=[self.mentorship_profile.username],
         )
 
         # Remove mentorship_profile from community
@@ -5195,7 +5193,7 @@ class CoPTaggingTests(TestCase):
         updated = edit_cop_event(
             event=event,
             content="Edited - only community_only tagged",
-            tagged_users=[str(self.community_only_profile.id)],
+            tagged_users=[self.community_only_profile.username],
         )
 
         # Only community_only_profile should be tagged; mentorship_profile was omitted
@@ -5215,7 +5213,7 @@ class CoPTaggingTests(TestCase):
             community_tag=self.community,
             event_type="social",
             content="Original",
-            tagged_users=[str(self.mentorship_profile.id)],
+            tagged_users=[self.mentorship_profile.username],
         )
 
         # Remove mentorship_profile from community and deactivate match
@@ -5238,7 +5236,7 @@ class CoPTaggingTests(TestCase):
             edit_cop_event(
                 event=event,
                 content="Re-add attempt",
-                tagged_users=[str(self.mentorship_profile.id)],
+                tagged_users=[self.mentorship_profile.username],
             )
 
     def test_edit_allows_removing_tag(self) -> None:
@@ -5250,7 +5248,7 @@ class CoPTaggingTests(TestCase):
             community_tag=self.community,
             event_type="social",
             content="Original",
-            tagged_users=[str(self.mentorship_profile.id)],
+            tagged_users=[self.mentorship_profile.username],
         )
 
         # Remove the tag by passing an empty list
@@ -5272,7 +5270,7 @@ class CoPTaggingTests(TestCase):
             {
                 "event_type": "social",
                 "content": "API post with tags",
-                "tagged_users": [str(self.community_only_profile.id)],
+                "tagged_users": [self.community_only_profile.username],
             },
             format="json",
         )
@@ -5292,7 +5290,7 @@ class CoPTaggingTests(TestCase):
             {
                 "event_type": "social",
                 "content": "Bad tags",
-                "tagged_users": [str(self.unrelated_profile.id)],
+                "tagged_users": [self.unrelated_profile.username],
             },
             format="json",
         )
@@ -5307,7 +5305,7 @@ class CoPTaggingTests(TestCase):
             {
                 "event_type": "social",
                 "content": "Self tag",
-                "tagged_users": [str(self.author_profile.id)],
+                "tagged_users": [self.author_profile.username],
             },
             format="json",
         )
@@ -5321,7 +5319,7 @@ class CoPTaggingTests(TestCase):
             community_tag=self.community,
             event_type="social",
             content="Listed post with tags",
-            tagged_users=[str(self.community_only_profile.id)],
+            tagged_users=[self.community_only_profile.username],
         )
 
         self._auth_author()
@@ -5345,7 +5343,7 @@ class CoPTaggingTests(TestCase):
             community_tag=self.community,
             event_type="social",
             content="Original with tags",
-            tagged_users=[str(self.mentorship_profile.id)],
+            tagged_users=[self.mentorship_profile.username],
         )
 
         self._auth_author()
@@ -5353,7 +5351,7 @@ class CoPTaggingTests(TestCase):
             self._detail_url(str(event.id)),
             {
                 "content": "Updated with different tags",
-                "tagged_users": [str(self.community_only_profile.id)],
+                "tagged_users": [self.community_only_profile.username],
             },
             format="json",
         )
@@ -5371,7 +5369,7 @@ class CoPTaggingTests(TestCase):
         # Let's validate as mentee tagging the mentor
         result = validate_tagged_users_list(
             author=self.mentorship_profile,
-            tagged_user_ids=[str(self.author_profile.id)],
+            tagged_usernames=[self.author_profile.username],
             community_id=str(self.community.id),
         )
         self.assertEqual(len(result), 1)

--- a/backend/profiles/urls.py
+++ b/backend/profiles/urls.py
@@ -12,6 +12,7 @@ from .views import (
     CommunityTagMembersListAPIView,
     CommunityTagPostDetailAPIView,
     CommunityTagPostsListCreateAPIView,
+    CommunityTagTaggableUsersAPIView,
     MentorPublicAverageRatingAPIView,
     MyAvailabilitySlotDetailAPIView,
     MyAvailabilitySlotListCreateAPIView,
@@ -104,6 +105,11 @@ urlpatterns = [
         "tags/<str:tag_id>/members/",
         CommunityTagMembersListAPIView.as_view(),
         name="community-tag-members",
+    ),
+    path(
+        "tags/<uuid:tag_id>/taggable-users/",
+        CommunityTagTaggableUsersAPIView.as_view(),
+        name="community-tag-taggable-users",
     ),
     path(
         "tags/<uuid:tag_id>/posts/",

--- a/backend/profiles/views.py
+++ b/backend/profiles/views.py
@@ -54,6 +54,7 @@ from .serializers import (
     PublicMentorProfileSearchListResponseSerializer,
     PublicMentorProfileSearchResultSerializer,
     SkillSerializer,
+    TaggableUsersResponseSerializer,
     resolve_picture_url,
 )
 from .services import (
@@ -66,6 +67,7 @@ from .services import (
     create_prp_event,
     edit_cop_event,
     edit_prp_event,
+    get_taggable_users_for_community,
     list_community_feed_events,
     list_profile_feed_events,
     soft_delete_cop_event,
@@ -1654,7 +1656,7 @@ class CommunityTagPostsListCreateAPIView(ProfileLookupMixin, APIView):
                     "(1) invalid `event_type`; "
                     "(2) `tagged_users` contains more than `COP_MAX_TAGS` (default 5) entries; "
                     "(3) author attempted to tag themselves; "
-                    "(4) a tagged user ID is not a current mentorship connection "
+                    "(4) a tagged username is not a current mentorship connection "
                     "or member of this community."
                 )
             ),
@@ -1717,6 +1719,72 @@ class CommunityTagPostsListCreateAPIView(ProfileLookupMixin, APIView):
 
         event.author = profile
         return Response(CommunityPostSerializer(event).data, status=status.HTTP_201_CREATED)
+
+
+class CommunityTagTaggableUsersAPIView(ProfileLookupMixin, APIView):
+    """List taggable users for authenticated author within a community."""
+
+    permission_classes = [IsUser]
+
+    @extend_schema(
+        operation_id="community_tag_taggable_users_list",
+        responses={
+            200: TaggableUsersResponseSerializer,
+            401: OpenApiResponse(description="Authentication required."),
+            403: OpenApiResponse(description="Not a member of this community."),
+            404: OpenApiResponse(description="Community tag not found."),
+        },
+        description=(
+            "Return users the authenticated author can tag in CoP posts for this community. "
+            "Includes active mentorship connections (bidirectional) and community members. "
+            "The requester is excluded from results. Use `username` values from this response "
+            "when sending `tagged_users` in CoP create/update payloads."
+        ),
+        tags=["Community Tags"],
+    )
+    def get(self, request: Request, tag_id: str) -> Response:
+        """Return taggable users for the requester in a given community."""
+        tag = CommunityTag.objects.filter(id=tag_id).first()
+        if tag is None:
+            return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
+
+        profile = self._get_request_profile_or_404(request)
+        if profile is None:
+            return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
+
+        is_member = CommunityTagMembership.objects.filter(profile=profile, tag=tag).exists()
+        if not is_member:
+            return Response(
+                {"detail": "You must be a member of this community to view taggable users."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        try:
+            taggable_profiles = (
+                get_taggable_users_for_community(profile, str(tag.id))
+                .only("username", "display_name")
+                .order_by("username")
+            )
+        except ValidationError as exc:
+            detail = str(exc.message) if hasattr(exc, "message") else str(exc)
+            return Response({"detail": detail}, status=status.HTTP_404_NOT_FOUND)
+
+        results = [
+            {
+                "username": taggable_profile.username,
+                "display_name": taggable_profile.display_name,
+            }
+            for taggable_profile in taggable_profiles
+        ]
+        return Response(
+            TaggableUsersResponseSerializer(
+                {
+                    "count": len(results),
+                    "results": results,
+                }
+            ).data,
+            status=status.HTTP_200_OK,
+        )
 
 
 class CommunityTagPostDetailAPIView(ProfileLookupMixin, APIView):

--- a/backend/profiles/views.py
+++ b/backend/profiles/views.py
@@ -277,9 +277,11 @@ class ProfilePostsListAPIView(ProfileLookupMixin, APIView):
             "Supports optional filtering by `category` and `event_type`. "
             "Results are ordered newest-first by action metadata: `created_at`, then "
             "`last_edited` as a tie-breaker. "
-            "For CoP posts, `community_id` and `community_name` are returned; "
+            "For CoP posts, `community_id`, `community_name`, and `tagged_users` are returned; "
             "`community_name` is resolved from the live community and falls back to the "
             "snapshotted payload value if the community has been deleted. "
+            "`tagged_users` is a list of `{user_id, username}` objects; usernames are snapshots "
+            "captured at tag-time and fall back to the stored snapshot if a user was deleted. "
             "For MCTE posts, `mentorship_partner` is resolved from the active mentorship "
             "relation and is `null` for PrP and CoP. Deleting a mentorship cascades to "
             "its timeline events, so deleted mentorship events are not included in this feed."
@@ -1617,7 +1619,9 @@ class CommunityTagPostsListCreateAPIView(ProfileLookupMixin, APIView):
         description=(
             "List community posts for a tag, ordered newest-first. "
             "Authenticated users can view all non-deleted posts. "
-            "Supports filtering by `event_type`. Pagination via `offset` and `limit`."
+            "Supports filtering by `event_type`. Pagination via `offset` and `limit`. "
+            "Each post includes a `tagged_users` array with `user_id` and `username` "
+            "for any users tagged in that post."
         ),
         tags=["Community Tags"],
     )
@@ -1644,7 +1648,16 @@ class CommunityTagPostsListCreateAPIView(ProfileLookupMixin, APIView):
         request=CoPCreateSerializer,
         responses={
             201: CommunityPostSerializer,
-            400: OpenApiResponse(description="Validation error."),
+            400: OpenApiResponse(
+                description=(
+                    "Validation error. Possible causes: "
+                    "(1) invalid `event_type`; "
+                    "(2) `tagged_users` contains more than `COP_MAX_TAGS` (default 5) entries; "
+                    "(3) author attempted to tag themselves; "
+                    "(4) a tagged user ID is not a current mentorship connection "
+                    "or member of this community."
+                )
+            ),
             401: OpenApiResponse(description="Authentication required."),
             403: OpenApiResponse(description="Not a member of this community."),
             404: OpenApiResponse(description="Community tag not found."),
@@ -1653,7 +1666,14 @@ class CommunityTagPostsListCreateAPIView(ProfileLookupMixin, APIView):
             "Create a community post (CoP) in a tag. Requester must be a member. "
             "`show_on_profile` defaults to `false`; set to `true` to also display "
             "this post on the author's profile feed. "
-            "`timestamp` is optional; defaults to creation time."
+            "`timestamp` is optional; defaults to creation time. "
+            "\n\n"
+            "**User Tagging** — optional `tagged_users` field accepts a list of profile UUIDs "
+            "(up to `COP_MAX_TAGS`, currently 5). Only the author's active mentorship connections "
+            "(bidirectional) and members of this community may be tagged. "
+            "The author may not tag themselves. "
+            "The response includes a `tagged_users` array with `user_id` and `username` for "
+            "each tagged user (username captured as a snapshot at creation time)."
         ),
         tags=["Community Tags"],
     )
@@ -1692,7 +1712,8 @@ class CommunityTagPostsListCreateAPIView(ProfileLookupMixin, APIView):
         except InvalidCoPEventTypeError as exc:
             return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
         except ValidationError as exc:
-            return Response({"detail": str(exc.message) if hasattr(exc, "message") else str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+            detail = str(exc.message) if hasattr(exc, "message") else str(exc)
+            return Response({"detail": detail}, status=status.HTTP_400_BAD_REQUEST)
 
         event.author = profile
         return Response(CommunityPostSerializer(event).data, status=status.HTTP_201_CREATED)
@@ -1729,13 +1750,35 @@ class CommunityTagPostDetailAPIView(ProfileLookupMixin, APIView):
         request=CoPUpdateSerializer,
         responses={
             200: CommunityPostSerializer,
-            400: OpenApiResponse(description="Validation error."),
+            400: OpenApiResponse(
+                description=(
+                    "Validation error. Possible causes: "
+                    "(1) no editable field provided; "
+                    "(2) invalid `event_type`; "
+                    "(3) `tagged_users` contains more than `COP_MAX_TAGS` (default 5) entries; "
+                    "(4) author attempted to tag themselves; "
+                    "(5) a newly added tagged user is not a current mentorship connection "
+                    "or member of this community."
+                )
+            ),
             401: OpenApiResponse(description="Authentication required."),
             404: OpenApiResponse(description="Post not found."),
         },
         description=(
             "Partially update a community post. Only the original author can edit. "
-            "Editable fields: `content`, `event_type`, `media_url`, `show_on_profile`."
+            "Editable fields: `content`, `event_type`, `media_url`, `show_on_profile`, "
+            "`tagged_users`. "
+            "\n\n"
+            "**Updating Tags** — when `tagged_users` is provided it replaces the current "
+            "tag list subject to the following rules:\n"
+            "- Users newly added to the list must be a current mentorship connection "
+            "(bidirectional) or a current member of this community.\n"
+            "- Previously tagged users who are still included in the new list are accepted "
+            "even if their connection/membership has since lapsed (e.g., mentorship "
+            "deactivated, user left the community).\n"
+            "- Omitting a user from the new list removes their tag. Once removed, an "
+            "untaggable user cannot be re-added.\n"
+            "- Omitting `tagged_users` entirely leaves existing tags unchanged."
         ),
         tags=["Community Tags"],
     )
@@ -1763,7 +1806,8 @@ class CommunityTagPostDetailAPIView(ProfileLookupMixin, APIView):
         except InvalidCoPEventTypeError as exc:
             return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
         except ValidationError as exc:
-            return Response({"detail": str(exc.message) if hasattr(exc, "message") else str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+            detail = str(exc.message) if hasattr(exc, "message") else str(exc)
+            return Response({"detail": detail}, status=status.HTTP_400_BAD_REQUEST)
 
         return Response(CommunityPostSerializer(updated_event).data, status=status.HTTP_200_OK)
 

--- a/backend/profiles/views.py
+++ b/backend/profiles/views.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.contrib.gis.db.models.functions import Distance
 from django.contrib.gis.geos import Point
 from django.contrib.gis.measure import D
+from django.core.exceptions import ValidationError
 from django.db import IntegrityError, models, transaction
 from django.db.models import Count, Q
 from django.db.models.deletion import ProtectedError
@@ -1686,9 +1687,12 @@ class CommunityTagPostsListCreateAPIView(ProfileLookupMixin, APIView):
                 media_url=validated.get("media_url"),
                 show_on_profile=validated.get("show_on_profile", False),
                 timestamp=validated.get("timestamp"),
+                tagged_users=validated.get("tagged_users"),
             )
         except InvalidCoPEventTypeError as exc:
             return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        except ValidationError as exc:
+            return Response({"detail": str(exc.message) if hasattr(exc, "message") else str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
         event.author = profile
         return Response(CommunityPostSerializer(event).data, status=status.HTTP_201_CREATED)
@@ -1754,9 +1758,12 @@ class CommunityTagPostDetailAPIView(ProfileLookupMixin, APIView):
                 media_url=validated.get("media_url"),
                 show_on_profile=validated.get("show_on_profile"),
                 update_media_url="media_url" in validated,
+                tagged_users=validated.get("tagged_users"),
             )
         except InvalidCoPEventTypeError as exc:
             return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        except ValidationError as exc:
+            return Response({"detail": str(exc.message) if hasattr(exc, "message") else str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
         return Response(CommunityPostSerializer(updated_event).data, status=status.HTTP_200_OK)
 

--- a/backend/profiles/views.py
+++ b/backend/profiles/views.py
@@ -1668,7 +1668,7 @@ class CommunityTagPostsListCreateAPIView(ProfileLookupMixin, APIView):
             "this post on the author's profile feed. "
             "`timestamp` is optional; defaults to creation time. "
             "\n\n"
-            "**User Tagging** — optional `tagged_users` field accepts a list of profile UUIDs "
+            "**User Tagging** — optional `tagged_users` field accepts a list of usernames "
             "(up to `COP_MAX_TAGS`, currently 5). Only the author's active mentorship connections "
             "(bidirectional) and members of this community may be tagged. "
             "The author may not tag themselves. "


### PR DESCRIPTION
## Related Issue

Closes #531 

## Description

This PR implements CoP tagging with username-based input.

Added configurable global max count limit in settings.py.

### `POST /api/profiles/tags/{tag_id}/posts/`
  - tagged_users is optional.
  - tagged_users is a list of usernames.
  - requester must be community member.
  - cannot tag self.
  - usernames must be in active mentorship connections or community members.
  - must not exceed COP_MAX_TAGS.

### `PATCH /api/profiles/tags/{tag_id}/posts/{event_id}/`
  - tagged_users, when provided, replaces current tag list
  - omission of tagged_users means keep current tags unchanged
  - newly added usernames must be currently taggable
  - previously tagged but now untaggable users may remain if still included
  - removing a previously tagged untaggable user prevents re-adding unless taggable again

### `GET /api/profiles/tags/{tag_id}/posts/`
- Returns CoP feed items including tagged_users entries with user_id and username.


### `GET /api/profiles/{username}/posts/`
- For CoP entries shown on profile, returns community_id, community_name, and tagged_users.

New endpoint:
### `GET /api/profiles/tags/{tag_id}/taggable-users/`
- Purpose:
  - fetch all users the requester can tag in that community
  - intended for autocomplete/suggestions before create/edit
- Access:
  - authenticated user
  - requester must be a member of that community
- Response shape:
  - count
  - results array of username and display_name
- Logic:
  - union of active mentorship connections (bidirectional) and community members
  - requester excluded

1. Input contract is username-first for tagging.
2. Output contract still includes both user_id and username for tagged users.
3. Username snapshots are preserved in payload to survive user deletion/name changes gracefully (currently unneeded).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or configuration

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code

## Notes

(Any additional information or considerations.)
