### PR TITLE
feat: View and Control Workshops From Profile

### DIFF
--- a/backend/mentorship/serializers.py
+++ b/backend/mentorship/serializers.py
@@ -794,6 +794,29 @@ class WorkshopParticipantCreateSerializer(serializers.Serializer):
     show_on_profile = serializers.BooleanField(default=False, required=False)
 
 
+class WorkshopAttendanceUpdateSerializer(serializers.Serializer):
+    """Write serializer for profile-scoped attendance updates."""
+
+    show_on_profile = serializers.BooleanField(required=False)
+    title = serializers.CharField(max_length=255, required=False)
+    description = serializers.CharField(required=False, allow_blank=True)
+    scheduled_at = serializers.DateTimeField(required=False)
+    end_at = serializers.DateTimeField(required=False)
+    max_participants = serializers.IntegerField(min_value=1, required=False)
+    status = serializers.ChoiceField(
+        choices=[Workshop.Status.SCHEDULED, Workshop.Status.COMPLETED, Workshop.Status.CANCELLED],
+        required=False,
+    )
+
+    def validate(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Require at least one supported attendance/workshop field."""
+        if not data:
+            raise serializers.ValidationError(
+                "Provide at least one updatable field for attendance or workshop."
+            )
+        return data
+
+
 class WorkshopAttendanceQueryParamsSerializer(serializers.Serializer):
     """Query params for profile-scoped workshop attendance endpoints."""
 

--- a/backend/profiles/tests.py
+++ b/backend/profiles/tests.py
@@ -5581,6 +5581,7 @@ class CommunityTagWorkshopsAPITests(TestCase):
             ).exists()
         )
 
+
 class ProfileWorkshopAttendanceAPITests(TestCase):
     """Tests for profile-scoped workshop attendance endpoints."""
 
@@ -5656,8 +5657,24 @@ class ProfileWorkshopAttendanceAPITests(TestCase):
             show_on_profile=True,
         )
 
+        self.authored_workshop = Workshop.objects.create(
+            community=self.tag,
+            author=self.author_profile,
+            title="Authored Workshop",
+            description="Managed from profile",
+            scheduled_at=now + timedelta(days=2),
+            end_at=now + timedelta(days=2, hours=2),
+            max_participants=20,
+        )
+        WorkshopParticipant.objects.create(
+            workshop=self.authored_workshop,
+            participant=self.author_profile,
+            show_on_profile=False,
+        )
+
         self.owner_token = _token_for_profile_tests(self.owner_user)
         self.viewer_token = _token_for_profile_tests(self.viewer_user)
+        self.author_token = _token_for_profile_tests(self.author_user)
 
     def test_me_attendance_list_returns_all_owner_records(self) -> None:
         self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.owner_token}")
@@ -5723,3 +5740,49 @@ class ProfileWorkshopAttendanceAPITests(TestCase):
         )
 
         self.assertEqual(response.status_code, 400)
+
+    def test_author_can_patch_workshop_fields_from_profile(self) -> None:
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.author_token}")
+
+        response = self.client.patch(
+            f"/api/profiles/me/workshops/attendance/{self.authored_workshop.id}/",
+            {"title": "Authored Workshop Updated", "max_participants": 25},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.authored_workshop.refresh_from_db()
+        self.assertEqual(self.authored_workshop.title, "Authored Workshop Updated")
+        self.assertEqual(self.authored_workshop.max_participants, 25)
+
+    def test_non_author_cannot_patch_workshop_fields_from_profile(self) -> None:
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.owner_token}")
+
+        response = self.client.patch(
+            f"/api/profiles/me/workshops/attendance/{self.upcoming_workshop.id}/",
+            {"title": "Should not work"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_author_delete_from_profile_cancels_workshop(self) -> None:
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.author_token}")
+
+        response = self.client.delete(
+            f"/api/profiles/me/workshops/attendance/{self.authored_workshop.id}/"
+        )
+
+        self.assertEqual(response.status_code, 204)
+        self.authored_workshop.refresh_from_db()
+        self.assertEqual(self.authored_workshop.status, Workshop.Status.CANCELLED)
+
+    def test_attendance_participants_list_available_from_profile(self) -> None:
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.owner_token}")
+
+        response = self.client.get(
+            f"/api/profiles/me/workshops/attendance/{self.upcoming_workshop.id}/participants/"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertGreaterEqual(response.data["count"], 1)

--- a/backend/profiles/urls.py
+++ b/backend/profiles/urls.py
@@ -27,6 +27,7 @@ from .views import (
     MyTagsListAPIView,
     MyWorkshopAttendanceDetailAPIView,
     MyWorkshopAttendanceListAPIView,
+    MyWorkshopAttendanceParticipantsListAPIView,
     PopularMentorsListAPIView,
     PopularTagsListAPIView,
     PostMediaUploadAPIView,
@@ -56,6 +57,11 @@ urlpatterns = [
         "me/workshops/attendance/<uuid:workshop_id>/",
         MyWorkshopAttendanceDetailAPIView.as_view(),
         name="profile-me-workshop-attendance-detail",
+    ),
+    path(
+        "me/workshops/attendance/<uuid:workshop_id>/participants/",
+        MyWorkshopAttendanceParticipantsListAPIView.as_view(),
+        name="profile-me-workshop-attendance-participants-list",
     ),
     path("me/posts/", MyProfilePostsCollectionAPIView.as_view(), name="profile-posts-me-create"),
     path(

--- a/backend/profiles/views.py
+++ b/backend/profiles/views.py
@@ -27,6 +27,7 @@ from mentorship.serializers import (
     WorkshopAttendanceFeedSerializer,
     WorkshopAttendanceItemSerializer,
     WorkshopAttendanceQueryParamsSerializer,
+    WorkshopAttendanceUpdateSerializer,
     WorkshopCreateSerializer,
     WorkshopDetailSerializer,
     WorkshopFeedSerializer,
@@ -2883,25 +2884,63 @@ class MyWorkshopAttendanceDetailAPIView(ProfileLookupMixin, APIView):
 
     @extend_schema(
         operation_id="profile_me_workshop_attendance_detail_patch",
-        request=WorkshopParticipantCreateSerializer,
+        request=WorkshopAttendanceUpdateSerializer,
         responses={
             200: WorkshopAttendanceItemSerializer,
+            400: OpenApiResponse(description="Validation error."),
+            403: OpenApiResponse(description="Only author can modify workshop fields."),
             404: OpenApiResponse(description="Attendance not found."),
         },
         tags=["Profiles"],
     )
     def patch(self, request: Request, workshop_id: str) -> Response:
-        """Update current user's show_on_profile for a workshop attendance."""
+        """Update attendance visibility and (author-only) workshop fields."""
         attendance = self._get_my_attendance_or_404(request, workshop_id)
         if attendance is None:
             return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
 
-        payload = WorkshopParticipantCreateSerializer(data=request.data)
-        payload.is_valid(raise_exception=True)
-        attendance.show_on_profile = payload.validated_data.get(
-            "show_on_profile", attendance.show_on_profile
-        )
-        attendance.save(update_fields=["show_on_profile"])
+        patch_payload = WorkshopAttendanceUpdateSerializer(data=request.data)
+        patch_payload.is_valid(raise_exception=True)
+        data = patch_payload.validated_data
+        workshop_editable_fields = {
+            "title",
+            "description",
+            "scheduled_at",
+            "end_at",
+            "max_participants",
+            "status",
+        }
+        has_visibility_update = "show_on_profile" in data
+        workshop_patch_data = {key: data[key] for key in workshop_editable_fields if key in data}
+
+        if not has_visibility_update and not workshop_patch_data:
+            return Response(
+                {
+                    "detail": (
+                        "Provide at least one updatable field: show_on_profile or workshop fields."
+                    )
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if has_visibility_update:
+            attendance.show_on_profile = data.get("show_on_profile", attendance.show_on_profile)
+            attendance.save(update_fields=["show_on_profile"])
+
+        if workshop_patch_data:
+            if attendance.workshop.author_id != attendance.participant_id:
+                return Response(
+                    {"detail": "Only workshop author can update workshop fields."},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+
+            workshop_payload = WorkshopUpdateSerializer(
+                data=workshop_patch_data,
+                context={"request": request, "workshop": attendance.workshop},
+            )
+            workshop_payload.is_valid(raise_exception=True)
+            workshop_payload.update(attendance.workshop, workshop_payload.validated_data)
+            attendance.refresh_from_db()
 
         return Response(
             WorkshopAttendanceItemSerializer(attendance, context={"request": request}).data,
@@ -2919,10 +2958,15 @@ class MyWorkshopAttendanceDetailAPIView(ProfileLookupMixin, APIView):
         tags=["Profiles"],
     )
     def delete(self, request: Request, workshop_id: str) -> Response:
-        """Remove current user's workshop attendance if workshop has not ended."""
+        """Cancel workshop if author, otherwise leave attendance before workshop end."""
         attendance = self._get_my_attendance_or_404(request, workshop_id)
         if attendance is None:
             return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
+
+        if attendance.workshop.author_id == attendance.participant_id:
+            attendance.workshop.status = Workshop.Status.CANCELLED
+            attendance.workshop.save(update_fields=["status", "updated_at"])
+            return Response(status=status.HTTP_204_NO_CONTENT)
 
         if attendance.workshop.is_past_end_time():
             return Response(
@@ -2952,6 +2996,100 @@ class MyWorkshopAttendanceDetailAPIView(ProfileLookupMixin, APIView):
                 "participant",
                 "participant__user",
             )
+            .filter(workshop_id=workshop_id, participant=profile)
+            .first()
+        )
+
+
+class MyWorkshopAttendanceParticipantsListAPIView(ProfileLookupMixin, APIView):
+    """List participants for a workshop the authenticated user is attending."""
+
+    permission_classes = [IsUser]
+
+    @extend_schema(
+        operation_id="profile_me_workshop_attendance_participants_list",
+        parameters=[
+            OpenApiParameter(
+                name="offset",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=OpenApiTypes.INT,
+                description="Zero-based index of the first item to include. Default: 0.",
+            ),
+            OpenApiParameter(
+                name="limit",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=OpenApiTypes.INT,
+                description="Maximum number of items to return. Default: 50. Maximum: 200.",
+            ),
+        ],
+        responses={
+            200: WorkshopParticipantFeedSerializer,
+            400: OpenApiResponse(description="Invalid query parameters."),
+            404: OpenApiResponse(description="Attendance or workshop not found."),
+        },
+        tags=["Profiles"],
+    )
+    def get(self, request: Request, workshop_id: str) -> Response:
+        """Return participants for workshop if requester has attendance record."""
+        attendance = self._get_my_attendance_or_404(request, workshop_id)
+        if attendance is None:
+            return Response(NOT_FOUND_DETAIL, status=status.HTTP_404_NOT_FOUND)
+
+        offset_raw = request.query_params.get("offset", "0")
+        limit_raw = request.query_params.get("limit", "50")
+        try:
+            offset = int(offset_raw)
+            limit = int(limit_raw)
+        except (TypeError, ValueError):
+            return Response(
+                {"detail": "`offset` and `limit` must be integers."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if offset < 0:
+            return Response(
+                {"detail": "`offset` must be >= 0."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if limit < 1:
+            return Response(
+                {"detail": "`limit` must be >= 1."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        limit = min(limit, 200)
+
+        queryset = attendance.workshop.participants.select_related(
+            "participant",
+            "participant__user",
+        ).order_by("joined_at")
+        total_count = queryset.count()
+        rows = list(queryset[offset : offset + limit])
+
+        serializer = WorkshopParticipantSerializer(rows, many=True)
+        return Response(
+            {
+                "count": total_count,
+                "offset": offset,
+                "limit": limit,
+                "results": serializer.data,
+            },
+            status=status.HTTP_200_OK,
+        )
+
+    def _get_my_attendance_or_404(
+        self,
+        request: Request,
+        workshop_id: str,
+    ) -> WorkshopParticipant | None:
+        """Resolve authenticated user's workshop attendance by workshop ID."""
+        profile = self._get_request_profile_or_404(request)
+        if profile is None:
+            return None
+
+        return (
+            WorkshopParticipant.objects.select_related("workshop")
             .filter(workshop_id=workshop_id, participant=profile)
             .first()
         )


### PR DESCRIPTION
# Related Issue

Closes #554 

## Description

This PR enhances the workshop management capabilities specifically from the user's profile context. It allows workshop authors to manage their workshops directly from their "My Workshops" view without needing to navigate back to the community page.

**Key Changes:**
1.  **Author Management from Profile**: 
    *   Updated `PATCH /api/profiles/me/workshops/attendance/{workshop_id}/` to allow authors to update workshop details (title, description, time, capacity, status) alongside their visibility preference.
    *   Updated `DELETE /api/profiles/me/workshops/attendance/{workshop_id}/` to perform a workshop cancellation (soft-delete) if the requester is the author.
2.  **Attendance Participants List**: 
    *   Added a new endpoint `GET /api/profiles/me/workshops/attendance/{workshop_id}/participants/` allowing users to view the participant list of any workshop they are enrolled in.
3.  **Serializers & Validation**: 
    *   Implemented `WorkshopAttendanceUpdateSerializer` to handle the dual-purpose update logic (visibility + workshop fields).
    *   Ensured strict author-only permission checks for workshop field modifications within the profile-scoped views.
4.  **Testing**: 
    *   Added comprehensive unit tests for the new profile-scoped management and participant list endpoints.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or configuration

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code

## Notes

These changes specifically target the UX for authors managing workshops from their profile page. The core workshop logic remains consistent with the previous backend implementation but is now exposed through more convenient, user-centric endpoints.