### PR TITLE
Feat/web guest view

### DIFF
--- a/web/e2e/tests/AT-001-auth-onboarding.spec.ts
+++ b/web/e2e/tests/AT-001-auth-onboarding.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test } from '@playwright/test';
 import { AuthApi } from '../api/AuthApi';
+import { AdminModerationPage } from '../pages/AdminModerationPage';
 import { DashboardPage } from '../pages/DashboardPage';
 import { LandingPage } from '../pages/LandingPage';
 import { LoginPage } from '../pages/LoginPage';
 import { OnboardingPage } from '../pages/OnboardingPage';
 import { RegisterPage } from '../pages/RegisterPage';
-import { AdminModerationPage } from '../pages/AdminModerationPage';
 
 test.describe('AT-001: Authentication & Onboarding', () => {
   test.use({ actionTimeout: 5000 });
@@ -98,7 +98,7 @@ test.describe('AT-001: Authentication & Onboarding', () => {
       // Step 11: Valid last name
       await onboardingPage.fillInput('Newuser');
       await onboardingPage.clickContinue();
-      await onboardingPage.expectQuestion(/How will you use Campus Tutor/i);
+      await onboardingPage.expectQuestion(/How will you use Neighborship/i);
 
       // Step 12: Empty role
       await onboardingPage.clickContinue();

--- a/web/src/components/MediaUploadField.tsx
+++ b/web/src/components/MediaUploadField.tsx
@@ -1,0 +1,81 @@
+import { useUploadPostMedia } from '#/lib/queries/ProfilePostQueries.ts'
+import { Button } from '@/components/ui/button'
+import { Loader2, Paperclip, X } from 'lucide-react'
+import { useRef, useState } from 'react'
+
+interface MediaUploadFieldProps {
+    onUrl: (url: string | null) => void
+    currentUrl?: string | null
+}
+
+export function MediaUploadField({ onUrl, currentUrl }: MediaUploadFieldProps) {
+    const inputRef = useRef<HTMLInputElement>(null)
+    const upload = useUploadPostMedia()
+    const [preview, setPreview] = useState<{ name: string; objectUrl?: string } | null>(
+        currentUrl ? { name: currentUrl.split('/').pop() ?? 'media' } : null,
+    )
+
+    function handleFile(file: File) {
+        const isImage = file.type.startsWith('image/')
+        const objectUrl = isImage ? URL.createObjectURL(file) : undefined
+        setPreview({ name: file.name, objectUrl })
+        upload.mutate(file, {
+            onSuccess: (data) => {
+                onUrl(data.url)
+            },
+            onError: () => {
+                setPreview(null)
+                onUrl(null)
+            },
+        })
+    }
+
+    function handleClear() {
+        if (preview?.objectUrl) URL.revokeObjectURL(preview.objectUrl)
+        setPreview(null)
+        onUrl(null)
+        if (inputRef.current) inputRef.current.value = ''
+        upload.reset()
+    }
+
+    return (
+        <div className="flex flex-col gap-1.5">
+            <input
+                ref={inputRef}
+                type="file"
+                accept="image/*,application/pdf"
+                className="hidden"
+                onChange={(e) => {
+                    const file = e.target.files?.[0]
+                    if (file) handleFile(file)
+                }}
+            />
+            {preview ? (
+                <div className="flex items-center gap-2 rounded-lg border border-line bg-background px-3 py-2 text-sm">
+                    {preview.objectUrl && (
+                        <img src={preview.objectUrl} alt="" className="h-10 w-10 rounded object-cover shrink-0" />
+                    )}
+                    <span className="flex-1 truncate text-ink-soft">{preview.name}</span>
+                    {upload.isPending && <Loader2 className="h-4 w-4 animate-spin shrink-0 text-accent" />}
+                    <button type="button" onClick={handleClear} className="shrink-0 text-ink-soft hover:text-ink">
+                        <X className="h-4 w-4" />
+                    </button>
+                </div>
+            ) : (
+                <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="w-fit gap-1.5"
+                    onClick={() => inputRef.current?.click()}
+                >
+                    <Paperclip className="h-4 w-4" />
+                    Attach media
+                </Button>
+            )}
+            {upload.isError && (
+                <p className="text-xs text-red-500">Upload failed. Please try again.</p>
+            )}
+        </div>
+    )
+}

--- a/web/src/components/features/communities/CommunityCard.tsx
+++ b/web/src/components/features/communities/CommunityCard.tsx
@@ -81,7 +81,7 @@ export function CommunityCard({
             </p>
 
             {/* Actions */}
-            <div className="grid grid-cols-2 gap-3 mt-auto">
+            <div className={cn('grid gap-3 mt-auto', onJoin !== undefined ? 'grid-cols-2' : 'grid-cols-1')}>
                 <Button
                     className="w-full bg-accent hover:bg-accent-light text-white shadow-sm"
                     size="sm"
@@ -89,26 +89,28 @@ export function CommunityCard({
                 >
                     View
                 </Button>
-                {isMember ? (
-                    <Button
-                        variant="outline"
-                        className="w-full border-line text-ink-soft hover:text-red-600 hover:border-red-300 bg-mist hover:bg-red-50"
-                        size="sm"
-                        disabled={isLeaving}
-                        onClick={() => onLeave?.(community.id)}
-                    >
-                        {isLeaving ? 'Leaving...' : 'Leave'}
-                    </Button>
-                ) : (
-                    <Button
-                        variant="outline"
-                        className="w-full border-line text-ink-soft hover:text-ink hover:border-accent/30 bg-mist hover:bg-accent/20"
-                        size="sm"
-                        disabled={isJoining}
-                        onClick={() => onJoin?.(community.id)}
-                    >
-                        {isJoining ? 'Joining...' : 'Join'}
-                    </Button>
+                {onJoin !== undefined && (
+                    isMember ? (
+                        <Button
+                            variant="outline"
+                            className="w-full border-line text-ink-soft hover:text-red-600 hover:border-red-300 bg-mist hover:bg-red-50"
+                            size="sm"
+                            disabled={isLeaving}
+                            onClick={() => onLeave?.(community.id)}
+                        >
+                            {isLeaving ? 'Leaving...' : 'Leave'}
+                        </Button>
+                    ) : (
+                        <Button
+                            variant="outline"
+                            className="w-full border-line text-ink-soft hover:text-ink hover:border-accent/30 bg-mist hover:bg-accent/20"
+                            size="sm"
+                            disabled={isJoining}
+                            onClick={() => onJoin(community.id)}
+                        >
+                            {isJoining ? 'Joining...' : 'Join'}
+                        </Button>
+                    )
                 )}
             </div>
         </div>

--- a/web/src/components/layout/AuthorizedHeader.tsx
+++ b/web/src/components/layout/AuthorizedHeader.tsx
@@ -105,9 +105,11 @@ export function AuthorizedHeader() {
                 to="/profiles/$username"
                 params={{ username: me?.username ?? '' }}
                 aria-label="Open profile page"
-                className="h-8 w-8 rounded-full bg-accent text-background flex items-center justify-center text-sm font-bold shadow-sm transition hover:brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+                className="h-8 w-8 rounded-full overflow-hidden bg-accent text-background flex items-center justify-center text-sm font-bold shadow-sm transition hover:brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
             >
-              {initials}
+              {profile?.picture_url
+                ? <img src={profile.picture_url} alt={initials} className="h-full w-full object-cover" />
+                : initials}
             </Link>
             <Button
                 variant="ghost"

--- a/web/src/components/layout/AuthorizedHeader.tsx
+++ b/web/src/components/layout/AuthorizedHeader.tsx
@@ -30,7 +30,7 @@ export function AuthorizedHeader() {
                 to="/dashboard"
                 className="font-bold font-display tracking-tight text-lg text-ink"
             >
-              Mentorship
+              Neighborship
             </Link>
 
             <nav className="hidden sm:flex items-center gap-1">

--- a/web/src/components/layout/UnauthorizedFooter.tsx
+++ b/web/src/components/layout/UnauthorizedFooter.tsx
@@ -1,5 +1,5 @@
+import { NavLink } from '@/components/NavLink'
 import { Muted } from '@/components/Typography'
-import {NavLink} from '@/components/NavLink'
 
 const FOOTER_LINKS = [
     { to: '/discover', label: 'Discover' },
@@ -28,7 +28,7 @@ export function UnauthorizedFooter() {
 
                 {/* Copyright */}
                 <Muted as="span" className="text-xs">
-                    © {new Date().getFullYear()} Campus Tutor
+                    © {new Date().getFullYear()} Neighborship
                 </Muted>
 
             </div>

--- a/web/src/components/layout/UnauthorizedHeader.tsx
+++ b/web/src/components/layout/UnauthorizedHeader.tsx
@@ -3,8 +3,9 @@ import { Button } from '@/components/ui/button'
 import {NavLink} from "#/components/NavLink.tsx";
 
 const NAV_LINKS = [
-    { to: '/discover', label: 'Discover' },
-    { to: '/about',    label: 'About'    },
+    { to: '/discover',    label: 'Discover'    },
+    { to: '/communities', label: 'Communities' },
+    { to: '/about',       label: 'About'       },
 ] as const
 
 export function UnauthorizedHeader() {

--- a/web/src/components/layout/UnauthorizedHeader.tsx
+++ b/web/src/components/layout/UnauthorizedHeader.tsx
@@ -15,7 +15,7 @@ export function UnauthorizedHeader() {
                 {/* Left: Logo and Navigation */}
                 <div className="flex items-center gap-8">
                     <Link to="/discover" className="font-bold font-display tracking-tight text-lg text-ink">
-                        Mentorship
+                        Neighborship
                     </Link>
 
                     <nav aria-label="Main navigation" className="hidden sm:flex items-center gap-1">

--- a/web/src/components/layout/UnauthorizedHeader.tsx
+++ b/web/src/components/layout/UnauthorizedHeader.tsx
@@ -1,6 +1,5 @@
 import { Link } from '@tanstack/react-router'
 import { Button } from '@/components/ui/button'
-import {NavLink} from "#/components/NavLink.tsx";
 
 const NAV_LINKS = [
     { to: '/discover',    label: 'Discover'    },
@@ -13,23 +12,30 @@ export function UnauthorizedHeader() {
         <header className="sticky top-0 z-50 w-full border-b border-line bg-header-bg backdrop-blur-md">
             <div className="page-wrap flex h-14 items-center justify-between">
 
+                {/* Left: Logo and Navigation */}
+                <div className="flex items-center gap-8">
+                    <Link to="/discover" className="font-bold font-display tracking-tight text-lg text-ink">
+                        Mentorship
+                    </Link>
 
-                {/* Nav */}
-                <nav aria-label="Main navigation" className="hidden sm:flex items-center gap-6">
-                    {NAV_LINKS.map(({ to, label }) => (
-                        <NavLink
-                            key={to}
-                            to={to}
-                        >
-                            {label}
-                        </NavLink>
-                    ))}
-                </nav>
+                    <nav aria-label="Main navigation" className="hidden sm:flex items-center gap-1">
+                        {NAV_LINKS.map(({ to, label }) => (
+                            <Link
+                                key={to}
+                                to={to}
+                                activeProps={{ className: 'bg-accent-muted text-ink font-semibold' }}
+                                className="text-sm font-medium text-ink-soft hover:text-ink hover:bg-accent-muted/60 transition-colors px-3 py-1.5 rounded-lg"
+                            >
+                                {label}
+                            </Link>
+                        ))}
+                    </nav>
+                </div>
 
                 {/* Actions */}
                 <div className="flex items-center gap-2">
                     <Link to="/login">
-                        <Button variant="ghost" size="sm" className="text-sm text-(--color-brand-ink-soft) hover:text-(--color-brand-ink)">
+                        <Button variant="ghost" size="sm" className="text-sm text-ink-soft hover:text-ink">
                             Sign in
                         </Button>
                     </Link>

--- a/web/src/components/layout/__test__/AuthorizedHeader.test.tsx
+++ b/web/src/components/layout/__test__/AuthorizedHeader.test.tsx
@@ -38,7 +38,7 @@ function renderWithClient(ui: React.ReactElement) {
 describe('AuthorizedHeader Component', () => {
   it('renders the branding text', () => {
     renderWithClient(<AuthorizedHeader />)
-    expect(screen.getByText('Mentorship')).toBeInTheDocument()
+    expect(screen.getByText('Neighborship')).toBeInTheDocument()
   })
 
   it('renders the navigation links', () => {

--- a/web/src/components/profile/EditProfileModal.tsx
+++ b/web/src/components/profile/EditProfileModal.tsx
@@ -1,5 +1,5 @@
 import { meQueryOptions } from '#/lib/queries/AuthQueries.ts'
-import { useOwnProfile, useUpdateProfile } from '#/lib/queries/ProfileQueries.ts'
+import { useOwnProfile, useUpdateProfile, useUploadProfilePicture } from '#/lib/queries/ProfileQueries.ts'
 import { SkillPicker } from '@/components/SkillPicker'
 import { Muted } from '@/components/Typography'
 import { Button } from '@/components/ui/button'
@@ -8,9 +8,10 @@ import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { Loader2, X } from 'lucide-react'
-import { useState } from 'react'
+import { Camera, Loader2, X } from 'lucide-react'
+import { useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import { toast } from 'sonner'
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -35,12 +36,28 @@ export function EditProfileModal({ mode, initialValues, onClose }: EditProfileMo
     const { data: me } = useQuery(meQueryOptions)
     const { data: profileData } = useOwnProfile()
     const updateProfile = useUpdateProfile()
+    const uploadPicture = useUploadProfilePicture()
     const queryClient = useQueryClient()
+    const pictureInputRef = useRef<HTMLInputElement>(null)
 
     const [bio, setBio] = useState(initialValues.bio)
     const [skills, setSkills] = useState<string[]>(initialValues.skills)
     const [title, setTitle] = useState(initialValues.title ?? '')
     const [showInitialsOnly, setShowInitialsOnly] = useState(initialValues.show_initials_only ?? false)
+
+    function handlePictureChange(file: File) {
+        if (file.size > 5 * 1024 * 1024) {
+            toast.error('Image must be under 5 MB')
+            return
+        }
+        uploadPicture.mutate(file, {
+            onSuccess: () => {
+                queryClient.invalidateQueries({ queryKey: ['profiles', 'me'] })
+                queryClient.invalidateQueries({ queryKey: ['profiles', me?.username] })
+            },
+            onError: () => toast.error('Failed to upload picture. Please try again.'),
+        })
+    }
 
     const isMentor = mode === 'MENTOR'
 
@@ -102,6 +119,42 @@ export function EditProfileModal({ mode, initialValues, onClose }: EditProfileMo
 
                 {/* Body */}
                 <div className="flex-1 overflow-y-auto px-6 py-5 space-y-6">
+
+                    {/* Profile picture */}
+                    <div className="flex flex-col items-center gap-2">
+                        <input
+                            ref={pictureInputRef}
+                            type="file"
+                            accept="image/*"
+                            className="hidden"
+                            onChange={e => { const f = e.target.files?.[0]; if (f) handlePictureChange(f) }}
+                        />
+                        <button
+                            type="button"
+                            onClick={() => pictureInputRef.current?.click()}
+                            className="relative group rounded-full focus:outline-none focus:ring-2 focus:ring-accent"
+                            aria-label="Change profile picture"
+                        >
+                            {profileData?.picture_url ? (
+                                <img
+                                    src={profileData.picture_url}
+                                    alt="Profile"
+                                    className="h-20 w-20 rounded-full object-cover"
+                                />
+                            ) : (
+                                <div className="h-20 w-20 rounded-full bg-accent text-white text-2xl font-bold flex items-center justify-center">
+                                    {me?.username?.[0]?.toUpperCase() ?? '?'}
+                                </div>
+                            )}
+                            <span className="absolute inset-0 rounded-full bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                                {uploadPicture.isPending
+                                    ? <Loader2 className="h-6 w-6 text-white animate-spin" />
+                                    : <Camera className="h-6 w-6 text-white" />
+                                }
+                            </span>
+                        </button>
+                        <Muted className="text-xs">Click to change photo</Muted>
+                    </div>
 
                     {/* Title — mentor only */}
                     {isMentor && (

--- a/web/src/components/profile/ProfilePostsSection.tsx
+++ b/web/src/components/profile/ProfilePostsSection.tsx
@@ -27,6 +27,14 @@ import {
     type ProfilePostUpdatePayload,
 } from '#/lib/queries/ProfilePostQueries.ts'
 
+// ---- Helpers ----
+
+function mediaFileName(url: string): string {
+    const raw = url.split('/').pop()?.split('?')[0] ?? 'media'
+    // Backend prepends a 32-char hex UUID + underscore; strip it if present
+    return /^[a-f0-9]{32}_/.test(raw) ? raw.slice(33) : raw
+}
+
 // ---- Types ----
 
 interface ProfilePostsSectionProps {
@@ -188,7 +196,7 @@ function ProfilePostCard({
                         rel="noopener noreferrer"
                         className="text-xs text-accent underline truncate"
                     >
-                        {post.media_url}
+                        {mediaFileName(post.media_url)}
                     </a>
                 )}
                 {post.category === 'MCTE' && post.mentorship_partner && (

--- a/web/src/components/profile/ProfilePostsSection.tsx
+++ b/web/src/components/profile/ProfilePostsSection.tsx
@@ -12,11 +12,11 @@ import {
     DialogTitle,
     DialogFooter,
 } from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Muted } from '@/components/Typography'
+import { MediaUploadField } from '@/components/MediaUploadField'
 import {
     useProfilePosts,
     useCreateProfilePost,
@@ -315,13 +315,9 @@ function CreatePostDialog({
                         <p className="text-xs text-ink-soft text-right">{form.content.length}/2000</p>
                     </div>
                     <div className="flex flex-col gap-1.5">
-                        <Label htmlFor="create_media_url">Media URL (optional)</Label>
-                        <Input
-                            id="create_media_url"
-                            value={form.media_url ?? ''}
-                            onChange={e => setForm(f => ({ ...f, media_url: e.target.value }))}
-                            placeholder="https://..."
-                            type="url"
+                        <Label>Media (optional)</Label>
+                        <MediaUploadField
+                            onUrl={url => setForm(f => ({ ...f, media_url: url ?? undefined }))}
                         />
                     </div>
                     <DialogFooter className="mt-2">
@@ -418,13 +414,10 @@ function EditPostDialog({
                         <p className="text-xs text-ink-soft text-right">{(form.content ?? '').length}/2000</p>
                     </div>
                     <div className="flex flex-col gap-1.5">
-                        <Label htmlFor="edit_media_url">Media URL (optional)</Label>
-                        <Input
-                            id="edit_media_url"
-                            value={(form.media_url as string) ?? ''}
-                            onChange={e => setForm(f => ({ ...f, media_url: e.target.value }))}
-                            placeholder="https://..."
-                            type="url"
+                        <Label>Media (optional)</Label>
+                        <MediaUploadField
+                            currentUrl={post.media_url}
+                            onUrl={url => setForm(f => ({ ...f, media_url: url }))}
                         />
                     </div>
                     <DialogFooter className="mt-2">

--- a/web/src/lib/queries/MessagingQueries.ts
+++ b/web/src/lib/queries/MessagingQueries.ts
@@ -66,11 +66,26 @@ async function fetchMessages(conversationId: string, page = 1, pageSize = 50): P
     return res.json()
 }
 
-async function sendMessage(conversationId: string, body: string): Promise<Message> {
+async function sendMessage(
+    conversationId: string,
+    body: string,
+    attachment?: File,
+): Promise<Message> {
+    const headers = authHeaders()
+    let reqBody: BodyInit
+    if (attachment) {
+        const form = new FormData()
+        form.append('body', body)
+        form.append('attachment', attachment)
+        reqBody = form
+    } else {
+        (headers as Record<string, string>)['Content-Type'] = 'application/json'
+        reqBody = JSON.stringify({ body })
+    }
     const res = await fetch(`${API_BASE_URL}/messages/conversations/${conversationId}/`, {
         method: 'POST',
-        headers: { ...authHeaders(), 'Content-Type': 'application/json' },
-        body: JSON.stringify({ body }),
+        headers,
+        body: reqBody,
     })
     if (!res.ok) await throwApiError(res)
     return res.json()
@@ -179,7 +194,8 @@ export function useMessages(conversationId: string) {
 
 export function useSendMessage(conversationId: string) {
     return useMutation({
-        mutationFn: (body: string) => sendMessage(conversationId, body),
+        mutationFn: ({ body, attachment }: { body: string; attachment?: File }) =>
+            sendMessage(conversationId, body, attachment),
     })
 }
 

--- a/web/src/lib/queries/MessagingQueries.ts
+++ b/web/src/lib/queries/MessagingQueries.ts
@@ -97,6 +97,7 @@ export const conversationsQueryOptions = queryOptions({
     queryKey: ['messaging', 'conversations'],
     queryFn: fetchConversations,
     staleTime: 30 * 1000,
+    enabled: !!localStorage.getItem('access_token'),
 })
 
 export const messagesQueryOptions = (conversationId: string, pageSize = 50, forceEnable = false) =>

--- a/web/src/lib/queries/ProfilePostQueries.ts
+++ b/web/src/lib/queries/ProfilePostQueries.ts
@@ -142,3 +142,22 @@ export function useDeleteProfilePost(username: string) {
         },
     })
 }
+
+async function uploadPostMedia(file: File): Promise<{ url: string }> {
+    const token = localStorage.getItem('access_token')
+    const form = new FormData()
+    form.append('file', file)
+    const res = await fetch(`${API_BASE_URL}/profiles/me/uploads/`, {
+        method: 'POST',
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        body: form,
+    })
+    if (!res.ok) await throwApiError(res)
+    return res.json()
+}
+
+export function useUploadPostMedia() {
+    return useMutation({
+        mutationFn: (file: File) => uploadPostMedia(file),
+    })
+}

--- a/web/src/lib/queries/ProfileQueries.ts
+++ b/web/src/lib/queries/ProfileQueries.ts
@@ -135,6 +135,25 @@ export function useUpdateUsername() {
     })
 }
 
+async function uploadProfilePicture(file: File): Promise<{ picture_url: string }> {
+    const token = localStorage.getItem('access_token')
+    const form = new FormData()
+    form.append('picture', file)
+    const res = await fetch(`${API_BASE_URL}/profiles/me/picture/`, {
+        method: 'POST',
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        body: form,
+    })
+    if (!res.ok) await throwApiError(res)
+    return res.json()
+}
+
+export function useUploadProfilePicture() {
+    return useMutation({
+        mutationFn: (file: File) => uploadProfilePicture(file),
+    })
+}
+
 // ---- Public mentor reviews ----
 
 export interface PublicReview {

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as UnauthorizedRouteRouteImport } from './routes/_unauthorized/route'
+import { Route as PublicRouteRouteImport } from './routes/_public/route'
 import { Route as OnBoardingRouteRouteImport } from './routes/_onBoarding/route'
 import { Route as AuthorizedRouteRouteImport } from './routes/_authorized/route'
 import { Route as IndexRouteImport } from './routes/index'
@@ -19,21 +20,25 @@ import { Route as UnauthorizedRegisterRouteImport } from './routes/_unauthorized
 import { Route as UnauthorizedLoginRouteImport } from './routes/_unauthorized/login'
 import { Route as UnauthorizedForgotPasswordRouteImport } from './routes/_unauthorized/forgot-password'
 import { Route as UnauthorizedAboutRouteImport } from './routes/_unauthorized/about'
+import { Route as PublicDiscoverRouteImport } from './routes/_public/discover'
+import { Route as PublicCommunitiesRouteImport } from './routes/_public/communities'
 import { Route as OnBoardingGettingToKnowYouRouteImport } from './routes/_onBoarding/gettingToKnowYou'
 import { Route as AuthorizedScheduleRouteImport } from './routes/_authorized/schedule'
 import { Route as AuthorizedMessagesRouteImport } from './routes/_authorized/messages'
-import { Route as AuthorizedDiscoverRouteImport } from './routes/_authorized/discover'
 import { Route as AuthorizedDashboardRouteImport } from './routes/_authorized/dashboard'
 import { Route as AuthorizedConnectionsRouteImport } from './routes/_authorized/connections'
-import { Route as AuthorizedCommunitiesRouteImport } from './routes/_authorized/communities'
 import { Route as AuthorizedAdminModerationRouteImport } from './routes/_authorized/admin-moderation'
+import { Route as PublicCommunitiesIndexRouteImport } from './routes/_public/communities.index'
 import { Route as AuthorizedConnectionsIndexRouteImport } from './routes/_authorized/connections.index'
-import { Route as AuthorizedCommunitiesIndexRouteImport } from './routes/_authorized/communities.index'
+import { Route as PublicCommunitiesCommunitySlugRouteImport } from './routes/_public/communities.$communitySlug'
 import { Route as AuthorizedConnectionsMatchIdRouteImport } from './routes/_authorized/connections.$matchId'
-import { Route as AuthorizedCommunitiesCommunitySlugRouteImport } from './routes/_authorized/communities.$communitySlug'
 
 const UnauthorizedRouteRoute = UnauthorizedRouteRouteImport.update({
   id: '/_unauthorized',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PublicRouteRoute = PublicRouteRouteImport.update({
+  id: '/_public',
   getParentRoute: () => rootRouteImport,
 } as any)
 const OnBoardingRouteRoute = OnBoardingRouteRouteImport.update({
@@ -81,6 +86,16 @@ const UnauthorizedAboutRoute = UnauthorizedAboutRouteImport.update({
   path: '/about',
   getParentRoute: () => UnauthorizedRouteRoute,
 } as any)
+const PublicDiscoverRoute = PublicDiscoverRouteImport.update({
+  id: '/discover',
+  path: '/discover',
+  getParentRoute: () => PublicRouteRoute,
+} as any)
+const PublicCommunitiesRoute = PublicCommunitiesRouteImport.update({
+  id: '/communities',
+  path: '/communities',
+  getParentRoute: () => PublicRouteRoute,
+} as any)
 const OnBoardingGettingToKnowYouRoute =
   OnBoardingGettingToKnowYouRouteImport.update({
     id: '/gettingToKnowYou',
@@ -97,11 +112,6 @@ const AuthorizedMessagesRoute = AuthorizedMessagesRouteImport.update({
   path: '/messages',
   getParentRoute: () => AuthorizedRouteRoute,
 } as any)
-const AuthorizedDiscoverRoute = AuthorizedDiscoverRouteImport.update({
-  id: '/discover',
-  path: '/discover',
-  getParentRoute: () => AuthorizedRouteRoute,
-} as any)
 const AuthorizedDashboardRoute = AuthorizedDashboardRouteImport.update({
   id: '/dashboard',
   path: '/dashboard',
@@ -112,28 +122,28 @@ const AuthorizedConnectionsRoute = AuthorizedConnectionsRouteImport.update({
   path: '/connections',
   getParentRoute: () => AuthorizedRouteRoute,
 } as any)
-const AuthorizedCommunitiesRoute = AuthorizedCommunitiesRouteImport.update({
-  id: '/communities',
-  path: '/communities',
-  getParentRoute: () => AuthorizedRouteRoute,
-} as any)
 const AuthorizedAdminModerationRoute =
   AuthorizedAdminModerationRouteImport.update({
     id: '/admin-moderation',
     path: '/admin-moderation',
     getParentRoute: () => AuthorizedRouteRoute,
   } as any)
+const PublicCommunitiesIndexRoute = PublicCommunitiesIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => PublicCommunitiesRoute,
+} as any)
 const AuthorizedConnectionsIndexRoute =
   AuthorizedConnectionsIndexRouteImport.update({
     id: '/',
     path: '/',
     getParentRoute: () => AuthorizedConnectionsRoute,
   } as any)
-const AuthorizedCommunitiesIndexRoute =
-  AuthorizedCommunitiesIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => AuthorizedCommunitiesRoute,
+const PublicCommunitiesCommunitySlugRoute =
+  PublicCommunitiesCommunitySlugRouteImport.update({
+    id: '/$communitySlug',
+    path: '/$communitySlug',
+    getParentRoute: () => PublicCommunitiesRoute,
   } as any)
 const AuthorizedConnectionsMatchIdRoute =
   AuthorizedConnectionsMatchIdRouteImport.update({
@@ -141,149 +151,146 @@ const AuthorizedConnectionsMatchIdRoute =
     path: '/$matchId',
     getParentRoute: () => AuthorizedConnectionsRoute,
   } as any)
-const AuthorizedCommunitiesCommunitySlugRoute =
-  AuthorizedCommunitiesCommunitySlugRouteImport.update({
-    id: '/$communitySlug',
-    path: '/$communitySlug',
-    getParentRoute: () => AuthorizedCommunitiesRoute,
-  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/admin-moderation': typeof AuthorizedAdminModerationRoute
-  '/communities': typeof AuthorizedCommunitiesRouteWithChildren
   '/connections': typeof AuthorizedConnectionsRouteWithChildren
   '/dashboard': typeof AuthorizedDashboardRoute
-  '/discover': typeof AuthorizedDiscoverRoute
   '/messages': typeof AuthorizedMessagesRoute
   '/schedule': typeof AuthorizedScheduleRoute
   '/gettingToKnowYou': typeof OnBoardingGettingToKnowYouRoute
+  '/communities': typeof PublicCommunitiesRouteWithChildren
+  '/discover': typeof PublicDiscoverRoute
   '/about': typeof UnauthorizedAboutRoute
   '/forgot-password': typeof UnauthorizedForgotPasswordRoute
   '/login': typeof UnauthorizedLoginRoute
   '/register': typeof UnauthorizedRegisterRoute
   '/reset-password': typeof UnauthorizedResetPasswordRoute
   '/profiles/$username': typeof ProfilesUsernameRoute
-  '/communities/$communitySlug': typeof AuthorizedCommunitiesCommunitySlugRoute
   '/connections/$matchId': typeof AuthorizedConnectionsMatchIdRoute
-  '/communities/': typeof AuthorizedCommunitiesIndexRoute
+  '/communities/$communitySlug': typeof PublicCommunitiesCommunitySlugRoute
   '/connections/': typeof AuthorizedConnectionsIndexRoute
+  '/communities/': typeof PublicCommunitiesIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/admin-moderation': typeof AuthorizedAdminModerationRoute
   '/dashboard': typeof AuthorizedDashboardRoute
-  '/discover': typeof AuthorizedDiscoverRoute
   '/messages': typeof AuthorizedMessagesRoute
   '/schedule': typeof AuthorizedScheduleRoute
   '/gettingToKnowYou': typeof OnBoardingGettingToKnowYouRoute
+  '/discover': typeof PublicDiscoverRoute
   '/about': typeof UnauthorizedAboutRoute
   '/forgot-password': typeof UnauthorizedForgotPasswordRoute
   '/login': typeof UnauthorizedLoginRoute
   '/register': typeof UnauthorizedRegisterRoute
   '/reset-password': typeof UnauthorizedResetPasswordRoute
   '/profiles/$username': typeof ProfilesUsernameRoute
-  '/communities/$communitySlug': typeof AuthorizedCommunitiesCommunitySlugRoute
   '/connections/$matchId': typeof AuthorizedConnectionsMatchIdRoute
-  '/communities': typeof AuthorizedCommunitiesIndexRoute
+  '/communities/$communitySlug': typeof PublicCommunitiesCommunitySlugRoute
   '/connections': typeof AuthorizedConnectionsIndexRoute
+  '/communities': typeof PublicCommunitiesIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/_authorized': typeof AuthorizedRouteRouteWithChildren
   '/_onBoarding': typeof OnBoardingRouteRouteWithChildren
+  '/_public': typeof PublicRouteRouteWithChildren
   '/_unauthorized': typeof UnauthorizedRouteRouteWithChildren
   '/_authorized/admin-moderation': typeof AuthorizedAdminModerationRoute
-  '/_authorized/communities': typeof AuthorizedCommunitiesRouteWithChildren
   '/_authorized/connections': typeof AuthorizedConnectionsRouteWithChildren
   '/_authorized/dashboard': typeof AuthorizedDashboardRoute
-  '/_authorized/discover': typeof AuthorizedDiscoverRoute
   '/_authorized/messages': typeof AuthorizedMessagesRoute
   '/_authorized/schedule': typeof AuthorizedScheduleRoute
   '/_onBoarding/gettingToKnowYou': typeof OnBoardingGettingToKnowYouRoute
+  '/_public/communities': typeof PublicCommunitiesRouteWithChildren
+  '/_public/discover': typeof PublicDiscoverRoute
   '/_unauthorized/about': typeof UnauthorizedAboutRoute
   '/_unauthorized/forgot-password': typeof UnauthorizedForgotPasswordRoute
   '/_unauthorized/login': typeof UnauthorizedLoginRoute
   '/_unauthorized/register': typeof UnauthorizedRegisterRoute
   '/_unauthorized/reset-password': typeof UnauthorizedResetPasswordRoute
   '/profiles/$username': typeof ProfilesUsernameRoute
-  '/_authorized/communities/$communitySlug': typeof AuthorizedCommunitiesCommunitySlugRoute
   '/_authorized/connections/$matchId': typeof AuthorizedConnectionsMatchIdRoute
-  '/_authorized/communities/': typeof AuthorizedCommunitiesIndexRoute
+  '/_public/communities/$communitySlug': typeof PublicCommunitiesCommunitySlugRoute
   '/_authorized/connections/': typeof AuthorizedConnectionsIndexRoute
+  '/_public/communities/': typeof PublicCommunitiesIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
     | '/admin-moderation'
-    | '/communities'
     | '/connections'
     | '/dashboard'
-    | '/discover'
     | '/messages'
     | '/schedule'
     | '/gettingToKnowYou'
+    | '/communities'
+    | '/discover'
     | '/about'
     | '/forgot-password'
     | '/login'
     | '/register'
     | '/reset-password'
     | '/profiles/$username'
-    | '/communities/$communitySlug'
     | '/connections/$matchId'
-    | '/communities/'
+    | '/communities/$communitySlug'
     | '/connections/'
+    | '/communities/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/admin-moderation'
     | '/dashboard'
-    | '/discover'
     | '/messages'
     | '/schedule'
     | '/gettingToKnowYou'
+    | '/discover'
     | '/about'
     | '/forgot-password'
     | '/login'
     | '/register'
     | '/reset-password'
     | '/profiles/$username'
-    | '/communities/$communitySlug'
     | '/connections/$matchId'
-    | '/communities'
+    | '/communities/$communitySlug'
     | '/connections'
+    | '/communities'
   id:
     | '__root__'
     | '/'
     | '/_authorized'
     | '/_onBoarding'
+    | '/_public'
     | '/_unauthorized'
     | '/_authorized/admin-moderation'
-    | '/_authorized/communities'
     | '/_authorized/connections'
     | '/_authorized/dashboard'
-    | '/_authorized/discover'
     | '/_authorized/messages'
     | '/_authorized/schedule'
     | '/_onBoarding/gettingToKnowYou'
+    | '/_public/communities'
+    | '/_public/discover'
     | '/_unauthorized/about'
     | '/_unauthorized/forgot-password'
     | '/_unauthorized/login'
     | '/_unauthorized/register'
     | '/_unauthorized/reset-password'
     | '/profiles/$username'
-    | '/_authorized/communities/$communitySlug'
     | '/_authorized/connections/$matchId'
-    | '/_authorized/communities/'
+    | '/_public/communities/$communitySlug'
     | '/_authorized/connections/'
+    | '/_public/communities/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AuthorizedRouteRoute: typeof AuthorizedRouteRouteWithChildren
   OnBoardingRouteRoute: typeof OnBoardingRouteRouteWithChildren
+  PublicRouteRoute: typeof PublicRouteRouteWithChildren
   UnauthorizedRouteRoute: typeof UnauthorizedRouteRouteWithChildren
   ProfilesUsernameRoute: typeof ProfilesUsernameRoute
 }
@@ -295,6 +302,13 @@ declare module '@tanstack/react-router' {
       path: ''
       fullPath: '/'
       preLoaderRoute: typeof UnauthorizedRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_public': {
+      id: '/_public'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof PublicRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_onBoarding': {
@@ -360,6 +374,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof UnauthorizedAboutRouteImport
       parentRoute: typeof UnauthorizedRouteRoute
     }
+    '/_public/discover': {
+      id: '/_public/discover'
+      path: '/discover'
+      fullPath: '/discover'
+      preLoaderRoute: typeof PublicDiscoverRouteImport
+      parentRoute: typeof PublicRouteRoute
+    }
+    '/_public/communities': {
+      id: '/_public/communities'
+      path: '/communities'
+      fullPath: '/communities'
+      preLoaderRoute: typeof PublicCommunitiesRouteImport
+      parentRoute: typeof PublicRouteRoute
+    }
     '/_onBoarding/gettingToKnowYou': {
       id: '/_onBoarding/gettingToKnowYou'
       path: '/gettingToKnowYou'
@@ -381,13 +409,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthorizedMessagesRouteImport
       parentRoute: typeof AuthorizedRouteRoute
     }
-    '/_authorized/discover': {
-      id: '/_authorized/discover'
-      path: '/discover'
-      fullPath: '/discover'
-      preLoaderRoute: typeof AuthorizedDiscoverRouteImport
-      parentRoute: typeof AuthorizedRouteRoute
-    }
     '/_authorized/dashboard': {
       id: '/_authorized/dashboard'
       path: '/dashboard'
@@ -402,19 +423,19 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthorizedConnectionsRouteImport
       parentRoute: typeof AuthorizedRouteRoute
     }
-    '/_authorized/communities': {
-      id: '/_authorized/communities'
-      path: '/communities'
-      fullPath: '/communities'
-      preLoaderRoute: typeof AuthorizedCommunitiesRouteImport
-      parentRoute: typeof AuthorizedRouteRoute
-    }
     '/_authorized/admin-moderation': {
       id: '/_authorized/admin-moderation'
       path: '/admin-moderation'
       fullPath: '/admin-moderation'
       preLoaderRoute: typeof AuthorizedAdminModerationRouteImport
       parentRoute: typeof AuthorizedRouteRoute
+    }
+    '/_public/communities/': {
+      id: '/_public/communities/'
+      path: '/'
+      fullPath: '/communities/'
+      preLoaderRoute: typeof PublicCommunitiesIndexRouteImport
+      parentRoute: typeof PublicCommunitiesRoute
     }
     '/_authorized/connections/': {
       id: '/_authorized/connections/'
@@ -423,12 +444,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthorizedConnectionsIndexRouteImport
       parentRoute: typeof AuthorizedConnectionsRoute
     }
-    '/_authorized/communities/': {
-      id: '/_authorized/communities/'
-      path: '/'
-      fullPath: '/communities/'
-      preLoaderRoute: typeof AuthorizedCommunitiesIndexRouteImport
-      parentRoute: typeof AuthorizedCommunitiesRoute
+    '/_public/communities/$communitySlug': {
+      id: '/_public/communities/$communitySlug'
+      path: '/$communitySlug'
+      fullPath: '/communities/$communitySlug'
+      preLoaderRoute: typeof PublicCommunitiesCommunitySlugRouteImport
+      parentRoute: typeof PublicCommunitiesRoute
     }
     '/_authorized/connections/$matchId': {
       id: '/_authorized/connections/$matchId'
@@ -437,31 +458,8 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthorizedConnectionsMatchIdRouteImport
       parentRoute: typeof AuthorizedConnectionsRoute
     }
-    '/_authorized/communities/$communitySlug': {
-      id: '/_authorized/communities/$communitySlug'
-      path: '/$communitySlug'
-      fullPath: '/communities/$communitySlug'
-      preLoaderRoute: typeof AuthorizedCommunitiesCommunitySlugRouteImport
-      parentRoute: typeof AuthorizedCommunitiesRoute
-    }
   }
 }
-
-interface AuthorizedCommunitiesRouteChildren {
-  AuthorizedCommunitiesCommunitySlugRoute: typeof AuthorizedCommunitiesCommunitySlugRoute
-  AuthorizedCommunitiesIndexRoute: typeof AuthorizedCommunitiesIndexRoute
-}
-
-const AuthorizedCommunitiesRouteChildren: AuthorizedCommunitiesRouteChildren = {
-  AuthorizedCommunitiesCommunitySlugRoute:
-    AuthorizedCommunitiesCommunitySlugRoute,
-  AuthorizedCommunitiesIndexRoute: AuthorizedCommunitiesIndexRoute,
-}
-
-const AuthorizedCommunitiesRouteWithChildren =
-  AuthorizedCommunitiesRoute._addFileChildren(
-    AuthorizedCommunitiesRouteChildren,
-  )
 
 interface AuthorizedConnectionsRouteChildren {
   AuthorizedConnectionsMatchIdRoute: typeof AuthorizedConnectionsMatchIdRoute
@@ -480,20 +478,16 @@ const AuthorizedConnectionsRouteWithChildren =
 
 interface AuthorizedRouteRouteChildren {
   AuthorizedAdminModerationRoute: typeof AuthorizedAdminModerationRoute
-  AuthorizedCommunitiesRoute: typeof AuthorizedCommunitiesRouteWithChildren
   AuthorizedConnectionsRoute: typeof AuthorizedConnectionsRouteWithChildren
   AuthorizedDashboardRoute: typeof AuthorizedDashboardRoute
-  AuthorizedDiscoverRoute: typeof AuthorizedDiscoverRoute
   AuthorizedMessagesRoute: typeof AuthorizedMessagesRoute
   AuthorizedScheduleRoute: typeof AuthorizedScheduleRoute
 }
 
 const AuthorizedRouteRouteChildren: AuthorizedRouteRouteChildren = {
   AuthorizedAdminModerationRoute: AuthorizedAdminModerationRoute,
-  AuthorizedCommunitiesRoute: AuthorizedCommunitiesRouteWithChildren,
   AuthorizedConnectionsRoute: AuthorizedConnectionsRouteWithChildren,
   AuthorizedDashboardRoute: AuthorizedDashboardRoute,
-  AuthorizedDiscoverRoute: AuthorizedDiscoverRoute,
   AuthorizedMessagesRoute: AuthorizedMessagesRoute,
   AuthorizedScheduleRoute: AuthorizedScheduleRoute,
 }
@@ -512,6 +506,33 @@ const OnBoardingRouteRouteChildren: OnBoardingRouteRouteChildren = {
 
 const OnBoardingRouteRouteWithChildren = OnBoardingRouteRoute._addFileChildren(
   OnBoardingRouteRouteChildren,
+)
+
+interface PublicCommunitiesRouteChildren {
+  PublicCommunitiesCommunitySlugRoute: typeof PublicCommunitiesCommunitySlugRoute
+  PublicCommunitiesIndexRoute: typeof PublicCommunitiesIndexRoute
+}
+
+const PublicCommunitiesRouteChildren: PublicCommunitiesRouteChildren = {
+  PublicCommunitiesCommunitySlugRoute: PublicCommunitiesCommunitySlugRoute,
+  PublicCommunitiesIndexRoute: PublicCommunitiesIndexRoute,
+}
+
+const PublicCommunitiesRouteWithChildren =
+  PublicCommunitiesRoute._addFileChildren(PublicCommunitiesRouteChildren)
+
+interface PublicRouteRouteChildren {
+  PublicCommunitiesRoute: typeof PublicCommunitiesRouteWithChildren
+  PublicDiscoverRoute: typeof PublicDiscoverRoute
+}
+
+const PublicRouteRouteChildren: PublicRouteRouteChildren = {
+  PublicCommunitiesRoute: PublicCommunitiesRouteWithChildren,
+  PublicDiscoverRoute: PublicDiscoverRoute,
+}
+
+const PublicRouteRouteWithChildren = PublicRouteRoute._addFileChildren(
+  PublicRouteRouteChildren,
 )
 
 interface UnauthorizedRouteRouteChildren {
@@ -537,6 +558,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AuthorizedRouteRoute: AuthorizedRouteRouteWithChildren,
   OnBoardingRouteRoute: OnBoardingRouteRouteWithChildren,
+  PublicRouteRoute: PublicRouteRouteWithChildren,
   UnauthorizedRouteRoute: UnauthorizedRouteRouteWithChildren,
   ProfilesUsernameRoute: ProfilesUsernameRoute,
 }

--- a/web/src/routes/_authorized/__tests__/discover.test.tsx
+++ b/web/src/routes/_authorized/__tests__/discover.test.tsx
@@ -113,7 +113,7 @@ vi.mock('@/lib/queries/DiscoverQueries.ts', async (importOriginal) => {
 
 // ── Test helpers ─────────────────────────────────────────────────────────────
 
-import { DiscoverPage } from '../discover'
+import { DiscoverPage } from '../../_public/discover'
 
 function renderDiscover() {
   const queryClient = new QueryClient({

--- a/web/src/routes/_authorized/__tests__/messages.test.tsx
+++ b/web/src/routes/_authorized/__tests__/messages.test.tsx
@@ -108,6 +108,6 @@ describe('MessagesPage', () => {
     const sendButton = screen.getByRole('button', { name: /send message/i })
     fireEvent.click(sendButton)
     
-    expect(mockMutate).toHaveBeenCalledWith('New message')
+    expect(mockMutate).toHaveBeenCalledWith({ body: 'New message', attachment: undefined })
   })
 })

--- a/web/src/routes/_authorized/communities.$communitySlug.tsx
+++ b/web/src/routes/_authorized/communities.$communitySlug.tsx
@@ -40,6 +40,11 @@ import { cn } from '@/lib/utils'
 import { toast } from 'sonner'
 import type { PublicMentorProfile } from '@/lib/queries/DiscoverQueries.ts'
 
+function mediaFileName(url: string): string {
+    const raw = url.split('/').pop()?.split('?')[0] ?? 'media'
+    return /^[a-f0-9]{32}_/.test(raw) ? raw.slice(33) : raw
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -220,7 +225,7 @@ function CommunityPostCard({
 
             {post.media_url && (
                 <a href={post.media_url} target="_blank" rel="noopener noreferrer" className="text-xs text-accent underline truncate">
-                    {post.media_url}
+                    {mediaFileName(post.media_url)}
                 </a>
             )}
         </div>

--- a/web/src/routes/_authorized/communities.$communitySlug.tsx
+++ b/web/src/routes/_authorized/communities.$communitySlug.tsx
@@ -15,9 +15,9 @@ import {
     DialogTitle,
     DialogFooter,
 } from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
+import { MediaUploadField } from '@/components/MediaUploadField'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import {
     communityDetailQueryOptions,
@@ -345,8 +345,8 @@ function CreatePostDialog({
                         <TaggableUsersList communityId={communityId} selected={form.tagged_users ?? []} onChange={(usernames) => setForm((f) => ({ ...f, tagged_users: usernames }))} />
                     </div>
                     <div className="flex flex-col gap-1.5">
-                        <Label htmlFor="cop_create_media">Media URL (optional)</Label>
-                        <Input id="cop_create_media" value={(form.media_url as string) ?? ''} onChange={(e) => setForm((f) => ({ ...f, media_url: e.target.value }))} placeholder="https://…" type="url" />
+                        <Label>Media (optional)</Label>
+                        <MediaUploadField onUrl={url => setForm(f => ({ ...f, media_url: url ?? undefined }))} />
                     </div>
                     <label className="flex items-center gap-2.5 cursor-pointer text-sm">
                         <Checkbox checked={form.show_on_profile} onCheckedChange={(v) => setForm((f) => ({ ...f, show_on_profile: Boolean(v) }))} />
@@ -429,8 +429,8 @@ function EditPostDialog({
                         <TaggableUsersList communityId={communityId} selected={form.tagged_users ?? []} onChange={(usernames) => setForm((f) => ({ ...f, tagged_users: usernames }))} />
                     </div>
                     <div className="flex flex-col gap-1.5">
-                        <Label htmlFor="cop_edit_media">Media URL (optional)</Label>
-                        <Input id="cop_edit_media" value={(form.media_url as string) ?? ''} onChange={(e) => setForm((f) => ({ ...f, media_url: e.target.value }))} placeholder="https://…" type="url" />
+                        <Label>Media (optional)</Label>
+                        <MediaUploadField currentUrl={post.media_url} onUrl={url => setForm(f => ({ ...f, media_url: url ?? undefined }))} />
                     </div>
                     <label className="flex items-center gap-2.5 cursor-pointer text-sm">
                         <Checkbox checked={form.show_on_profile} onCheckedChange={(v) => setForm((f) => ({ ...f, show_on_profile: Boolean(v) }))} />

--- a/web/src/routes/_authorized/connections.$matchId.tsx
+++ b/web/src/routes/_authorized/connections.$matchId.tsx
@@ -50,6 +50,11 @@ export const Route = createFileRoute('/_authorized/connections/$matchId')({
     component: JourneyPage,
 })
 
+function mediaFileName(url: string): string {
+    const raw = url.split('/').pop()?.split('?')[0] ?? 'media'
+    return /^[a-f0-9]{32}_/.test(raw) ? raw.slice(33) : raw
+}
+
 // ---------------------------------------------------------------------------
 // AGTE event metadata
 // ---------------------------------------------------------------------------
@@ -317,7 +322,7 @@ function MCTEItem({
                             rel="noopener noreferrer"
                             className="text-xs text-accent underline truncate"
                         >
-                            {event.media_url}
+                            {mediaFileName(event.media_url)}
                         </a>
                     )}
                     <Muted className="text-xs">{formatTimestamp(event.timestamp)}</Muted>

--- a/web/src/routes/_authorized/connections.$matchId.tsx
+++ b/web/src/routes/_authorized/connections.$matchId.tsx
@@ -22,9 +22,9 @@ import {
     DialogTitle,
     DialogFooter,
 } from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
+import { MediaUploadField } from '@/components/MediaUploadField'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Checkbox } from '@/components/ui/checkbox'
 import { toast } from 'sonner'
@@ -404,13 +404,9 @@ function CreateMCTEDialog({ matchId, open, onOpenChange }: CreateMCTEDialogProps
                         <p className="text-xs text-ink-soft text-right">{form.content.length}/2000</p>
                     </div>
                     <div className="flex flex-col gap-1.5">
-                        <Label htmlFor="media_url">Media URL (optional)</Label>
-                        <Input
-                            id="media_url"
-                            value={form.media_url ?? ''}
-                            onChange={e => setForm(f => ({ ...f, media_url: e.target.value }))}
-                            placeholder="https://..."
-                            type="url"
+                        <Label>Media (optional)</Label>
+                        <MediaUploadField
+                            onUrl={url => setForm(f => ({ ...f, media_url: url ?? undefined }))}
                         />
                     </div>
                     <div className="flex items-center gap-2">
@@ -506,13 +502,10 @@ function EditMCTEDialog({ matchId, event, open, onOpenChange }: EditMCTEDialogPr
                         <p className="text-xs text-ink-soft text-right">{(form.content ?? '').length}/2000</p>
                     </div>
                     <div className="flex flex-col gap-1.5">
-                        <Label htmlFor="edit_media_url">Media URL (optional)</Label>
-                        <Input
-                            id="edit_media_url"
-                            value={form.media_url ?? ''}
-                            onChange={e => setForm(f => ({ ...f, media_url: e.target.value }))}
-                            placeholder="https://..."
-                            type="url"
+                        <Label>Media (optional)</Label>
+                        <MediaUploadField
+                            currentUrl={event.media_url}
+                            onUrl={url => setForm(f => ({ ...f, media_url: url ?? undefined }))}
                         />
                     </div>
                     <div className="flex items-center gap-2">

--- a/web/src/routes/_authorized/messages.tsx
+++ b/web/src/routes/_authorized/messages.tsx
@@ -13,7 +13,7 @@ import { cn, getInitials } from '#/lib/utils.ts'
 import { Button } from '@/components/ui/button'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
-import { Check, CheckCheck, Loader2, MessageSquare, Send } from 'lucide-react'
+import { Check, CheckCheck, Loader2, MessageSquare, Paperclip, Send, X } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState, type SyntheticEvent } from 'react'
 
 export const Route = createFileRoute('/_authorized/messages')({
@@ -173,6 +173,8 @@ function Thread({ conversationId }: { readonly conversationId: string }) {
     const queryClient = useQueryClient()
     const { enqueueMessage, updateMessageStatus, dequeueMessage } = useMessageQueue(conversationId)
     const [text, setText] = useState('')
+    const [attachedFile, setAttachedFile] = useState<File | null>(null)
+    const fileInputRef = useRef<HTMLInputElement>(null)
 
     // Mark conversation as read when opening
     useEffect(() => {
@@ -217,15 +219,17 @@ function Thread({ conversationId }: { readonly conversationId: string }) {
         async (e: SyntheticEvent) => {
             e.preventDefault()
             const body = text.trim()
-            if (!body || sendMessage.isPending) return
+            if ((!body && !attachedFile) || sendMessage.isPending) return
 
             setIsAtBottom(true) // Force scroll to bottom for new message
             const queuedMsg = enqueueMessage(body)
             setText('')
+            setAttachedFile(null)
+            if (fileInputRef.current) fileInputRef.current.value = ''
 
             try {
                 updateMessageStatus(queuedMsg.tempId, 'sending')
-                await sendMessage.mutateAsync(body)
+                await sendMessage.mutateAsync({ body, attachment: attachedFile ?? undefined })
                 dequeueMessage(queuedMsg.tempId)
                 queryClient.invalidateQueries({ queryKey: ['messaging', 'messages', conversationId] })
             } catch (error) {
@@ -233,7 +237,7 @@ function Thread({ conversationId }: { readonly conversationId: string }) {
                 console.error('[Messages] Error sending message:', error)
             }
         },
-        [text, sendMessage, enqueueMessage, updateMessageStatus, dequeueMessage, queryClient, conversationId],
+        [text, attachedFile, sendMessage, enqueueMessage, updateMessageStatus, dequeueMessage, queryClient, conversationId],
     )
 
     return (
@@ -280,34 +284,66 @@ function Thread({ conversationId }: { readonly conversationId: string }) {
             {/* Input */}
             <form
                 onSubmit={handleSubmit}
-                className="shrink-0 border-t border-line px-4 py-3 flex items-end gap-2"
+                className="shrink-0 border-t border-line px-4 py-3 flex flex-col gap-2"
             >
-                <textarea
-                    value={text}
-                    onChange={e => setText(e.target.value)}
-                    onKeyDown={e => {
-                        if (e.key === 'Enter' && !e.shiftKey) {
-                            e.preventDefault()
-                            handleSubmit(e as unknown as SyntheticEvent)
-                        }
-                    }}
-                    placeholder="Type a message… (Enter to send)"
-                    rows={1}
-                    className="flex-1 resize-none rounded-xl border border-line bg-background px-3 py-2 text-sm text-ink placeholder:text-ink-soft focus:outline-none focus:ring-2 focus:ring-accent/40 max-h-32 overflow-y-auto"
-                />
-                <Button
-                    type="submit"
-                    size="icon"
-                    aria-label="Send message"
-                    disabled={!text.trim() || sendMessage.isPending}
-                    className="rounded-xl bg-accent hover:bg-accent/90 text-white shrink-0"
-                >
-                    {sendMessage.isPending ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                        <Send className="h-4 w-4" />
-                    )}
-                </Button>
+                {attachedFile && (
+                    <div className="flex items-center gap-2 rounded-lg border border-line bg-background px-3 py-1.5 text-xs text-ink-soft w-fit max-w-full">
+                        <Paperclip className="h-3.5 w-3.5 shrink-0" />
+                        <span className="truncate">{attachedFile.name}</span>
+                        <button
+                            type="button"
+                            onClick={() => { setAttachedFile(null); if (fileInputRef.current) fileInputRef.current.value = '' }}
+                            className="shrink-0 hover:text-ink"
+                        >
+                            <X className="h-3.5 w-3.5" />
+                        </button>
+                    </div>
+                )}
+                <div className="flex items-end gap-2">
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept="image/*,application/pdf,audio/*"
+                        className="hidden"
+                        onChange={e => setAttachedFile(e.target.files?.[0] ?? null)}
+                    />
+                    <Button
+                        type="button"
+                        size="icon"
+                        variant="ghost"
+                        aria-label="Attach file"
+                        onClick={() => fileInputRef.current?.click()}
+                        className="rounded-xl shrink-0 text-ink-soft hover:text-ink"
+                    >
+                        <Paperclip className="h-4 w-4" />
+                    </Button>
+                    <textarea
+                        value={text}
+                        onChange={e => setText(e.target.value)}
+                        onKeyDown={e => {
+                            if (e.key === 'Enter' && !e.shiftKey) {
+                                e.preventDefault()
+                                handleSubmit(e as unknown as SyntheticEvent)
+                            }
+                        }}
+                        placeholder="Type a message… (Enter to send)"
+                        rows={1}
+                        className="flex-1 resize-none rounded-xl border border-line bg-background px-3 py-2 text-sm text-ink placeholder:text-ink-soft focus:outline-none focus:ring-2 focus:ring-accent/40 max-h-32 overflow-y-auto"
+                    />
+                    <Button
+                        type="submit"
+                        size="icon"
+                        aria-label="Send message"
+                        disabled={(!text.trim() && !attachedFile) || sendMessage.isPending}
+                        className="rounded-xl bg-accent hover:bg-accent/90 text-white shrink-0"
+                    >
+                        {sendMessage.isPending ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                            <Send className="h-4 w-4" />
+                        )}
+                    </Button>
+                </div>
             </form>
         </div>
     )

--- a/web/src/routes/_onBoarding/gettingToKnowYou.tsx
+++ b/web/src/routes/_onBoarding/gettingToKnowYou.tsx
@@ -7,7 +7,7 @@ import { logout, meQueryOptions, useUpdateAppUsageMode } from "#/lib/queries/Aut
 import { useOwnProfile, useUpdateProfile, useUpdateUsername } from "#/lib/queries/ProfileQueries.ts"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute, useRouter } from '@tanstack/react-router'
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 export const Route = createFileRoute('/_onBoarding/gettingToKnowYou')({
     loader: ({ context }) => context.queryClient.ensureQueryData(meQueryOptions),
@@ -61,7 +61,7 @@ const BASE_QUESTIONS: Question[] = [
     },
     {
         key: 'primaryUsage',
-        question: "How will you use Campus Tutor ?",
+        question: "How will you use Neighborship ?",
         clarification: "This helps us personalize your experience.",
         type: 'choice',
         validate: ({ primaryUsage }) =>

--- a/web/src/routes/_public/communities.$communitySlug.tsx
+++ b/web/src/routes/_public/communities.$communitySlug.tsx
@@ -552,7 +552,7 @@ function EditDescriptionModal({
 // Route
 // ---------------------------------------------------------------------------
 
-export const Route = createFileRoute('/_authorized/communities/$communitySlug')({
+export const Route = createFileRoute('/_public/communities/$communitySlug')({
     component: CommunityDetailPage,
 })
 
@@ -573,7 +573,10 @@ export function CommunityDetailPage() {
 
     const { data: me } = useQuery(meQueryOptions)
     const { data: community, isLoading } = useQuery(communityDetailQueryOptions(communitySlug))
-    const { data: membersData } = useQuery(communityMembersQueryOptions(communitySlug, 1, 50))
+    const { data: membersData } = useQuery({
+        ...communityMembersQueryOptions(communitySlug, 1, 50),
+        enabled: !!me,
+    })
     const { matchedUsernames, sendMessageTo } = useMessaging()
 
     const {
@@ -649,36 +652,38 @@ export function CommunityDetailPage() {
             {/* ── Two-column layout: LEFT = members sidebar, RIGHT = header + feed ── */}
             <div className="flex items-start gap-6 px-4 sm:px-6 w-full">
 
-                {/* ── LEFT: Members sidebar ───────────────────────────────── */}
-                <aside className="hidden lg:flex flex-col w-64 shrink-0 sticky top-20 self-start">
-                    <div className="island-shell rounded-xl flex flex-col max-h-[calc(100vh-6rem)] overflow-hidden">
-                        <div className="px-4 py-3 border-b border-line flex items-center justify-between">
-                            <span className="text-sm font-semibold text-ink">Members</span>
-                            <span className="text-xs text-ink-soft">{totalMembers.toLocaleString()}</span>
+                {/* ── LEFT: Members sidebar (authenticated users only) ────── */}
+                {me && (
+                    <aside className="hidden lg:flex flex-col w-64 shrink-0 sticky top-20 self-start">
+                        <div className="island-shell rounded-xl flex flex-col max-h-[calc(100vh-6rem)] overflow-hidden">
+                            <div className="px-4 py-3 border-b border-line flex items-center justify-between">
+                                <span className="text-sm font-semibold text-ink">Members</span>
+                                <span className="text-xs text-ink-soft">{totalMembers.toLocaleString()}</span>
+                            </div>
+                            <div className="overflow-y-auto divide-y divide-line">
+                                {members.length === 0 ? (
+                                    <p className="text-xs text-ink-soft px-4 py-6 text-center">No members yet.</p>
+                                ) : (
+                                    <>
+                                        {members.map((profile) => (
+                                            <MemberCard
+                                                key={profile.id}
+                                                profile={profile}
+                                                onViewProfile={(username) => navigate({ to: '/profiles/$username', params: { username } })}
+                                                onSendMessage={matchedUsernames.has(profile.username) ? sendMessageTo : undefined}
+                                            />
+                                        ))}
+                                        {totalMembers > 50 && (
+                                            <p className="text-xs text-ink-soft px-4 py-3 text-center">
+                                                and {(totalMembers - 50).toLocaleString()} more
+                                            </p>
+                                        )}
+                                    </>
+                                )}
+                            </div>
                         </div>
-                        <div className="overflow-y-auto divide-y divide-line">
-                            {members.length === 0 ? (
-                                <p className="text-xs text-ink-soft px-4 py-6 text-center">No members yet.</p>
-                            ) : (
-                                <>
-                                    {members.map((profile) => (
-                                        <MemberCard
-                                            key={profile.id}
-                                            profile={profile}
-                                            onViewProfile={(username) => navigate({ to: '/profiles/$username', params: { username } })}
-                                            onSendMessage={matchedUsernames.has(profile.username) ? sendMessageTo : undefined}
-                                        />
-                                    ))}
-                                    {totalMembers > 50 && (
-                                        <p className="text-xs text-ink-soft px-4 py-3 text-center">
-                                            and {(totalMembers - 50).toLocaleString()} more
-                                        </p>
-                                    )}
-                                </>
-                            )}
-                        </div>
-                    </div>
-                </aside>
+                    </aside>
+                )}
 
                 {/* ── RIGHT: Community header + feed ──────────────────────── */}
                 <div className="flex-1 min-w-0 flex flex-col gap-5">

--- a/web/src/routes/_public/communities.index.tsx
+++ b/web/src/routes/_public/communities.index.tsx
@@ -32,7 +32,7 @@ import type { CommunityTag } from '@/lib/queries/CommunityQueries.ts'
 const PAGE_SIZE = 6
 const SECTION_CLASS = 'w-full max-w-screen-2xl mx-auto px-4 sm:px-8 md:px-12 lg:px-20 xl:px-28'
 
-export const Route = createFileRoute('/_authorized/communities/')({
+export const Route = createFileRoute('/_public/communities/')({
     component: CommunitiesPage,
 })
 
@@ -47,8 +47,8 @@ interface CommunityRowProps {
     communities: CommunityTag[]
     myIds: Set<string>
     onView: (id: string) => void
-    onJoin: (id: string) => void
-    onLeave: (id: string) => void
+    onJoin: ((id: string) => void) | undefined
+    onLeave: ((id: string) => void) | undefined
     joiningId: string | null
     leavingId: string | null
 }
@@ -238,6 +238,9 @@ export function CommunitiesPage() {
         }
     }, [leaveMutation])
 
+    const onJoin = me ? handleJoin : undefined
+    const onLeave = me ? handleLeave : undefined
+
     return (
         <div className="py-10 sm:py-16 rise-in flex flex-col gap-12">
 
@@ -266,14 +269,16 @@ export function CommunitiesPage() {
                                 <X className="h-4 w-4" />
                             </Button>
                         )}
-                        <Button
-                            className="shrink-0 bg-accent hover:bg-accent-light text-white shadow-sm flex items-center gap-1.5"
-                            size="sm"
-                            onClick={() => setShowCreateModal(true)}
-                        >
-                            <Plus className="h-4 w-4" />
-                            <span className="hidden sm:inline">Create</span>
-                        </Button>
+                        {me && (
+                            <Button
+                                className="shrink-0 bg-accent hover:bg-accent-light text-white shadow-sm flex items-center gap-1.5"
+                                size="sm"
+                                onClick={() => setShowCreateModal(true)}
+                            >
+                                <Plus className="h-4 w-4" />
+                                <span className="hidden sm:inline">Create</span>
+                            </Button>
+                        )}
                     </div>
                 </section>
             </div>
@@ -289,8 +294,8 @@ export function CommunitiesPage() {
                             communities={myCommunities}
                             myIds={myIds}
                             onView={handleView}
-                            onJoin={handleJoin}
-                            onLeave={handleLeave}
+                            onJoin={onJoin}
+                            onLeave={onLeave}
                             joiningId={joiningId}
                             leavingId={leavingId}
                         />
@@ -304,8 +309,8 @@ export function CommunitiesPage() {
                             communities={popularCommunities}
                             myIds={myIds}
                             onView={handleView}
-                            onJoin={handleJoin}
-                            onLeave={handleLeave}
+                            onJoin={onJoin}
+                            onLeave={onLeave}
                             joiningId={joiningId}
                             leavingId={leavingId}
                         />
@@ -332,7 +337,7 @@ export function CommunitiesPage() {
                                 ? (<>No communities found matching <span className="font-semibold text-ink">"{debouncedQuery}"</span>.</>)
                                 : 'No communities yet.'}
                         </p>
-                        {!debouncedQuery && (
+                        {!debouncedQuery && me && (
                             <p className="text-ink-soft text-sm mt-2">
                                 Be the first to{' '}
                                 <button
@@ -353,8 +358,8 @@ export function CommunitiesPage() {
                                 community={community}
                                 isMember={myIds.has(community.id)}
                                 onViewCommunity={handleView}
-                                onJoin={handleJoin}
-                                onLeave={handleLeave}
+                                onJoin={onJoin}
+                                onLeave={onLeave}
                                 isJoining={joiningId === community.id}
                                 isLeaving={leavingId === community.id}
                                 className="h-full"

--- a/web/src/routes/_public/communities.tsx
+++ b/web/src/routes/_public/communities.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Outlet } from '@tanstack/react-router'
 
-export const Route = createFileRoute('/_authorized/communities')({
+export const Route = createFileRoute('/_public/communities')({
     component: () => <Outlet />,
 })

--- a/web/src/routes/_public/discover.tsx
+++ b/web/src/routes/_public/discover.tsx
@@ -20,7 +20,7 @@ const PAGE_SIZE = 6
 const DISCOVER_SECTION_CONTAINER_CLASS =
     'w-full max-w-screen-2xl mx-auto px-4 sm:px-8 md:px-12 lg:px-20 xl:px-28'
 
-export const Route = createFileRoute('/_authorized/discover')({
+export const Route = createFileRoute('/_public/discover')({
     component: DiscoverPage,
 })
 

--- a/web/src/routes/_public/route.tsx
+++ b/web/src/routes/_public/route.tsx
@@ -1,0 +1,23 @@
+import { createFileRoute, Outlet } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
+import { meQueryOptions } from '#/lib/queries/AuthQueries.ts'
+import { AuthorizedHeader } from '@/components/layout/AuthorizedHeader'
+import { UnauthorizedHeader } from '@/components/layout/UnauthorizedHeader'
+import { UnauthorizedFooter } from '@/components/layout/UnauthorizedFooter'
+
+export const Route = createFileRoute('/_public')({
+    component: PublicLayout,
+})
+
+function PublicLayout() {
+    const { data: me } = useQuery(meQueryOptions)
+    return (
+        <div className="flex min-h-screen flex-col bg-black/[0.02] dark:bg-background">
+            {me ? <AuthorizedHeader /> : <UnauthorizedHeader />}
+            <main className="flex-1">
+                <Outlet />
+            </main>
+            {!me && <UnauthorizedFooter />}
+        </div>
+    )
+}

--- a/web/src/routes/_unauthorized/__tests__/register.test.tsx
+++ b/web/src/routes/_unauthorized/__tests__/register.test.tsx
@@ -126,7 +126,7 @@ describe('RegisterPage Component', () => {
     it('renders the left sidebar with branding content', () => {
       render(<RegisterPage />)
 
-      expect(screen.getByText(/Campus Tutor/i)).toBeInTheDocument()
+      expect(screen.getByText(/Neighborship/i)).toBeInTheDocument()
       expect(screen.getByText(/Academic Editorial Excellence/i)).toBeInTheDocument()
       expect(screen.getByText(/Join our community of academic excellence/i)).toBeInTheDocument()
       expect(screen.getByText(/Join 2,000\+ scholars/i)).toBeInTheDocument()

--- a/web/src/routes/_unauthorized/about.tsx
+++ b/web/src/routes/_unauthorized/about.tsx
@@ -67,7 +67,7 @@ function About() {
                 <section className="flex flex-col items-center gap-6 text-center max-w-4xl mx-auto">
                     <p className="text-xs font-semibold uppercase tracking-widest text-accent">About the platform</p>
                     <Display as="h1" className="text-5xl sm:text-6xl md:text-7xl tracking-tight text-ink">
-                        Mentorship,{' '}
+                        Neighborship,{' '}
                         <span className="italic text-accent">Done Right</span>
                     </Display>
                     <p className="text-lg text-ink-soft leading-relaxed max-w-2xl">

--- a/web/src/routes/_unauthorized/about.tsx
+++ b/web/src/routes/_unauthorized/about.tsx
@@ -1,23 +1,176 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { Display, Muted } from '@/components/Typography'
+import { Button } from '@/components/ui/button'
+import { Users, Star, CalendarDays, MessageSquare, TrendingUp, Sparkles } from 'lucide-react'
 
 export const Route = createFileRoute('/_unauthorized/about')({
-  component: About,
+    component: About,
 })
 
+const FEATURES = [
+    {
+        icon: Star,
+        title: 'Verified Mentors',
+        desc: 'Every mentor is rated by their mentees. Find someone trusted by the community, not just an algorithm.',
+    },
+    {
+        icon: CalendarDays,
+        title: 'Flexible Scheduling',
+        desc: 'Book open slots directly on a mentor\'s calendar. No back-and-forth emails, no friction.',
+    },
+    {
+        icon: Users,
+        title: 'Communities',
+        desc: 'Join topic-driven communities, share progress, and learn alongside peers on the same journey.',
+    },
+    {
+        icon: MessageSquare,
+        title: 'Direct Messaging',
+        desc: 'Once connected, message your mentor or mentee any time. Conversations stay in one place.',
+    },
+    {
+        icon: TrendingUp,
+        title: 'Track Your Growth',
+        desc: 'Post achievements, milestones, and progress updates to your profile timeline.',
+    },
+    {
+        icon: Sparkles,
+        title: 'Curated Discovery',
+        desc: 'Filter by skill, rating, and availability to find exactly the mentor you need.',
+    },
+]
+
+const STEPS = [
+    {
+        number: '01',
+        title: 'Create your profile',
+        desc: 'Sign up, pick your role, and fill in your skills or the areas you want to grow in.',
+    },
+    {
+        number: '02',
+        title: 'Find the right match',
+        desc: 'Browse the Discover page, search by skill, and read community reviews before reaching out.',
+    },
+    {
+        number: '03',
+        title: 'Start growing together',
+        desc: 'Book sessions, join communities, post milestones, and build a lasting professional relationship.',
+    },
+]
+
 function About() {
-  return (
-    <main className="page-wrap px-4 py-12 min-h-screen">
-      <section className="island-shell rounded-2xl p-6 sm:p-8">
-        <p className="island-kicker mb-2">About</p>
-        <h1 className="display-title mb-3 text-4xl font-bold text-[var(--sea-ink)] sm:text-5xl">
-          A small starter with room to grow.
-        </h1>
-        <p className="m-0 max-w-3xl text-base leading-8 text-[var(--sea-ink-soft)]">
-          TanStack Start gives you type-safe routing, server functions, and
-          modern SSR defaults. Use this as a clean foundation, then layer in
-          your own routes, styling, and add-ons.
-        </p>
-      </section>
-    </main>
-  )
+    return (
+        <div className="rise-in flex flex-col gap-20 py-16 sm:py-24">
+
+            {/* ── Hero ──────────────────────────────────────────────────── */}
+            <div className="page-wrap">
+                <section className="flex flex-col items-center gap-6 text-center max-w-4xl mx-auto">
+                    <p className="text-xs font-semibold uppercase tracking-widest text-accent">About the platform</p>
+                    <Display as="h1" className="text-5xl sm:text-6xl md:text-7xl tracking-tight text-ink">
+                        Mentorship,{' '}
+                        <span className="italic text-accent">Done Right</span>
+                    </Display>
+                    <p className="text-lg text-ink-soft leading-relaxed max-w-2xl">
+                        We built this platform because finding a great mentor should not be hard.
+                        No cold emails, no LinkedIn guesswork — just a curated network where knowledge flows freely.
+                    </p>
+                    <div className="flex items-center gap-3 pt-2">
+                        <Link to="/register">
+                            <Button className="bg-accent hover:bg-accent-light text-white px-8">
+                                Get started free
+                            </Button>
+                        </Link>
+                        <Link to="/discover">
+                            <Button variant="ghost" className="text-ink-soft hover:text-ink">
+                                Browse mentors →
+                            </Button>
+                        </Link>
+                    </div>
+                </section>
+            </div>
+
+            {/* ── Mission ───────────────────────────────────────────────── */}
+            <div className="page-wrap">
+                <div className="island-shell rounded-2xl p-8 sm:p-12 flex flex-col sm:flex-row gap-10 items-start">
+                    <div className="shrink-0 h-12 w-12 rounded-xl bg-accent/10 flex items-center justify-center">
+                        <Sparkles className="h-6 w-6 text-accent" />
+                    </div>
+                    <div className="flex flex-col gap-3">
+                        <h2 className="text-2xl font-bold text-ink font-display">Our mission</h2>
+                        <p className="text-ink-soft leading-relaxed max-w-3xl">
+                            Careers grow fastest when someone further down the road shares what they wish they had known earlier.
+                            Our mission is to make that conversation happen at scale — connecting ambitious learners with experienced
+                            professionals in a structured, respectful, and productive environment.
+                        </p>
+                        <p className="text-ink-soft leading-relaxed max-w-3xl">
+                            We are built by students and practitioners who experienced both sides of mentorship firsthand.
+                            Every feature here was designed to remove friction and make the relationship as valuable as possible.
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            {/* ── Features grid ─────────────────────────────────────────── */}
+            <div className="page-wrap flex flex-col gap-8">
+                <div className="flex flex-col items-center gap-2 text-center">
+                    <h2 className="text-3xl font-bold text-ink font-display">Everything you need</h2>
+                    <Muted className="max-w-xl">From discovery to deep mentorship — all in one place.</Muted>
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+                    {FEATURES.map(({ icon: Icon, title, desc }) => (
+                        <div key={title} className="island-shell rounded-xl p-6 flex flex-col gap-3 hover:shadow-md transition-shadow">
+                            <div className="h-10 w-10 rounded-lg bg-accent/10 flex items-center justify-center shrink-0">
+                                <Icon className="h-5 w-5 text-accent" />
+                            </div>
+                            <h3 className="font-semibold text-ink">{title}</h3>
+                            <p className="text-sm text-ink-soft leading-relaxed">{desc}</p>
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            {/* ── How it works ──────────────────────────────────────────── */}
+            <div className="page-wrap flex flex-col gap-8">
+                <div className="flex flex-col items-center gap-2 text-center">
+                    <h2 className="text-3xl font-bold text-ink font-display">How it works</h2>
+                    <Muted className="max-w-xl">Three steps from sign-up to your first session.</Muted>
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                    {STEPS.map(({ number, title, desc }) => (
+                        <div key={number} className="flex flex-col gap-4">
+                            <span className="text-5xl font-bold font-display text-accent/20 leading-none">{number}</span>
+                            <h3 className="text-lg font-semibold text-ink">{title}</h3>
+                            <p className="text-sm text-ink-soft leading-relaxed">{desc}</p>
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            {/* ── CTA ───────────────────────────────────────────────────── */}
+            <div className="page-wrap">
+                <div className="island-shell rounded-2xl p-10 sm:p-16 flex flex-col items-center gap-6 text-center">
+                    <Display as="h2" className="text-4xl sm:text-5xl text-ink">
+                        Ready to find your{' '}
+                        <span className="italic text-accent">mentor</span>?
+                    </Display>
+                    <p className="text-ink-soft max-w-xl leading-relaxed">
+                        Join the network today. It is free to sign up, free to discover, and the first session is always yours to arrange.
+                    </p>
+                    <div className="flex items-center gap-3">
+                        <Link to="/register">
+                            <Button className="bg-accent hover:bg-accent-light text-white px-10 py-5 rounded-full text-sm font-bold uppercase tracking-widest shadow-md hover:-translate-y-0.5 transition-all duration-300">
+                                Create your account
+                            </Button>
+                        </Link>
+                        <Link to="/login">
+                            <Button variant="ghost" className="text-ink-soft hover:text-ink">
+                                Sign in
+                            </Button>
+                        </Link>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    )
 }

--- a/web/src/routes/_unauthorized/forgot-password.tsx
+++ b/web/src/routes/_unauthorized/forgot-password.tsx
@@ -1,13 +1,13 @@
-import { createFileRoute, Link } from '@tanstack/react-router'
-import { useState } from 'react'
-import { useMutation } from '@tanstack/react-query'
-import { ArrowLeft, CheckCircle, Mail } from 'lucide-react'
+import { forgotPasswordFn } from '#/lib/queries/AuthQueries.ts'
+import { Body, Display, Heading, Muted } from '@/components/Typography'
 import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Card, CardContent, CardFooter, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
-import { Display, Heading, Body, Muted } from '@/components/Typography'
-import { forgotPasswordFn } from '#/lib/queries/AuthQueries.ts'
+import { useMutation } from '@tanstack/react-query'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { ArrowLeft, CheckCircle, Mail } from 'lucide-react'
+import { useState } from 'react'
 
 export const Route = createFileRoute('/_unauthorized/forgot-password')({
     component: ForgotPasswordPage,
@@ -40,7 +40,7 @@ export function ForgotPasswordPage() {
     return (
         <div className="grid min-h-screen lg:grid-cols-[5fr_4fr]">
             <aside className="hidden lg:flex flex-col px-14 py-12 bg-petal border-r border-line">
-                <Display className="mb-10">Campus Tutor</Display>
+                <Display className="mb-10">Neighborship</Display>
                 <div className="island-shell rounded-2xl px-8 py-10 space-y-6 min-h-3/4 rise-in">
                     <Body className="island-kicker">Account Recovery</Body>
                     <Display as="h2" className="leading-[1.2] max-w-xs">

--- a/web/src/routes/_unauthorized/login.tsx
+++ b/web/src/routes/_unauthorized/login.tsx
@@ -10,12 +10,12 @@ import {
 } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { useGoogleLogin } from '@react-oauth/google'
 import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
 import { CalendarDays, Search, TrendingUp } from 'lucide-react'
-import { useGoogleLogin } from '@react-oauth/google'
 
-import { handleAuthSuccess, loginFn, googleLoginFn } from "#/lib/queries/AuthQueries.ts"
 import { requestForToken } from "#/lib/firebase-client"
+import { googleLoginFn, handleAuthSuccess, loginFn } from "#/lib/queries/AuthQueries.ts"
 import { useMutation } from "@tanstack/react-query"
 import { useState } from "react"
 
@@ -83,14 +83,14 @@ export function LoginPage() {
         <div className="grid min-h-screen lg:grid-cols-[5fr_4fr]">
 
             <aside className="lg:flex flex-col px-14 py-12 bg-petal border-r border-line">
-                <Display className="mb-10">Campus Tutor</Display>
+                <Display className="mb-10">Neighborship</Display>
                 <div className="island-shell rounded-2xl px-8 py-10 space-y-6 min-h-3/4 rise-in">
                     <Body className="island-kicker">Peer tutoring platform</Body>
                     <Display as="h2" className="leading-[1.2] max-w-xs">
                         Study better,<br />together.
                     </Display>
                     <Body className="text-(--color-brand-ink-soft) max-w-90">
-                        Find tutors from your own campus, book sessions around your
+                        Find mentors from your own campus, book sessions around your
                         schedule, and actually understand the material.
                     </Body>
                     <ul className="flex flex-col gap-6">

--- a/web/src/routes/_unauthorized/register.tsx
+++ b/web/src/routes/_unauthorized/register.tsx
@@ -1,21 +1,21 @@
-import {createFileRoute, Link, useRouter} from '@tanstack/react-router'
-import { z } from 'zod'
-import { useState } from 'react'
+import { requestForToken } from "#/lib/firebase-client"
+import { googleLoginFn, handleAuthSuccess, registerFn } from "#/lib/queries/AuthQueries.ts"
+import { Body, Display, Heading, Muted } from "@/components/Typography"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Checkbox } from "@/components/ui/checkbox"
 import {
     Card,
     CardContent,
     CardFooter,
 } from "@/components/ui/card"
-import { Heading, Body, Display, Muted } from "@/components/Typography"
-import { User, Mail } from 'lucide-react'
-import {useMutation} from "@tanstack/react-query";
-import {handleAuthSuccess, registerFn, googleLoginFn} from "#/lib/queries/AuthQueries.ts";
-import { requestForToken } from "#/lib/firebase-client";
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
 import { useGoogleLogin } from '@react-oauth/google'
+import { useMutation } from "@tanstack/react-query"
+import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
+import { Mail, User } from 'lucide-react'
+import { useState } from 'react'
+import { z } from 'zod'
 
 
 
@@ -125,7 +125,7 @@ export function RegisterPage() {
         <div className="grid min-h-screen lg:grid-cols-[5fr_4fr]">
             {/* Left Column: Editorial Content */}
             <aside className="lg:flex flex-col px-14 py-12 bg-petal border-r border-line relative overflow-hidden">
-                <Display className="mb-10 relative z-10">Campus Tutor</Display>
+                <Display className="mb-10 relative z-10">Neighborship</Display>
 
                 <div className="island-shell rounded-2xl px-8 py-10 space-y-6 min-h-3/4 relative z-10 rise-in">
                     <Body className="island-kicker">Academic Editorial Excellence</Body>

--- a/web/src/routes/_unauthorized/reset-password.tsx
+++ b/web/src/routes/_unauthorized/reset-password.tsx
@@ -1,13 +1,13 @@
-import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
-import { useState } from 'react'
-import { useMutation } from '@tanstack/react-query'
-import { ArrowLeft, CheckCircle, KeyRound, XCircle } from 'lucide-react'
+import { clearAuthState, resetPasswordFn } from '#/lib/queries/AuthQueries.ts'
+import { Body, Display, Heading, Muted } from '@/components/Typography'
 import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Card, CardContent, CardFooter, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
-import { Display, Heading, Body, Muted } from '@/components/Typography'
-import { resetPasswordFn, clearAuthState } from '#/lib/queries/AuthQueries.ts'
+import { useMutation } from '@tanstack/react-query'
+import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
+import { ArrowLeft, CheckCircle, KeyRound, XCircle } from 'lucide-react'
+import { useState } from 'react'
 
 export const Route = createFileRoute('/_unauthorized/reset-password')({
     component: ResetPasswordPage,
@@ -66,7 +66,7 @@ export function ResetPasswordPage() {
     return (
         <div className="grid min-h-screen lg:grid-cols-[5fr_4fr]">
             <aside className="hidden lg:flex flex-col px-14 py-12 bg-petal border-r border-line">
-                <Display className="mb-10">Campus Tutor</Display>
+                <Display className="mb-10">Neighborship</Display>
                 <div className="island-shell rounded-2xl px-8 py-10 space-y-6 min-h-3/4 rise-in">
                     <Body className="island-kicker">Account Recovery</Body>
                     <Display as="h2" className="leading-[1.2] max-w-xs">


### PR DESCRIPTION
## Related Issue

  Closes #522 #517   (duplicates)

  ## Description

  Makes Discover, Communities, and Community Detail pages accessible to unauthenticated (guest) users, without allowing any write actions. Also redesigns the unauthorized header and About
  page to match the authorized header's style.

  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [x] Refactoring (no functional changes)
  - [ ] Documentation
  - [ ] CI/CD or configuration

  ## Checklist

  - [x] I have tested my changes locally
  - [x] My code builds without errors
  - [ ] I have written or updated tests where applicable
  - [x] I have performed a self-review of my code

  ## Notes

  **Guest access rules:**
  - **Discover** — fully visible; search and filters work; no send-message buttons
  - **Communities list** — visible and searchable; Create, Join, and Leave buttons hidden for guests
  - **Community detail** — community info and member count visible; member list sidebar and feed hidden (feed shows "Members only" lock)
  - **Profiles** — unchanged; already guest-accessible; posts remain hidden for guests by design

  **Refactoring:**
  - Introduced a `_public` layout group (`routes/_public/`) that shows the correct header based on auth state without redirecting guests. Discover and Communities routes moved from
  `_authorized` into `_public`.
  - `conversationsQueryOptions` now has `enabled: !!token` to prevent unauthenticated API calls on public pages.
  - `CommunityCard` hides the Join/Leave button when `onJoin` is not passed.
  - `UnauthorizedHeader` restyled to match `AuthorizedHeader` (logo, nav pill highlights, token names).
  - About page rewritten with hero, mission, features grid, how-it-works steps, and CTA.
