### PR TITLE
test: AT-008 feedback and reviews e2e test coverage

### DIFF
--- a/backend/mentorship/services.py
+++ b/backend/mentorship/services.py
@@ -717,7 +717,9 @@ def delete_match_feedback(*, feedback: Feedback) -> None:
 
     # Determine whether this feedback was already in a visible threshold batch.
     mentee_feedback_ids = list(
-        Feedback.objects.filter(match__mentor=mentor).exclude(submitted_by=mentor).order_by("id")
+        Feedback.objects.filter(match__mentor=mentor)
+        .exclude(submitted_by=mentor)
+        .order_by("created_at", "id")
     )
     visible_limit = (mentor.review_count // threshold) * threshold
     feedback_index = next(

--- a/backend/profiles/views.py
+++ b/backend/profiles/views.py
@@ -1213,7 +1213,7 @@ class ProfileReviewsByUsernameAPIView(ProfileLookupMixin, APIView):
             Feedback.objects.filter(match__mentor=profile)
             .exclude(submitted_by=profile)
             .exclude(text="")
-            .order_by("id")
+            .order_by("created_at", "id")
         )
 
         total = min(feedback_qs.count(), allowed_reviews_count)

--- a/web/e2e/api/TestDataApi.ts
+++ b/web/e2e/api/TestDataApi.ts
@@ -76,6 +76,38 @@ export type Notification = {
   is_read?: boolean;
 };
 
+export type Feedback = {
+  id: string;
+  match: string;
+  submitted_by: {
+    id: string;
+    username: string;
+    display_name: string;
+  };
+  rating: number;
+  text: string;
+  created_at: string;
+};
+
+export type MentorRating = {
+  username: string;
+  average_rating: string;
+  review_count: number;
+};
+
+export type PublicReview = {
+  rating: number;
+  text: string;
+  created_at: string;
+};
+
+export type PublicReviewsResponse = {
+  count: number;
+  page: number;
+  pageSize: number;
+  results: PublicReview[];
+};
+
 export class TestDataApi {
   readonly request: APIRequestContext;
 
@@ -212,6 +244,55 @@ export class TestDataApi {
     });
     expect(response.ok()).toBeTruthy();
     return response.json() as Promise<Notification[]>;
+  }
+
+  async fetchMatchFeedback(auth: AuthResponse, matchId: string) {
+    const response = await this.request.get(`${API_BASE_URL}/mentorship/matches/${matchId}/feedback/`, {
+      headers: this.authHeaders(auth),
+    });
+    expect(response.ok()).toBeTruthy();
+    return response.json() as Promise<Feedback[]>;
+  }
+
+  async submitMatchFeedback(
+    auth: AuthResponse,
+    matchId: string,
+    data: { rating: number; text?: string },
+  ) {
+    const response = await this.trySubmitMatchFeedback(auth, matchId, data);
+    expect(response.ok()).toBeTruthy();
+    return response.json() as Promise<Feedback>;
+  }
+
+  async trySubmitMatchFeedback(
+    auth: AuthResponse,
+    matchId: string,
+    data: { rating: number; text?: string },
+  ) {
+    return this.request.post(`${API_BASE_URL}/mentorship/matches/${matchId}/feedback/`, {
+      headers: this.authHeaders(auth),
+      data,
+    });
+  }
+
+  async tryFetchMatchFeedback(auth: AuthResponse, matchId: string) {
+    return this.request.get(`${API_BASE_URL}/mentorship/matches/${matchId}/feedback/`, {
+      headers: this.authHeaders(auth),
+    });
+  }
+
+  async fetchMentorRating(mentorUsername: string) {
+    const response = await this.request.get(`${API_BASE_URL}/profiles/${mentorUsername}/rating/`);
+    expect(response.ok()).toBeTruthy();
+    return response.json() as Promise<MentorRating>;
+  }
+
+  async fetchMentorReviews(mentorUsername: string, page = 1, pageSize = 10) {
+    const response = await this.request.get(
+      `${API_BASE_URL}/profiles/${mentorUsername}/reviews/?page=${page}&pageSize=${pageSize}`,
+    );
+    expect(response.ok()).toBeTruthy();
+    return response.json() as Promise<PublicReviewsResponse>;
   }
 
   private async registerOrLogin(email: string): Promise<AuthResponse> {

--- a/web/e2e/pages/DashboardPage.ts
+++ b/web/e2e/pages/DashboardPage.ts
@@ -52,6 +52,42 @@ export class DashboardPage {
     await expect(this.page.getByText(`Session with ${peerName}`).first()).toBeVisible();
   }
 
+  async expectRateMentorCard(mentorName: string) {
+    await expect(this.page.getByRole('heading', { name: 'Rate Your Mentors' })).toBeVisible();
+    const ratingCard = this.findRatingCard(mentorName);
+    await expect(ratingCard).toBeVisible();
+    await expect(ratingCard.getByRole('button', { name: /^Rate$/i })).toBeVisible();
+  }
+
+  async openRatingModal(mentorName: string) {
+    const ratingCard = this.findRatingCard(mentorName);
+    await expect(ratingCard).toBeVisible();
+    await ratingCard.getByRole('button', { name: /^Rate$/i }).click();
+    await expect(this.page.getByRole('dialog')).toBeVisible();
+    await expect(this.page.getByRole('heading', { name: `Rate your session with ${mentorName}` })).toBeVisible();
+  }
+
+  async expectRatingSubmitDisabled() {
+    await expect(this.page.getByRole('button', { name: 'Submit Rating' })).toBeDisabled();
+  }
+
+  async selectRating(stars: number, expectedLabel: string) {
+    await this.page.getByRole('button', { name: `Rate ${stars} stars` }).click();
+    await expect(this.page.getByText(expectedLabel)).toBeVisible();
+    await expect(this.page.getByRole('button', { name: 'Submit Rating' })).toBeEnabled();
+  }
+
+  async submitRating(reviewText: string) {
+    await this.page.getByPlaceholder('Share your experience with this mentor...').fill(reviewText);
+    await this.page.getByRole('button', { name: 'Submit Rating' }).click();
+    await expect(this.page.getByText('Rating submitted!').first()).toBeVisible();
+    await expect(this.page.getByRole('dialog')).toHaveCount(0);
+  }
+
+  async expectMentorNotPendingRating(mentorName: string) {
+    await expect(this.findRatingCard(mentorName)).toHaveCount(0);
+  }
+
   async openSessionManager(peerName: string) {
     const sessionCard = this.page.locator('.island-shell', {
       has: this.page.getByText(`Session with ${peerName}`),
@@ -96,5 +132,13 @@ export class DashboardPage {
       await expect(requestCard.getByText(coverLetter)).toBeVisible();
     }
     return requestCard;
+  }
+
+  private findRatingCard(mentorName: string) {
+    return this.page.locator('.island-shell', {
+      has: this.page.getByText(mentorName),
+    }).filter({
+      has: this.page.getByRole('button', { name: /^Rate$/i }),
+    }).first();
   }
 }

--- a/web/e2e/pages/ProfilePage.ts
+++ b/web/e2e/pages/ProfilePage.ts
@@ -55,6 +55,16 @@ export class ProfilePage {
     await expect(this.page.getByText('Requested')).toBeVisible();
   }
 
+  async expectAverageRating(rating: string | RegExp) {
+    await expect(this.page.getByText('Average Rating')).toBeVisible();
+    await expect(this.page.getByText(rating).first()).toBeVisible();
+  }
+
+  async expectPublicReview(reviewText: string) {
+    await expect(this.page.getByText('Reviews')).toBeVisible();
+    await expect(this.page.getByText(reviewText)).toBeVisible();
+  }
+
   private async clickAvailabilityCell(dayIndexFromMonday: number, hour: number) {
     const hourIndex = hour - 8;
     const cellIndex = 8 + hourIndex * 8 + 1 + dayIndexFromMonday;

--- a/web/e2e/tests/AT-008-feedback-and-reviews.spec.ts
+++ b/web/e2e/tests/AT-008-feedback-and-reviews.spec.ts
@@ -1,0 +1,230 @@
+import { expect, test, type APIResponse } from '@playwright/test';
+import { TestDataApi, type AuthResponse, type UserSeed } from '../api/TestDataApi';
+import { DashboardPage } from '../pages/DashboardPage';
+import { ProfilePage } from '../pages/ProfilePage';
+
+const REVIEW_THRESHOLD = Math.max(1, Number(process.env.RATING_UPDATE_THRESHOLD ?? 5));
+const REVIEW_SAMPLES = [
+  { label: 'batch_a', rating: 5, text: 'Excellent guidance on practical backend tradeoffs.' },
+  { label: 'batch_b', rating: 4, text: 'Helpful examples and steady pacing.' },
+  { label: 'batch_c', rating: 5, text: 'Strong explanations and actionable next steps.' },
+  { label: 'batch_d', rating: 4, text: 'Useful session with concrete testing advice.' },
+  { label: 'batch_e', rating: 5, text: 'Focused review with clear improvement suggestions.' },
+  { label: 'batch_f', rating: 4, text: 'Good structure and practical follow-up material.' },
+];
+
+function toDateString(date: Date) {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}
+
+function hourLabel(hour: number) {
+  return `${String(hour).padStart(2, '0')}:00:00`;
+}
+
+function makeMentee(runId: number, label: string): UserSeed {
+  return {
+    email: `rating.${label}.${runId}@example.com`,
+    username: `rating_${label}_${runId}`,
+    displayName: `Rating ${label} ${runId}`,
+    title: 'Computer Science Mentee',
+    bio: 'Learning through structured mentorship sessions and mentor feedback.',
+    skills: ['Python/Django', 'Testing'],
+  };
+}
+
+async function expectForbidden(response: APIResponse) {
+  expect(response.status()).toBe(403);
+}
+
+test.describe('AT-008: Feedback & Reviews', () => {
+  test('mentee rates an accepted mentor, feedback is protected, and public ratings update at threshold', async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(150_000);
+
+    const runId = Date.now();
+    const api = new TestDataApi(request);
+    const mentor: UserSeed = {
+      email: `rating.mentor.${runId}@example.com`,
+      username: `rating_mentor_${runId}`,
+      displayName: `Rating Mentor ${runId}`,
+      title: 'Python Mentorship Lead',
+      bio: 'Helps mentees improve backend systems through clear examples and practical review.',
+      skills: ['Python/Django', 'System Design', 'Testing'],
+    };
+    const primaryMentee = makeMentee(runId, 'primary');
+    const unrelatedMentee = makeMentee(runId, 'unrelated');
+    const visibleReviewText = 'Clear explanations and useful examples.';
+    const thresholdReviews = REVIEW_SAMPLES.slice(0, REVIEW_THRESHOLD - 1);
+    const thresholdRatings = [4, ...thresholdReviews.map((review) => review.rating)];
+    const expectedPublicAverage = (
+      thresholdRatings.reduce((total, rating) => total + rating, 0) / thresholdRatings.length
+    ).toFixed(2);
+    const expectedProfileAverage = Number(expectedPublicAverage).toFixed(1);
+
+    const mentorAuth = await api.seedUser(mentor, 'MENTOR');
+    const primaryMenteeAuth = await api.seedUser(primaryMentee, 'MENTEE');
+    const unrelatedMenteeAuth = await api.seedUser(unrelatedMentee, 'MENTEE');
+
+    let slotOffset = 1;
+    async function createAcceptedMatch(menteeAuth: AuthResponse, mentee: UserSeed) {
+      const slotDate = toDateString(new Date(Date.now() + slotOffset * 24 * 60 * 60 * 1000));
+      const slot = await api.createAvailabilitySlot(mentorAuth, {
+        date: slotDate,
+        startTime: hourLabel(9 + (slotOffset % 7)),
+        endTime: hourLabel(10 + (slotOffset % 7)),
+      });
+      slotOffset += 1;
+
+      const mentorshipRequest = await api.sendMentorshipRequest(menteeAuth, {
+        mentor_username: mentor.username,
+        slot_id: slot.id,
+        cover_letter: `I would like to review Python mentorship goals for ${mentee.displayName}.`,
+      });
+      await api.respondToRequest(mentorAuth, mentorshipRequest.id, 'accept');
+
+      const matches = await api.fetchMyMatches(menteeAuth);
+      const match = matches.find((item) => (
+        item.mentor.username === mentor.username
+        && item.mentee.username === mentee.username
+        && item.is_active
+      ));
+      expect(match).toBeTruthy();
+      return match!;
+    }
+
+    const primaryMatch = await createAcceptedMatch(primaryMenteeAuth, primaryMentee);
+
+    await test.step('Public rating and public reviews are empty before feedback is submitted', async () => {
+      const rating = await api.fetchMentorRating(mentor.username);
+      expect(rating.review_count).toBe(0);
+      expect(rating.average_rating).toBe('0.00');
+
+      const reviews = await api.fetchMentorReviews(mentor.username);
+      expect(reviews.count).toBe(0);
+      expect(reviews.results).toHaveLength(0);
+    });
+
+    await test.step('Mentee submits mentor rating from the Dashboard', async () => {
+      const dashboardPage = new DashboardPage(page);
+
+      await api.loginInBrowser(page, primaryMenteeAuth);
+      await dashboardPage.expectRateMentorCard(mentor.displayName);
+      await dashboardPage.openRatingModal(mentor.displayName);
+      await dashboardPage.expectRatingSubmitDisabled();
+      await dashboardPage.selectRating(4, 'Very good');
+      await dashboardPage.submitRating(visibleReviewText);
+      await dashboardPage.expectMentorNotPendingRating(mentor.displayName);
+
+      const feedback = await api.fetchMatchFeedback(primaryMenteeAuth, primaryMatch.id);
+      expect(feedback).toHaveLength(1);
+      expect(feedback[0]).toMatchObject({
+        match: primaryMatch.id,
+        rating: 4,
+        text: visibleReviewText,
+      });
+      expect(feedback[0].submitted_by.username).toBe(primaryMentee.username);
+      expect(Number.isNaN(Date.parse(feedback[0].created_at))).toBeFalsy();
+    });
+
+    await test.step('Duplicate feedback, invalid ratings, and unrelated access are rejected', async () => {
+      const duplicate = await api.trySubmitMatchFeedback(primaryMenteeAuth, primaryMatch.id, {
+        rating: 5,
+        text: 'Trying to submit a duplicate review.',
+      });
+      expect(duplicate.status()).toBe(400);
+      await expect(duplicate.json()).resolves.toMatchObject({
+        detail: 'You have already submitted feedback for this match.',
+      });
+
+      await expectForbidden(await api.tryFetchMatchFeedback(unrelatedMenteeAuth, primaryMatch.id));
+      await expectForbidden(await api.trySubmitMatchFeedback(unrelatedMenteeAuth, primaryMatch.id, {
+        rating: 5,
+        text: 'Trying to rate a mentor through someone else\'s match.',
+      }));
+
+      const lowerBoundMentee = makeMentee(runId, 'lower_bound');
+      const upperBoundMentee = makeMentee(runId, 'upper_bound');
+      const lowerBoundAuth = await api.seedUser(lowerBoundMentee, 'MENTEE');
+      const upperBoundAuth = await api.seedUser(upperBoundMentee, 'MENTEE');
+      const lowerBoundMatch = await createAcceptedMatch(lowerBoundAuth, lowerBoundMentee);
+      const upperBoundMatch = await createAcceptedMatch(upperBoundAuth, upperBoundMentee);
+
+      const tooLow = await api.trySubmitMatchFeedback(lowerBoundAuth, lowerBoundMatch.id, {
+        rating: 0,
+        text: 'Invalid low rating.',
+      });
+      expect(tooLow.status()).toBe(400);
+
+      const tooHigh = await api.trySubmitMatchFeedback(upperBoundAuth, upperBoundMatch.id, {
+        rating: 6,
+        text: 'Invalid high rating.',
+      });
+      expect(tooHigh.status()).toBe(400);
+    });
+
+    await test.step('Mentor receives a feedback notification', async () => {
+      const notifications = await api.fetchNotifications(mentorAuth);
+      expect(notifications.some((item) => (
+        item.type === 'new_feedback_available'
+        && item.title === 'New Feedback Available'
+        && item.message === 'You received new feedback.'
+      ))).toBeTruthy();
+    });
+
+    await test.step('Public rating and reviews update when the threshold batch is completed', async () => {
+      for (const review of thresholdReviews) {
+        const mentee = makeMentee(runId, review.label);
+        const menteeAuth = await api.seedUser(mentee, 'MENTEE');
+        const match = await createAcceptedMatch(menteeAuth, mentee);
+        const feedback = await api.submitMatchFeedback(menteeAuth, match.id, {
+          rating: review.rating,
+          text: review.text,
+        });
+        expect(feedback.rating).toBe(review.rating);
+        expect(feedback.text).toBe(review.text);
+        expect(Number.isNaN(Date.parse(feedback.created_at))).toBeFalsy();
+      }
+
+      const rating = await api.fetchMentorRating(mentor.username);
+      expect(rating.review_count).toBe(REVIEW_THRESHOLD);
+      expect(rating.average_rating).toBe(expectedPublicAverage);
+
+      const reviews = await api.fetchMentorReviews(mentor.username);
+      expect(reviews.count).toBe(REVIEW_THRESHOLD);
+      expect(reviews.results.map((review) => review.text)).toEqual(
+        expect.arrayContaining([visibleReviewText, ...thresholdReviews.map((review) => review.text)]),
+      );
+      expect(reviews.results[0]).not.toHaveProperty('submitted_by');
+
+      const profilePage = new ProfilePage(page);
+      await profilePage.goto(mentor.username);
+      await profilePage.expectLoaded(mentor.username, mentor.displayName);
+      await profilePage.expectAverageRating(expectedProfileAverage);
+      await profilePage.expectPublicReview(visibleReviewText);
+    });
+
+    if (REVIEW_THRESHOLD > 1) {
+      await test.step('A partial batch after the threshold is not publicly visible yet', async () => {
+        const extraReviewText = 'This extra review should wait for the next public batch.';
+        const extraMentee = makeMentee(runId, 'extra_hidden');
+        const extraMenteeAuth = await api.seedUser(extraMentee, 'MENTEE');
+        const extraMatch = await createAcceptedMatch(extraMenteeAuth, extraMentee);
+
+        await api.submitMatchFeedback(extraMenteeAuth, extraMatch.id, {
+          rating: 5,
+          text: extraReviewText,
+        });
+
+        const rating = await api.fetchMentorRating(mentor.username);
+        expect(rating.review_count).toBe(REVIEW_THRESHOLD + 1);
+        expect(rating.average_rating).toBe(expectedPublicAverage);
+
+        const reviews = await api.fetchMentorReviews(mentor.username);
+        expect(reviews.count).toBe(REVIEW_THRESHOLD);
+        expect(reviews.results.map((review) => review.text)).not.toContain(extraReviewText);
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Related Issue

Closes #491 

## Description

Adds Playwright e2e coverage for AT-008 Feedback & Reviews. The test covers mentee mentor rating, duplicate and invalid feedback rejection, access control, mentor notifications, and public rating/review threshold behavior.

Also fixes public review threshold ordering so visible review batches are based on creation order instead of UUID order.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or configuration

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code

## Notes

Tested locally with:

`npm run test:e2e -- AT-008-feedback-and-reviews.spec.ts`
