### PR TITLE
Feat/web file upload

### DIFF
--- a/web/src/components/MediaUploadField.tsx
+++ b/web/src/components/MediaUploadField.tsx
@@ -1,0 +1,81 @@
+import { useUploadPostMedia } from '#/lib/queries/ProfilePostQueries.ts'
+import { Button } from '@/components/ui/button'
+import { Loader2, Paperclip, X } from 'lucide-react'
+import { useRef, useState } from 'react'
+
+interface MediaUploadFieldProps {
+    onUrl: (url: string | null) => void
+    currentUrl?: string | null
+}
+
+export function MediaUploadField({ onUrl, currentUrl }: MediaUploadFieldProps) {
+    const inputRef = useRef<HTMLInputElement>(null)
+    const upload = useUploadPostMedia()
+    const [preview, setPreview] = useState<{ name: string; objectUrl?: string } | null>(
+        currentUrl ? { name: currentUrl.split('/').pop() ?? 'media' } : null,
+    )
+
+    function handleFile(file: File) {
+        const isImage = file.type.startsWith('image/')
+        const objectUrl = isImage ? URL.createObjectURL(file) : undefined
+        setPreview({ name: file.name, objectUrl })
+        upload.mutate(file, {
+            onSuccess: (data) => {
+                onUrl(data.url)
+            },
+            onError: () => {
+                setPreview(null)
+                onUrl(null)
+            },
+        })
+    }
+
+    function handleClear() {
+        if (preview?.objectUrl) URL.revokeObjectURL(preview.objectUrl)
+        setPreview(null)
+        onUrl(null)
+        if (inputRef.current) inputRef.current.value = ''
+        upload.reset()
+    }
+
+    return (
+        <div className="flex flex-col gap-1.5">
+            <input
+                ref={inputRef}
+                type="file"
+                accept="image/*,application/pdf"
+                className="hidden"
+                onChange={(e) => {
+                    const file = e.target.files?.[0]
+                    if (file) handleFile(file)
+                }}
+            />
+            {preview ? (
+                <div className="flex items-center gap-2 rounded-lg border border-line bg-background px-3 py-2 text-sm">
+                    {preview.objectUrl && (
+                        <img src={preview.objectUrl} alt="" className="h-10 w-10 rounded object-cover shrink-0" />
+                    )}
+                    <span className="flex-1 truncate text-ink-soft">{preview.name}</span>
+                    {upload.isPending && <Loader2 className="h-4 w-4 animate-spin shrink-0 text-accent" />}
+                    <button type="button" onClick={handleClear} className="shrink-0 text-ink-soft hover:text-ink">
+                        <X className="h-4 w-4" />
+                    </button>
+                </div>
+            ) : (
+                <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="w-fit gap-1.5"
+                    onClick={() => inputRef.current?.click()}
+                >
+                    <Paperclip className="h-4 w-4" />
+                    Attach media
+                </Button>
+            )}
+            {upload.isError && (
+                <p className="text-xs text-red-500">Upload failed. Please try again.</p>
+            )}
+        </div>
+    )
+}

--- a/web/src/components/layout/AuthorizedHeader.tsx
+++ b/web/src/components/layout/AuthorizedHeader.tsx
@@ -105,9 +105,11 @@ export function AuthorizedHeader() {
                 to="/profiles/$username"
                 params={{ username: me?.username ?? '' }}
                 aria-label="Open profile page"
-                className="h-8 w-8 rounded-full bg-accent text-background flex items-center justify-center text-sm font-bold shadow-sm transition hover:brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+                className="h-8 w-8 rounded-full overflow-hidden bg-accent text-background flex items-center justify-center text-sm font-bold shadow-sm transition hover:brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
             >
-              {initials}
+              {profile?.picture_url
+                ? <img src={profile.picture_url} alt={initials} className="h-full w-full object-cover" />
+                : initials}
             </Link>
             <Button
                 variant="ghost"

--- a/web/src/components/profile/EditProfileModal.tsx
+++ b/web/src/components/profile/EditProfileModal.tsx
@@ -1,5 +1,5 @@
 import { meQueryOptions } from '#/lib/queries/AuthQueries.ts'
-import { useOwnProfile, useUpdateProfile } from '#/lib/queries/ProfileQueries.ts'
+import { useOwnProfile, useUpdateProfile, useUploadProfilePicture } from '#/lib/queries/ProfileQueries.ts'
 import { SkillPicker } from '@/components/SkillPicker'
 import { Muted } from '@/components/Typography'
 import { Button } from '@/components/ui/button'
@@ -8,9 +8,10 @@ import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { Loader2, X } from 'lucide-react'
-import { useState } from 'react'
+import { Camera, Loader2, X } from 'lucide-react'
+import { useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import { toast } from 'sonner'
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -35,12 +36,28 @@ export function EditProfileModal({ mode, initialValues, onClose }: EditProfileMo
     const { data: me } = useQuery(meQueryOptions)
     const { data: profileData } = useOwnProfile()
     const updateProfile = useUpdateProfile()
+    const uploadPicture = useUploadProfilePicture()
     const queryClient = useQueryClient()
+    const pictureInputRef = useRef<HTMLInputElement>(null)
 
     const [bio, setBio] = useState(initialValues.bio)
     const [skills, setSkills] = useState<string[]>(initialValues.skills)
     const [title, setTitle] = useState(initialValues.title ?? '')
     const [showInitialsOnly, setShowInitialsOnly] = useState(initialValues.show_initials_only ?? false)
+
+    function handlePictureChange(file: File) {
+        if (file.size > 5 * 1024 * 1024) {
+            toast.error('Image must be under 5 MB')
+            return
+        }
+        uploadPicture.mutate(file, {
+            onSuccess: () => {
+                queryClient.invalidateQueries({ queryKey: ['profiles', 'me'] })
+                queryClient.invalidateQueries({ queryKey: ['profiles', me?.username] })
+            },
+            onError: () => toast.error('Failed to upload picture. Please try again.'),
+        })
+    }
 
     const isMentor = mode === 'MENTOR'
 
@@ -102,6 +119,42 @@ export function EditProfileModal({ mode, initialValues, onClose }: EditProfileMo
 
                 {/* Body */}
                 <div className="flex-1 overflow-y-auto px-6 py-5 space-y-6">
+
+                    {/* Profile picture */}
+                    <div className="flex flex-col items-center gap-2">
+                        <input
+                            ref={pictureInputRef}
+                            type="file"
+                            accept="image/*"
+                            className="hidden"
+                            onChange={e => { const f = e.target.files?.[0]; if (f) handlePictureChange(f) }}
+                        />
+                        <button
+                            type="button"
+                            onClick={() => pictureInputRef.current?.click()}
+                            className="relative group rounded-full focus:outline-none focus:ring-2 focus:ring-accent"
+                            aria-label="Change profile picture"
+                        >
+                            {profileData?.picture_url ? (
+                                <img
+                                    src={profileData.picture_url}
+                                    alt="Profile"
+                                    className="h-20 w-20 rounded-full object-cover"
+                                />
+                            ) : (
+                                <div className="h-20 w-20 rounded-full bg-accent text-white text-2xl font-bold flex items-center justify-center">
+                                    {me?.username?.[0]?.toUpperCase() ?? '?'}
+                                </div>
+                            )}
+                            <span className="absolute inset-0 rounded-full bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                                {uploadPicture.isPending
+                                    ? <Loader2 className="h-6 w-6 text-white animate-spin" />
+                                    : <Camera className="h-6 w-6 text-white" />
+                                }
+                            </span>
+                        </button>
+                        <Muted className="text-xs">Click to change photo</Muted>
+                    </div>
 
                     {/* Title — mentor only */}
                     {isMentor && (

--- a/web/src/components/profile/ProfilePostsSection.tsx
+++ b/web/src/components/profile/ProfilePostsSection.tsx
@@ -27,6 +27,14 @@ import {
     type ProfilePostUpdatePayload,
 } from '#/lib/queries/ProfilePostQueries.ts'
 
+// ---- Helpers ----
+
+function mediaFileName(url: string): string {
+    const raw = url.split('/').pop()?.split('?')[0] ?? 'media'
+    // Backend prepends a 32-char hex UUID + underscore; strip it if present
+    return /^[a-f0-9]{32}_/.test(raw) ? raw.slice(33) : raw
+}
+
 // ---- Types ----
 
 interface ProfilePostsSectionProps {
@@ -188,7 +196,7 @@ function ProfilePostCard({
                         rel="noopener noreferrer"
                         className="text-xs text-accent underline truncate"
                     >
-                        {post.media_url}
+                        {mediaFileName(post.media_url)}
                     </a>
                 )}
                 {post.category === 'MCTE' && post.mentorship_partner && (

--- a/web/src/components/profile/ProfilePostsSection.tsx
+++ b/web/src/components/profile/ProfilePostsSection.tsx
@@ -12,11 +12,11 @@ import {
     DialogTitle,
     DialogFooter,
 } from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Muted } from '@/components/Typography'
+import { MediaUploadField } from '@/components/MediaUploadField'
 import {
     useProfilePosts,
     useCreateProfilePost,
@@ -315,13 +315,9 @@ function CreatePostDialog({
                         <p className="text-xs text-ink-soft text-right">{form.content.length}/2000</p>
                     </div>
                     <div className="flex flex-col gap-1.5">
-                        <Label htmlFor="create_media_url">Media URL (optional)</Label>
-                        <Input
-                            id="create_media_url"
-                            value={form.media_url ?? ''}
-                            onChange={e => setForm(f => ({ ...f, media_url: e.target.value }))}
-                            placeholder="https://..."
-                            type="url"
+                        <Label>Media (optional)</Label>
+                        <MediaUploadField
+                            onUrl={url => setForm(f => ({ ...f, media_url: url ?? undefined }))}
                         />
                     </div>
                     <DialogFooter className="mt-2">
@@ -418,13 +414,10 @@ function EditPostDialog({
                         <p className="text-xs text-ink-soft text-right">{(form.content ?? '').length}/2000</p>
                     </div>
                     <div className="flex flex-col gap-1.5">
-                        <Label htmlFor="edit_media_url">Media URL (optional)</Label>
-                        <Input
-                            id="edit_media_url"
-                            value={(form.media_url as string) ?? ''}
-                            onChange={e => setForm(f => ({ ...f, media_url: e.target.value }))}
-                            placeholder="https://..."
-                            type="url"
+                        <Label>Media (optional)</Label>
+                        <MediaUploadField
+                            currentUrl={post.media_url}
+                            onUrl={url => setForm(f => ({ ...f, media_url: url }))}
                         />
                     </div>
                     <DialogFooter className="mt-2">

--- a/web/src/lib/queries/MessagingQueries.ts
+++ b/web/src/lib/queries/MessagingQueries.ts
@@ -66,11 +66,26 @@ async function fetchMessages(conversationId: string, page = 1, pageSize = 50): P
     return res.json()
 }
 
-async function sendMessage(conversationId: string, body: string): Promise<Message> {
+async function sendMessage(
+    conversationId: string,
+    body: string,
+    attachment?: File,
+): Promise<Message> {
+    const headers = authHeaders()
+    let reqBody: BodyInit
+    if (attachment) {
+        const form = new FormData()
+        form.append('body', body)
+        form.append('attachment', attachment)
+        reqBody = form
+    } else {
+        (headers as Record<string, string>)['Content-Type'] = 'application/json'
+        reqBody = JSON.stringify({ body })
+    }
     const res = await fetch(`${API_BASE_URL}/messages/conversations/${conversationId}/`, {
         method: 'POST',
-        headers: { ...authHeaders(), 'Content-Type': 'application/json' },
-        body: JSON.stringify({ body }),
+        headers,
+        body: reqBody,
     })
     if (!res.ok) await throwApiError(res)
     return res.json()
@@ -179,7 +194,8 @@ export function useMessages(conversationId: string) {
 
 export function useSendMessage(conversationId: string) {
     return useMutation({
-        mutationFn: (body: string) => sendMessage(conversationId, body),
+        mutationFn: ({ body, attachment }: { body: string; attachment?: File }) =>
+            sendMessage(conversationId, body, attachment),
     })
 }
 

--- a/web/src/lib/queries/ProfilePostQueries.ts
+++ b/web/src/lib/queries/ProfilePostQueries.ts
@@ -142,3 +142,22 @@ export function useDeleteProfilePost(username: string) {
         },
     })
 }
+
+async function uploadPostMedia(file: File): Promise<{ url: string }> {
+    const token = localStorage.getItem('access_token')
+    const form = new FormData()
+    form.append('file', file)
+    const res = await fetch(`${API_BASE_URL}/profiles/me/uploads/`, {
+        method: 'POST',
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        body: form,
+    })
+    if (!res.ok) await throwApiError(res)
+    return res.json()
+}
+
+export function useUploadPostMedia() {
+    return useMutation({
+        mutationFn: (file: File) => uploadPostMedia(file),
+    })
+}

--- a/web/src/lib/queries/ProfileQueries.ts
+++ b/web/src/lib/queries/ProfileQueries.ts
@@ -135,6 +135,25 @@ export function useUpdateUsername() {
     })
 }
 
+async function uploadProfilePicture(file: File): Promise<{ picture_url: string }> {
+    const token = localStorage.getItem('access_token')
+    const form = new FormData()
+    form.append('picture', file)
+    const res = await fetch(`${API_BASE_URL}/profiles/me/picture/`, {
+        method: 'POST',
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        body: form,
+    })
+    if (!res.ok) await throwApiError(res)
+    return res.json()
+}
+
+export function useUploadProfilePicture() {
+    return useMutation({
+        mutationFn: (file: File) => uploadProfilePicture(file),
+    })
+}
+
 // ---- Public mentor reviews ----
 
 export interface PublicReview {

--- a/web/src/routes/_authorized/__tests__/messages.test.tsx
+++ b/web/src/routes/_authorized/__tests__/messages.test.tsx
@@ -108,6 +108,6 @@ describe('MessagesPage', () => {
     const sendButton = screen.getByRole('button', { name: /send message/i })
     fireEvent.click(sendButton)
     
-    expect(mockMutate).toHaveBeenCalledWith('New message')
+    expect(mockMutate).toHaveBeenCalledWith({ body: 'New message', attachment: undefined })
   })
 })

--- a/web/src/routes/_authorized/communities.$communitySlug.tsx
+++ b/web/src/routes/_authorized/communities.$communitySlug.tsx
@@ -40,6 +40,11 @@ import { cn } from '@/lib/utils'
 import { toast } from 'sonner'
 import type { PublicMentorProfile } from '@/lib/queries/DiscoverQueries.ts'
 
+function mediaFileName(url: string): string {
+    const raw = url.split('/').pop()?.split('?')[0] ?? 'media'
+    return /^[a-f0-9]{32}_/.test(raw) ? raw.slice(33) : raw
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -220,7 +225,7 @@ function CommunityPostCard({
 
             {post.media_url && (
                 <a href={post.media_url} target="_blank" rel="noopener noreferrer" className="text-xs text-accent underline truncate">
-                    {post.media_url}
+                    {mediaFileName(post.media_url)}
                 </a>
             )}
         </div>

--- a/web/src/routes/_authorized/communities.$communitySlug.tsx
+++ b/web/src/routes/_authorized/communities.$communitySlug.tsx
@@ -15,9 +15,9 @@ import {
     DialogTitle,
     DialogFooter,
 } from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
+import { MediaUploadField } from '@/components/MediaUploadField'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import {
     communityDetailQueryOptions,
@@ -345,8 +345,8 @@ function CreatePostDialog({
                         <TaggableUsersList communityId={communityId} selected={form.tagged_users ?? []} onChange={(usernames) => setForm((f) => ({ ...f, tagged_users: usernames }))} />
                     </div>
                     <div className="flex flex-col gap-1.5">
-                        <Label htmlFor="cop_create_media">Media URL (optional)</Label>
-                        <Input id="cop_create_media" value={(form.media_url as string) ?? ''} onChange={(e) => setForm((f) => ({ ...f, media_url: e.target.value }))} placeholder="https://…" type="url" />
+                        <Label>Media (optional)</Label>
+                        <MediaUploadField onUrl={url => setForm(f => ({ ...f, media_url: url ?? undefined }))} />
                     </div>
                     <label className="flex items-center gap-2.5 cursor-pointer text-sm">
                         <Checkbox checked={form.show_on_profile} onCheckedChange={(v) => setForm((f) => ({ ...f, show_on_profile: Boolean(v) }))} />
@@ -429,8 +429,8 @@ function EditPostDialog({
                         <TaggableUsersList communityId={communityId} selected={form.tagged_users ?? []} onChange={(usernames) => setForm((f) => ({ ...f, tagged_users: usernames }))} />
                     </div>
                     <div className="flex flex-col gap-1.5">
-                        <Label htmlFor="cop_edit_media">Media URL (optional)</Label>
-                        <Input id="cop_edit_media" value={(form.media_url as string) ?? ''} onChange={(e) => setForm((f) => ({ ...f, media_url: e.target.value }))} placeholder="https://…" type="url" />
+                        <Label>Media (optional)</Label>
+                        <MediaUploadField currentUrl={post.media_url} onUrl={url => setForm(f => ({ ...f, media_url: url ?? undefined }))} />
                     </div>
                     <label className="flex items-center gap-2.5 cursor-pointer text-sm">
                         <Checkbox checked={form.show_on_profile} onCheckedChange={(v) => setForm((f) => ({ ...f, show_on_profile: Boolean(v) }))} />

--- a/web/src/routes/_authorized/connections.$matchId.tsx
+++ b/web/src/routes/_authorized/connections.$matchId.tsx
@@ -50,6 +50,11 @@ export const Route = createFileRoute('/_authorized/connections/$matchId')({
     component: JourneyPage,
 })
 
+function mediaFileName(url: string): string {
+    const raw = url.split('/').pop()?.split('?')[0] ?? 'media'
+    return /^[a-f0-9]{32}_/.test(raw) ? raw.slice(33) : raw
+}
+
 // ---------------------------------------------------------------------------
 // AGTE event metadata
 // ---------------------------------------------------------------------------
@@ -317,7 +322,7 @@ function MCTEItem({
                             rel="noopener noreferrer"
                             className="text-xs text-accent underline truncate"
                         >
-                            {event.media_url}
+                            {mediaFileName(event.media_url)}
                         </a>
                     )}
                     <Muted className="text-xs">{formatTimestamp(event.timestamp)}</Muted>

--- a/web/src/routes/_authorized/connections.$matchId.tsx
+++ b/web/src/routes/_authorized/connections.$matchId.tsx
@@ -22,9 +22,9 @@ import {
     DialogTitle,
     DialogFooter,
 } from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
+import { MediaUploadField } from '@/components/MediaUploadField'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Checkbox } from '@/components/ui/checkbox'
 import { toast } from 'sonner'
@@ -404,13 +404,9 @@ function CreateMCTEDialog({ matchId, open, onOpenChange }: CreateMCTEDialogProps
                         <p className="text-xs text-ink-soft text-right">{form.content.length}/2000</p>
                     </div>
                     <div className="flex flex-col gap-1.5">
-                        <Label htmlFor="media_url">Media URL (optional)</Label>
-                        <Input
-                            id="media_url"
-                            value={form.media_url ?? ''}
-                            onChange={e => setForm(f => ({ ...f, media_url: e.target.value }))}
-                            placeholder="https://..."
-                            type="url"
+                        <Label>Media (optional)</Label>
+                        <MediaUploadField
+                            onUrl={url => setForm(f => ({ ...f, media_url: url ?? undefined }))}
                         />
                     </div>
                     <div className="flex items-center gap-2">
@@ -506,13 +502,10 @@ function EditMCTEDialog({ matchId, event, open, onOpenChange }: EditMCTEDialogPr
                         <p className="text-xs text-ink-soft text-right">{(form.content ?? '').length}/2000</p>
                     </div>
                     <div className="flex flex-col gap-1.5">
-                        <Label htmlFor="edit_media_url">Media URL (optional)</Label>
-                        <Input
-                            id="edit_media_url"
-                            value={form.media_url ?? ''}
-                            onChange={e => setForm(f => ({ ...f, media_url: e.target.value }))}
-                            placeholder="https://..."
-                            type="url"
+                        <Label>Media (optional)</Label>
+                        <MediaUploadField
+                            currentUrl={event.media_url}
+                            onUrl={url => setForm(f => ({ ...f, media_url: url ?? undefined }))}
                         />
                     </div>
                     <div className="flex items-center gap-2">

--- a/web/src/routes/_authorized/messages.tsx
+++ b/web/src/routes/_authorized/messages.tsx
@@ -13,7 +13,7 @@ import { cn, getInitials } from '#/lib/utils.ts'
 import { Button } from '@/components/ui/button'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
-import { Check, CheckCheck, Loader2, MessageSquare, Send } from 'lucide-react'
+import { Check, CheckCheck, Loader2, MessageSquare, Paperclip, Send, X } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState, type SyntheticEvent } from 'react'
 
 export const Route = createFileRoute('/_authorized/messages')({
@@ -173,6 +173,8 @@ function Thread({ conversationId }: { readonly conversationId: string }) {
     const queryClient = useQueryClient()
     const { enqueueMessage, updateMessageStatus, dequeueMessage } = useMessageQueue(conversationId)
     const [text, setText] = useState('')
+    const [attachedFile, setAttachedFile] = useState<File | null>(null)
+    const fileInputRef = useRef<HTMLInputElement>(null)
 
     // Mark conversation as read when opening
     useEffect(() => {
@@ -217,15 +219,17 @@ function Thread({ conversationId }: { readonly conversationId: string }) {
         async (e: SyntheticEvent) => {
             e.preventDefault()
             const body = text.trim()
-            if (!body || sendMessage.isPending) return
+            if ((!body && !attachedFile) || sendMessage.isPending) return
 
             setIsAtBottom(true) // Force scroll to bottom for new message
             const queuedMsg = enqueueMessage(body)
             setText('')
+            setAttachedFile(null)
+            if (fileInputRef.current) fileInputRef.current.value = ''
 
             try {
                 updateMessageStatus(queuedMsg.tempId, 'sending')
-                await sendMessage.mutateAsync(body)
+                await sendMessage.mutateAsync({ body, attachment: attachedFile ?? undefined })
                 dequeueMessage(queuedMsg.tempId)
                 queryClient.invalidateQueries({ queryKey: ['messaging', 'messages', conversationId] })
             } catch (error) {
@@ -233,7 +237,7 @@ function Thread({ conversationId }: { readonly conversationId: string }) {
                 console.error('[Messages] Error sending message:', error)
             }
         },
-        [text, sendMessage, enqueueMessage, updateMessageStatus, dequeueMessage, queryClient, conversationId],
+        [text, attachedFile, sendMessage, enqueueMessage, updateMessageStatus, dequeueMessage, queryClient, conversationId],
     )
 
     return (
@@ -280,34 +284,66 @@ function Thread({ conversationId }: { readonly conversationId: string }) {
             {/* Input */}
             <form
                 onSubmit={handleSubmit}
-                className="shrink-0 border-t border-line px-4 py-3 flex items-end gap-2"
+                className="shrink-0 border-t border-line px-4 py-3 flex flex-col gap-2"
             >
-                <textarea
-                    value={text}
-                    onChange={e => setText(e.target.value)}
-                    onKeyDown={e => {
-                        if (e.key === 'Enter' && !e.shiftKey) {
-                            e.preventDefault()
-                            handleSubmit(e as unknown as SyntheticEvent)
-                        }
-                    }}
-                    placeholder="Type a message… (Enter to send)"
-                    rows={1}
-                    className="flex-1 resize-none rounded-xl border border-line bg-background px-3 py-2 text-sm text-ink placeholder:text-ink-soft focus:outline-none focus:ring-2 focus:ring-accent/40 max-h-32 overflow-y-auto"
-                />
-                <Button
-                    type="submit"
-                    size="icon"
-                    aria-label="Send message"
-                    disabled={!text.trim() || sendMessage.isPending}
-                    className="rounded-xl bg-accent hover:bg-accent/90 text-white shrink-0"
-                >
-                    {sendMessage.isPending ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                        <Send className="h-4 w-4" />
-                    )}
-                </Button>
+                {attachedFile && (
+                    <div className="flex items-center gap-2 rounded-lg border border-line bg-background px-3 py-1.5 text-xs text-ink-soft w-fit max-w-full">
+                        <Paperclip className="h-3.5 w-3.5 shrink-0" />
+                        <span className="truncate">{attachedFile.name}</span>
+                        <button
+                            type="button"
+                            onClick={() => { setAttachedFile(null); if (fileInputRef.current) fileInputRef.current.value = '' }}
+                            className="shrink-0 hover:text-ink"
+                        >
+                            <X className="h-3.5 w-3.5" />
+                        </button>
+                    </div>
+                )}
+                <div className="flex items-end gap-2">
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept="image/*,application/pdf,audio/*"
+                        className="hidden"
+                        onChange={e => setAttachedFile(e.target.files?.[0] ?? null)}
+                    />
+                    <Button
+                        type="button"
+                        size="icon"
+                        variant="ghost"
+                        aria-label="Attach file"
+                        onClick={() => fileInputRef.current?.click()}
+                        className="rounded-xl shrink-0 text-ink-soft hover:text-ink"
+                    >
+                        <Paperclip className="h-4 w-4" />
+                    </Button>
+                    <textarea
+                        value={text}
+                        onChange={e => setText(e.target.value)}
+                        onKeyDown={e => {
+                            if (e.key === 'Enter' && !e.shiftKey) {
+                                e.preventDefault()
+                                handleSubmit(e as unknown as SyntheticEvent)
+                            }
+                        }}
+                        placeholder="Type a message… (Enter to send)"
+                        rows={1}
+                        className="flex-1 resize-none rounded-xl border border-line bg-background px-3 py-2 text-sm text-ink placeholder:text-ink-soft focus:outline-none focus:ring-2 focus:ring-accent/40 max-h-32 overflow-y-auto"
+                    />
+                    <Button
+                        type="submit"
+                        size="icon"
+                        aria-label="Send message"
+                        disabled={(!text.trim() && !attachedFile) || sendMessage.isPending}
+                        className="rounded-xl bg-accent hover:bg-accent/90 text-white shrink-0"
+                    >
+                        {sendMessage.isPending ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                            <Send className="h-4 w-4" />
+                        )}
+                    </Button>
+                </div>
             </form>
         </div>
     )


### PR DESCRIPTION
## Related Issue

  Closes #470  #471  #527  #524 . 527 and 524 copies of the previous ones.

  ## Description

  Implements file upload across the web frontend. Profile pictures can now be uploaded directly from the Edit Profile modal. Post forms (profile posts, timeline events, community posts)
  replace the URL text input with a file picker that pre-uploads on pick and shows a thumbnail preview. Messages support file attachments via a paperclip button.

  ## Type of Change

  - [x] New feature

  ## Checklist

  - [x] I have tested my changes locally
  - [x] My code builds without errors
  - [ ] I have written or updated tests where applicable
  - [x] I have performed a self-review of my code
