### PR TITLE
Feat/web UI enhance

### DIFF
--- a/web/src/components/MediaAttachment.tsx
+++ b/web/src/components/MediaAttachment.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react'
+import { cn, getAbsoluteMediaUrl } from '@/lib/utils'
+
+export function mediaFileName(url: string): string {
+    const raw = url.split('/').pop()?.split('?')[0] ?? 'media'
+    return /^[a-f0-9]{32}_/.test(raw) ? raw.slice(33) : raw
+}
+
+function isPdfUrl(url: string): boolean {
+    return url.split('?')[0].toLowerCase().endsWith('.pdf')
+}
+
+interface MediaAttachmentProps {
+    url: string
+    imgClassName?: string
+    linkClassName?: string
+}
+
+export function MediaAttachment({ url, imgClassName, linkClassName }: MediaAttachmentProps) {
+    const absUrl = getAbsoluteMediaUrl(url)
+    const [imgFailed, setImgFailed] = useState(isPdfUrl(absUrl))
+
+    if (!imgFailed) {
+        return (
+            <a href={absUrl} target="_blank" rel="noopener noreferrer" className="block">
+                <img
+                    src={absUrl}
+                    alt={mediaFileName(url)}
+                    className={cn('max-h-60 rounded-lg border border-line object-contain', imgClassName)}
+                    onError={() => setImgFailed(true)}
+                />
+            </a>
+        )
+    }
+
+    return (
+        <a
+            href={absUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={cn('text-xs text-accent-aa underline truncate block', linkClassName)}
+        >
+            {mediaFileName(url)}
+        </a>
+    )
+}

--- a/web/src/components/NavLink.tsx
+++ b/web/src/components/NavLink.tsx
@@ -10,13 +10,12 @@ export function NavLink({ className, ...props }: NavLinkProps) {
     return (
         <Link
             className={cn(
-                'text-sm text-brand-ink-soft hover:text-brand-ink transition-colors',
+                'text-sm text-ink-soft hover:text-ink transition-colors',
                 className
             )}
             activeProps={{
                 className: cn(
-                    'hover:text-ink) transition-colors',
-                    'text-kicker',
+                    'text-ink font-semibold',
                     className
                 )
             }}

--- a/web/src/components/features/discover/DiscoverFilterPanel.tsx
+++ b/web/src/components/features/discover/DiscoverFilterPanel.tsx
@@ -68,7 +68,7 @@ export function DiscoverFilterPanel({
               <button
                 type="button"
                 onClick={onClear}
-                className="flex items-center gap-1 text-xs text-accent hover:text-accent-light font-semibold transition-colors"
+                className="flex items-center gap-1 text-xs text-accent-aa hover:text-accent font-semibold transition-colors"
               >
                 <X className="h-3 w-3" />
                 Clear all
@@ -90,7 +90,7 @@ export function DiscoverFilterPanel({
                     'px-3 py-1 rounded-full text-xs font-bold uppercase tracking-wider transition-all duration-150',
                     active
                       ? 'bg-accent text-white shadow-sm scale-105'
-                      : 'bg-accent-muted text-primary hover:bg-accent/20 border border-accent/10',
+                      : 'bg-accent-muted text-ink hover:bg-accent/20 border border-accent/10',
                   )}
                 >
                   {skill}

--- a/web/src/components/features/discover/DiscoverSearchBar.tsx
+++ b/web/src/components/features/discover/DiscoverSearchBar.tsx
@@ -20,7 +20,7 @@ export function DiscoverSearchBar({
   return (
     <div className={cn('relative w-full', className)}>
       <div className="absolute inset-y-0 left-5 flex items-center pointer-events-none">
-        <Search className="h-6 w-6 text-ink-soft" />
+        <Search className="h-6 w-6 text-ink-soft" aria-hidden="true" />
       </div>
       <input
         type="text"

--- a/web/src/components/features/discover/ProfileCard.tsx
+++ b/web/src/components/features/discover/ProfileCard.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/ui/button'
 import { Body } from '@/components/Typography'
-import { cn } from '@/lib/utils'
+import { cn, getAbsoluteMediaUrl } from '@/lib/utils'
 import type { PublicMentorProfile } from '@/lib/queries/DiscoverQueries.ts'
 
 interface ProfileCardProps {
@@ -35,7 +35,7 @@ function ProfileAvatar({
   if (pictureUrl && !showInitialsOnly) {
     return (
         <img
-            src={pictureUrl}
+            src={getAbsoluteMediaUrl(pictureUrl)}
             alt={displayName}
             className="h-20 w-20 rounded-full object-cover shrink-0 border border-line shadow-sm"
         />

--- a/web/src/components/features/discover/ProfileCard.tsx
+++ b/web/src/components/features/discover/ProfileCard.tsx
@@ -63,7 +63,7 @@ export function ProfileCard({
   return (
       <div
           className={cn(
-              'island-shell rounded-xl p-8 flex flex-col gap-6 shadow-md hover:shadow-xl/30',
+              'island-shell rounded-xl p-8 flex flex-col gap-6 shadow-md hover:shadow-xl/30 transition-shadow duration-200',
               className,
           )}
       >
@@ -78,16 +78,16 @@ export function ProfileCard({
             <h3 className="font-display text-2xl font-bold text-ink leading-tight truncate">
               {profile.full_name}
             </h3>
-            <p className="text-accent font-medium text-sm mt-0.5">{profile.title}</p>
+            <p className="text-accent-aa font-medium text-sm mt-0.5">{profile.title}</p>
           </div>
         </div>
 
         {/* Expertises */}
-        <div className="px-6 pb-6 pt-2 flex flex-wrap gap-2 text-sm z-10 relative">
+        <div className="flex flex-wrap gap-2">
           {profile.skills?.slice(0, 3).map((skill) => (
             <span
               key={skill}
-              className="px-3 py-1 bg-accent-muted text-primary text-xs font-bold uppercase tracking-wider rounded-full border border-accent/10"
+              className="px-3 py-1 bg-accent-muted text-ink text-xs font-bold uppercase tracking-wider rounded-full border border-accent/10"
             >
               {skill}
             </span>

--- a/web/src/components/layout/AuthorizedHeader.tsx
+++ b/web/src/components/layout/AuthorizedHeader.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button'
 import { logout, meQueryOptions } from "#/lib/queries/AuthQueries.ts"
 import { useQuery } from "@tanstack/react-query"
 import { useProfile } from "#/lib/queries/ProfileQueries.ts"
-import { getInitials } from "#/lib/utils.ts"
+import { getAbsoluteMediaUrl, getInitials } from "#/lib/utils.ts"
 import { useNotifications } from "#/lib/queries/NotificationQueries.ts"
 
 export function AuthorizedHeader() {
@@ -116,7 +116,7 @@ export function AuthorizedHeader() {
                 className="h-8 w-8 rounded-full overflow-hidden bg-accent text-background flex items-center justify-center text-sm font-bold shadow-sm transition hover:brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
             >
               {profile?.picture_url
-                ? <img src={profile.picture_url} alt={initials} className="h-full w-full object-cover" />
+                ? <img src={getAbsoluteMediaUrl(profile.picture_url)} alt={initials} className="h-full w-full object-cover" />
                 : initials}
             </Link>
             <Button

--- a/web/src/components/layout/AuthorizedHeader.tsx
+++ b/web/src/components/layout/AuthorizedHeader.tsx
@@ -11,8 +11,10 @@ export function AuthorizedHeader() {
   const { data: profile } = useProfile(me?.username ?? '')
   const { data: notifications = [] } = useNotifications()
 
-  const hasUnread = notifications.some(n => !n.is_read && n.type !== 'new_message')
-  const hasMessageNotification = notifications.some(n => n.type === 'new_message' && !n.is_read)
+  const unreadCount = notifications.filter(n => !n.is_read && n.type !== 'new_message').length
+  const unreadMessageCount = notifications.filter(n => n.type === 'new_message' && !n.is_read).length
+  const hasUnread = unreadCount > 0
+  const hasMessageNotification = unreadMessageCount > 0
 
   const initials = profile?.full_name
       ? getInitials(profile.full_name)
@@ -42,7 +44,10 @@ export function AuthorizedHeader() {
                 <span className="relative">
                   Dashboard
                   {hasUnread && (
-                    <span className="absolute -top-1 -right-2.5 h-2 w-2 rounded-full bg-accent" />
+                    <span className="absolute -top-2 -right-3.5 min-w-[1.1rem] h-[1.1rem] px-0.5 rounded-full bg-accent text-white text-[10px] font-bold flex items-center justify-center leading-none">
+                      {unreadCount > 9 ? '9+' : unreadCount}
+                      <span className="sr-only"> unread notifications</span>
+                    </span>
                   )}
                 </span>
               </Link>
@@ -83,7 +88,10 @@ export function AuthorizedHeader() {
                 <span className="relative">
                   Messages
                   {hasMessageNotification && (
-                    <span className="absolute -top-1 -right-2.5 h-2 w-2 rounded-full bg-accent" />
+                    <span className="absolute -top-2 -right-3.5 min-w-[1.1rem] h-[1.1rem] px-0.5 rounded-full bg-accent text-white text-[10px] font-bold flex items-center justify-center leading-none">
+                      {unreadMessageCount > 9 ? '9+' : unreadMessageCount}
+                      <span className="sr-only"> unread messages</span>
+                    </span>
                   )}
                 </span>
               </Link>
@@ -104,7 +112,7 @@ export function AuthorizedHeader() {
             <Link
                 to="/profiles/$username"
                 params={{ username: me?.username ?? '' }}
-                aria-label="Open profile page"
+                aria-label={`${profile?.full_name ?? me?.username ?? 'My'} profile`}
                 className="h-8 w-8 rounded-full overflow-hidden bg-accent text-background flex items-center justify-center text-sm font-bold shadow-sm transition hover:brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
             >
               {profile?.picture_url

--- a/web/src/components/profile/AvailabilityCalendar.tsx
+++ b/web/src/components/profile/AvailabilityCalendar.tsx
@@ -106,8 +106,8 @@ function CancelModal({ slot, username, onClose, onSuccess }: CancelModalProps) {
             <div className="relative z-10 w-full max-w-sm rounded-3xl island-shell shadow-2xl flex flex-col">
                 <div className="flex items-start justify-between px-6 pt-6 pb-4 border-b border-line">
                     <h2 className="text-lg font-semibold text-ink">Cancel booking?</h2>
-                    <button onClick={onClose} className="rounded-xl p-1.5 hover:bg-accent-muted transition-colors text-ink-soft hover:text-ink">
-                        <X className="h-5 w-5" />
+                    <button onClick={onClose} aria-label="Close" className="rounded-xl p-1.5 hover:bg-accent-muted transition-colors text-ink-soft hover:text-ink">
+                        <X className="h-5 w-5" aria-hidden="true" />
                     </button>
                 </div>
                 <div className="px-6 py-5">
@@ -202,8 +202,8 @@ function BookingModal({ slot, mentorUsername, isFirstTime, onClose, onSuccess }:
                                 : 'You already have a match with this mentor — book directly.'}
                         </Muted>
                     </div>
-                    <button onClick={onClose} className="rounded-xl p-1.5 hover:bg-accent-muted transition-colors text-ink-soft hover:text-ink">
-                        <X className="h-5 w-5" />
+                    <button onClick={onClose} aria-label="Close" className="rounded-xl p-1.5 hover:bg-accent-muted transition-colors text-ink-soft hover:text-ink">
+                        <X className="h-5 w-5" aria-hidden="true" />
                     </button>
                 </div>
 
@@ -346,11 +346,11 @@ export function AvailabilityCalendar({ username, isOwner, isAuthenticated }: Ava
 
     return (
         <>
-            <Card className="border-line bg-white/70 shadow-sm">
+            <Card className="border-line bg-card shadow-sm">
                 <CardHeader>
                     <div className="flex items-center justify-between">
                         <CardTitle className="text-lg flex items-center gap-2">
-                            <CalendarDays className="h-4 w-4" />
+                            <CalendarDays className="h-4 w-4" aria-hidden="true" />
                             Availability
                         </CardTitle>
                         <div className="flex items-center gap-2">
@@ -359,8 +359,9 @@ export function AvailabilityCalendar({ username, isOwner, isAuthenticated }: Ava
                                 onClick={() => setWeekOffset(o => Math.max(o - 1, -4))}
                                 disabled={weekOffset <= -4}
                                 className="h-7 w-7 p-0"
+                                aria-label="Previous week"
                             >
-                                <ChevronLeft className="h-4 w-4" />
+                                <ChevronLeft className="h-4 w-4" aria-hidden="true" />
                             </Button>
                             <span className="text-xs text-ink-soft min-w-[140px] text-center">{weekLabel}</span>
                             <Button
@@ -368,8 +369,9 @@ export function AvailabilityCalendar({ username, isOwner, isAuthenticated }: Ava
                                 onClick={() => setWeekOffset(o => Math.min(o + 1, 4))}
                                 disabled={weekOffset >= 4}
                                 className="h-7 w-7 p-0"
+                                aria-label="Next week"
                             >
-                                <ChevronRight className="h-4 w-4" />
+                                <ChevronRight className="h-4 w-4" aria-hidden="true" />
                             </Button>
                         </div>
                     </div>

--- a/web/src/components/profile/EditProfileModal.tsx
+++ b/web/src/components/profile/EditProfileModal.tsx
@@ -128,7 +128,7 @@ export function EditProfileModal({ mode, initialValues, onClose }: EditProfileMo
                         className="rounded-xl p-1.5 hover:bg-accent-muted transition-colors text-ink-soft hover:text-ink"
                         aria-label="Close"
                     >
-                        <X className="h-5 w-5" />
+                        <X className="h-5 w-5" aria-hidden="true" />
                     </button>
                 </div>
 
@@ -161,7 +161,7 @@ export function EditProfileModal({ mode, initialValues, onClose }: EditProfileMo
                                     {me?.username?.[0]?.toUpperCase() ?? '?'}
                                 </div>
                             )}
-                            <span className="absolute inset-0 rounded-full bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                            <span className="absolute inset-0 rounded-full bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center" aria-hidden="true">
                                 {uploadPicture.isPending
                                     ? <Loader2 className="h-6 w-6 text-white animate-spin" />
                                     : <Camera className="h-6 w-6 text-white" />
@@ -185,7 +185,7 @@ export function EditProfileModal({ mode, initialValues, onClose }: EditProfileMo
                                 className="bg-background"
                                 aria-invalid={!!errors.title}
                             />
-                            {errors.title && <p className="text-xs text-destructive">{errors.title}</p>}
+                            {errors.title && <p className="text-xs text-destructive" role="alert">{errors.title}</p>}
                         </div>
                     )}
 
@@ -205,7 +205,7 @@ export function EditProfileModal({ mode, initialValues, onClose }: EditProfileMo
                         />
                         <div className="flex justify-between items-center">
                             {errors.bio
-                                ? <p className="text-xs text-destructive">{errors.bio}</p>
+                                ? <p className="text-xs text-destructive" role="alert">{errors.bio}</p>
                                 : <span />
                             }
                             <Muted className="text-xs">{bio.length} / 500</Muted>
@@ -227,11 +227,12 @@ export function EditProfileModal({ mode, initialValues, onClose }: EditProfileMo
                     {/* Show initials only toggle */}
                     <div className="flex items-center gap-4 rounded-xl border border-line p-4 bg-black/[0.02]">
                         <Switch
+                            id="show-initials-toggle"
                             checked={showInitialsOnly}
                             onCheckedChange={setShowInitialsOnly}
                         />
                         <div>
-                            <p className="text-sm font-medium text-ink">Show initials only</p>
+                            <label htmlFor="show-initials-toggle" className="text-sm font-medium text-ink cursor-pointer">Show initials only</label>
                             <Muted className="text-xs">Your full name and picture will be hidden from others.</Muted>
                         </div>
                     </div>
@@ -247,8 +248,11 @@ export function EditProfileModal({ mode, initialValues, onClose }: EditProfileMo
                         className="bg-accent hover:bg-accent/90 text-white min-w-[90px]"
                         onClick={handleSave}
                         disabled={updateProfile.isPending}
+                        aria-busy={updateProfile.isPending}
                     >
-                        {updateProfile.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Save'}
+                        {updateProfile.isPending
+                            ? <><Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /><span className="sr-only">Saving…</span></>
+                            : 'Save'}
                     </Button>
                 </div>
 

--- a/web/src/components/profile/EditProfileModal.tsx
+++ b/web/src/components/profile/EditProfileModal.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
+import { getAbsoluteMediaUrl } from '@/lib/utils'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Camera, Loader2, X } from 'lucide-react'
 import { useRef, useState } from 'react'
@@ -151,7 +152,7 @@ export function EditProfileModal({ mode, initialValues, onClose }: EditProfileMo
                         >
                             {profileData?.picture_url ? (
                                 <img
-                                    src={profileData.picture_url}
+                                    src={getAbsoluteMediaUrl(profileData.picture_url)}
                                     alt="Profile"
                                     className="h-20 w-20 rounded-full object-cover"
                                 />

--- a/web/src/components/profile/ProfilePageView.tsx
+++ b/web/src/components/profile/ProfilePageView.tsx
@@ -42,10 +42,11 @@ interface ProfilePageViewProps {
 
 function StarRow({ rating }: { rating: number }) {
     return (
-        <div className="flex items-center gap-0.5">
+        <div className="flex items-center gap-0.5" aria-label={`${rating} out of 5 stars`}>
             {[1, 2, 3, 4, 5].map(n => (
                 <Star
                     key={n}
+                    aria-hidden="true"
                     className={`h-3.5 w-3.5 ${n <= rating ? 'fill-amber-400 text-amber-400' : 'text-gray-200'}`}
                 />
             ))}
@@ -67,7 +68,7 @@ function MentorReviewsList({ username }: { username: string }) {
     }
 
     if (!data || data.results.length === 0) {
-        return <p className="text-sm text-gray-500 italic">No public reviews yet.</p>
+        return <p className="text-sm text-ink-soft italic">No public reviews yet.</p>
     }
 
     const totalPages = Math.ceil(data.count / pageSize)
@@ -95,8 +96,9 @@ function MentorReviewsList({ username }: { username: string }) {
                         disabled={page === 1}
                         onClick={() => setPage(p => p - 1)}
                         className="h-7 px-2"
+                        aria-label="Previous page"
                     >
-                        <ChevronLeft className="h-4 w-4" />
+                        <ChevronLeft className="h-4 w-4" aria-hidden="true" />
                     </Button>
                     <Muted className="text-xs">{page} / {totalPages}</Muted>
                     <Button
@@ -105,8 +107,9 @@ function MentorReviewsList({ username }: { username: string }) {
                         disabled={page === totalPages}
                         onClick={() => setPage(p => p + 1)}
                         className="h-7 px-2"
+                        aria-label="Next page"
                     >
-                        <ChevronRight className="h-4 w-4" />
+                        <ChevronRight className="h-4 w-4" aria-hidden="true" />
                     </Button>
                 </div>
             )}
@@ -165,7 +168,7 @@ export function ProfilePageView({ profile, isOwner, isAuthenticatedViewer }: Pro
   )
 
   const bioCard = (
-      <Card className="border-line bg-white/70 shadow-sm">
+      <Card className="border-line bg-card shadow-sm">
         <CardHeader>
           <CardTitle className="text-lg">Bio</CardTitle>
         </CardHeader>
@@ -196,16 +199,16 @@ export function ProfilePageView({ profile, isOwner, isAuthenticatedViewer }: Pro
               <div className="space-y-6">
                 {avatarBlock}
                 {bioCard}
-                <Card className="border-line bg-white/70 shadow-sm">
+                <Card className="border-line bg-card shadow-sm">
                   <CardHeader>
                     <CardTitle className="text-lg flex items-center gap-2">
-                      <Sparkles className="h-4 w-4 text-amber-500" />
+                      <Sparkles className="h-4 w-4 text-amber-500" aria-hidden="true" />
                       Eager to Learn
                     </CardTitle>
                   </CardHeader>
                   <CardContent>
                     {profile.skills.length === 0 ? (
-                        <p className="text-gray-500 italic">No skills listed</p>
+                        <p className="text-ink-soft italic">No skills listed</p>
                     ) : (
                         <div className="flex flex-wrap gap-2">
                             {profile.skills.map(skill => (
@@ -242,13 +245,13 @@ export function ProfilePageView({ profile, isOwner, isAuthenticatedViewer }: Pro
                     <div className="space-y-6">
                         {avatarBlock}
                         {bioCard}
-                        <Card className="border-line bg-white/70 shadow-sm">
+                        <Card className="border-line bg-card shadow-sm">
                             <CardHeader>
                                 <CardTitle className="text-lg">Expertise</CardTitle>
                             </CardHeader>
                             <CardContent>
                                 {profile.skills.length === 0 ? (
-                                    <p className="text-gray-500 italic">No skills listed</p>
+                                    <p className="text-ink-soft italic">No skills listed</p>
                                 ) : (
                                     <div className="flex flex-wrap gap-2">
                                         {profile.skills.map(skill => (
@@ -264,10 +267,10 @@ export function ProfilePageView({ profile, isOwner, isAuthenticatedViewer }: Pro
                             </CardContent>
                         </Card>
 
-                        <Card className="border-line bg-white/70 shadow-sm">
+                        <Card className="border-line bg-card shadow-sm">
                             <CardHeader>
                                 <CardTitle className="text-lg flex items-center gap-2">
-                                    <Star className="h-4 w-4 text-amber-500" />
+                                    <Star className="h-4 w-4 text-amber-500" aria-hidden="true" />
                                     Reviews
                                 </CardTitle>
                             </CardHeader>
@@ -278,15 +281,15 @@ export function ProfilePageView({ profile, isOwner, isAuthenticatedViewer }: Pro
                     </div>
 
                     <aside className="space-y-4">
-                        <Card className="border-line bg-white/80 shadow-sm">
+                        <Card className="border-line bg-card shadow-sm">
                             <CardHeader>
                                 <CardTitle className="text-lg">Snapshot</CardTitle>
                             </CardHeader>
                             <CardContent className="grid gap-3">
                                 <div className="rounded-lg bg-accent-muted/60 p-3 border border-line">
                                     <Muted className="text-xs uppercase tracking-wider">Average Rating</Muted>
-                                    <p className="text-2xl font-semibold text-ink mt-1 flex items-center gap-1">
-                                        <Star className="h-4 w-4 fill-current text-amber-500" />
+                                    <p className="text-2xl font-semibold text-ink mt-1 flex items-center gap-1" aria-label={`Average rating: ${profile.average_rating.toFixed(1)} out of 5`}>
+                                        <Star className="h-4 w-4 fill-current text-amber-500" aria-hidden="true" />
                                         {profile.average_rating.toFixed(1)}
                                     </p>
                                 </div>

--- a/web/src/components/profile/ProfilePageView.tsx
+++ b/web/src/components/profile/ProfilePageView.tsx
@@ -5,7 +5,7 @@ import { Star, Sparkles, Pencil, EyeOff, ChevronLeft, ChevronRight } from 'lucid
 import { EditProfileModal } from '#/components/profile/EditProfileModal.tsx'
 import { ProfilePostsSection } from '#/components/profile/ProfilePostsSection.tsx'
 import { useState } from 'react'
-import { getInitials } from '#/lib/utils.ts'
+import { getAbsoluteMediaUrl, getInitials } from '#/lib/utils.ts'
 import { AvailabilityCalendar } from "#/components/profile/AvailabilityCalendar.tsx";
 import { useAvailabilitySlots } from "#/lib/queries/ProfileTimeSlotQueries.ts";
 import { useMentorReviews } from '#/lib/queries/ProfileQueries.ts'
@@ -125,7 +125,7 @@ export function ProfilePageView({ profile, isOwner, isAuthenticatedViewer }: Pro
       <div className="flex flex-wrap items-center gap-5">
         {profile.picture_url && !profile.show_initials_only ? (
             <img
-                src={profile.picture_url}
+                src={getAbsoluteMediaUrl(profile.picture_url)}
                 alt={`${profile.full_name} profile picture`}
                 className="h-20 w-20 rounded-2xl object-cover ring-1 ring-line"
             />

--- a/web/src/components/profile/ProfilePostsSection.tsx
+++ b/web/src/components/profile/ProfilePostsSection.tsx
@@ -17,6 +17,7 @@ import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Muted } from '@/components/Typography'
 import { MediaUploadField } from '@/components/MediaUploadField'
+import { MediaAttachment } from '@/components/MediaAttachment'
 import {
     useProfilePosts,
     useCreateProfilePost,
@@ -29,11 +30,6 @@ import {
 
 // ---- Helpers ----
 
-function mediaFileName(url: string): string {
-    const raw = url.split('/').pop()?.split('?')[0] ?? 'media'
-    // Backend prepends a 32-char hex UUID + underscore; strip it if present
-    return /^[a-f0-9]{32}_/.test(raw) ? raw.slice(33) : raw
-}
 
 // ---- Types ----
 
@@ -189,16 +185,7 @@ function ProfilePostCard({
                 {post.content && (
                     <p className="text-sm text-ink leading-relaxed whitespace-pre-wrap">{post.content}</p>
                 )}
-                {post.media_url && (
-                    <a
-                        href={post.media_url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-xs text-accent underline truncate"
-                    >
-                        {mediaFileName(post.media_url)}
-                    </a>
-                )}
+                {post.media_url && <MediaAttachment url={post.media_url} />}
                 {post.category === 'MCTE' && post.mentorship_partner && (
                     <Muted className="text-xs">
                         From the mentorship journey with{' '}
@@ -328,7 +315,7 @@ function CreatePostDialog({
                             onUrl={url => setForm(f => ({ ...f, media_url: url ?? undefined }))}
                         />
                     </div>
-                    <DialogFooter className="mt-2">
+                    <DialogFooter className="mt-2 border-t border-line">
                         <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
                             Cancel
                         </Button>

--- a/web/src/lib/queries/MessagingQueries.ts
+++ b/web/src/lib/queries/MessagingQueries.ts
@@ -117,10 +117,10 @@ export function useConversations() {
 
 export function useMessages(conversationId: string) {
     const [pageSize, setPageSize] = useState(50)
-    
-    const { 
-        messages: firebaseMessages, 
-        isLoading: fbLoading, 
+
+    const {
+        messages: firebaseMessages,
+        isLoading: fbLoading,
         isFirebaseAvailable: fbAvailable,
         loadMore: fbLoadMore,
         hasMore: fbHasMore
@@ -129,10 +129,19 @@ export function useMessages(conversationId: string) {
     const { data: httpMessages = [], isLoading: httpLoading } = useQuery(
         messagesQueryOptions(conversationId, pageSize, !fbAvailable),
     )
-    
+
     const { queue: queuedMessages } = useMessageQueue(conversationId)
+    const { data: conversations = [] } = useQuery(conversationsQueryOptions)
 
     const mergedMessages = useMemo(() => {
+        // Build username → picture_url map from the conversation participants
+        const conv = conversations.find(c => c.id === conversationId)
+        const pictureMap: Record<string, string | null> = {}
+        if (conv) {
+            pictureMap[conv.mentor.username] = conv.mentor.picture_url
+            pictureMap[conv.mentee.username] = conv.mentee.picture_url
+        }
+
         const remoteMessages = fbAvailable ? firebaseMessages : httpMessages
         const remoteMsgIds = new Set(remoteMessages.map(m => m.id))
 
@@ -146,7 +155,7 @@ export function useMessages(conversationId: string) {
                         id: msg.sender_id,
                         username: msg.sender_username,
                         display_name: msg.sender_display_name,
-                        picture_url: msg.sender_picture_url,
+                        picture_url: pictureMap[msg.sender_username] ?? msg.sender_picture_url,
                         title: null,
                     },
                     body: msg.body,
@@ -175,7 +184,7 @@ export function useMessages(conversationId: string) {
         return [...allMessages, ...queuedOnlyMessages].sort(
             (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
         )
-    }, [fbAvailable, firebaseMessages, httpMessages, queuedMessages, conversationId])
+    }, [fbAvailable, firebaseMessages, httpMessages, queuedMessages, conversationId, conversations])
 
     const loadMore = useCallback(() => {
         if (fbAvailable) {

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -13,3 +13,17 @@ export function getInitials(fullName: string): string {
       .slice(0, 2)
       .toUpperCase()
 }
+
+const API_SERVER = (import.meta.env.VITE_API_URL as string | undefined)?.replace(/\/$/, '') ?? ''
+
+/**
+ * Convert a Django-relative media path (e.g. `/media/...`) to an absolute URL
+ * using VITE_API_URL. Absolute URLs and empty strings are returned unchanged.
+ */
+export function getAbsoluteMediaUrl(path: string | null | undefined): string {
+  if (!path) return ''
+  if (path.startsWith('http://') || path.startsWith('https://') || path.startsWith('data:')) {
+    return path
+  }
+  return `${API_SERVER}${path.startsWith('/') ? '' : '/'}${path}`
+}

--- a/web/src/routes/_authorized/connections.$matchId.tsx
+++ b/web/src/routes/_authorized/connections.$matchId.tsx
@@ -13,8 +13,8 @@ import {
 import { meQueryOptions } from '#/lib/queries/AuthQueries.ts'
 import { Display, Body, Muted } from '@/components/Typography'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
 import {
     Dialog,
     DialogContent,
@@ -117,7 +117,7 @@ function JourneyPage() {
             {/* Header */}
             <header className="flex flex-col gap-4 max-w-2xl">
                 <Link to="/connections" className="inline-flex items-center gap-1.5 text-ink-soft hover:text-ink text-sm transition-colors w-fit">
-                    <ArrowLeft className="w-4 h-4" />
+                    <ArrowLeft className="w-4 h-4" aria-hidden="true" />
                     Back to Connections
                 </Link>
                 <div className="flex items-start justify-between gap-4 flex-wrap">
@@ -134,9 +134,9 @@ function JourneyPage() {
                     </div>
                     <Button
                         onClick={() => setCreateOpen(true)}
-                        className="rounded-full bg-accent hover:bg-accent/90 text-white gap-2 shrink-0"
+                        className="rounded-full bg-accent hover:bg-accent-light text-white gap-2 shrink-0"
                     >
-                        <Plus className="w-4 h-4" />
+                        <Plus className="w-4 h-4" aria-hidden="true" />
                         Add Entry
                     </Button>
                 </div>
@@ -144,8 +144,8 @@ function JourneyPage() {
 
             {/* Timeline */}
             {isLoading ? (
-                <div className="flex justify-center py-16">
-                    <Loader2 className="h-6 w-6 animate-spin text-ink-soft" />
+                <div className="flex justify-center py-16" role="status" aria-label="Loading journey">
+                    <Loader2 className="h-6 w-6 animate-spin text-ink-soft" aria-hidden="true" />
                 </div>
             ) : isError ? (
                 <ErrorState />
@@ -153,20 +153,25 @@ function JourneyPage() {
                 <EmptyState />
             ) : (
                 <section aria-label="Journey timeline">
-                    <div className="relative flex flex-col gap-0">
-                        {feed.results.map((event, index) => (
-                            <TimelineEventItem
-                                key={event.id}
-                                event={event}
-                                isLast={index === feed.results.length - 1}
-                                currentUsername={me?.username}
-                                onEdit={setEditEvent}
-                                onDelete={setDeleteEvent}
-                            />
-                        ))}
+                    <div className="island-shell rounded-xl overflow-hidden shadow-md">
+                        <div className="px-6 py-4 border-b border-line flex items-center justify-between">
+                            <span className="text-sm font-semibold text-ink">Timeline</span>
+                            <span className="text-xs text-ink-soft">{feed.count} {feed.count === 1 ? 'event' : 'events'}</span>
+                        </div>
+                        <div className="flex flex-col gap-3 p-4">
+                            {feed.results.map((event) => (
+                                <TimelineEventItem
+                                    key={event.id}
+                                    event={event}
+                                    currentUsername={me?.username}
+                                    onEdit={setEditEvent}
+                                    onDelete={setDeleteEvent}
+                                />
+                            ))}
+                        </div>
                     </div>
                     {feed.count > feed.results.length && (
-                        <p className="mt-6 text-center text-ink-soft text-sm">
+                        <p className="mt-4 text-center text-ink-soft text-sm">
                             Showing {feed.results.length} of {feed.count} events
                         </p>
                     )}
@@ -205,21 +210,20 @@ function JourneyPage() {
 
 interface TimelineEventItemProps {
     event: JourneyEvent
-    isLast: boolean
     currentUsername: string | undefined
     onEdit: (e: JourneyEvent) => void
     onDelete: (e: JourneyEvent) => void
 }
 
-function TimelineEventItem({ event, isLast, currentUsername, onEdit, onDelete }: TimelineEventItemProps) {
+function TimelineEventItem({ event, currentUsername, onEdit, onDelete }: TimelineEventItemProps) {
     if (event.category === 'AGTE') {
-        return <AGTEItem event={event} isLast={isLast} />
+        return <AGTEItem event={event} />
     }
     const isOwner = !!currentUsername && event.author?.username === currentUsername
-    return <MCTEItem event={event} isLast={isLast} isOwner={isOwner} onEdit={onEdit} onDelete={onDelete} />
+    return <MCTEItem event={event} isOwner={isOwner} onEdit={onEdit} onDelete={onDelete} />
 }
 
-function AGTEItem({ event, isLast }: { event: JourneyEvent; isLast: boolean }) {
+function AGTEItem({ event }: { event: JourneyEvent }) {
     const meta = AGTE_META[event.type] ?? { label: event.type, Icon: AlertCircle, color: 'text-ink-soft' }
     const { Icon, label, color } = meta
 
@@ -229,18 +233,12 @@ function AGTEItem({ event, isLast }: { event: JourneyEvent; isLast: boolean }) {
     const cancelReason = payload['cancel_reason'] as string | undefined
 
     return (
-        <div className="relative flex gap-4 pb-8">
-            {/* Vertical line */}
-            {!isLast && (
-                <div className="absolute left-5 top-10 bottom-0 w-px bg-line" />
-            )}
-            {/* Dot */}
-            <div className={`mt-1 w-10 h-10 rounded-full bg-surface border border-line flex items-center justify-center shrink-0 z-10 ${color}`}>
-                <Icon className="w-5 h-5" />
+        <div className="rounded-lg border border-line bg-mist/50 px-4 py-3 flex items-start gap-3">
+            <div className={cn('mt-0.5 w-8 h-8 rounded-full bg-surface border border-line flex items-center justify-center shrink-0', color)}>
+                <Icon className="w-4 h-4" aria-hidden="true" />
             </div>
-            {/* Content */}
-            <div className="flex flex-col gap-1 pt-1.5 min-w-0">
-                <p className={`font-semibold text-sm ${color}`}>{label}</p>
+            <div className="flex flex-col gap-0.5 min-w-0">
+                <p className={cn('font-semibold text-sm', color)}>{label}</p>
                 {startAt && (
                     <p className="text-xs text-ink-soft">
                         {formatSessionTime(startAt)}
@@ -258,13 +256,11 @@ function AGTEItem({ event, isLast }: { event: JourneyEvent; isLast: boolean }) {
 
 function MCTEItem({
     event,
-    isLast,
     isOwner,
     onEdit,
     onDelete,
 }: {
     event: JourneyEvent
-    isLast: boolean
     isOwner: boolean
     onEdit: (e: JourneyEvent) => void
     onDelete: (e: JourneyEvent) => void
@@ -273,61 +269,56 @@ function MCTEItem({
     const { Icon, label, variant } = meta
 
     return (
-        <div className="relative flex gap-4 pb-8">
-            {!isLast && (
-                <div className="absolute left-5 top-10 bottom-0 w-px bg-line" />
-            )}
-            <div className="mt-1 w-10 h-10 rounded-full bg-accent/10 border border-accent/20 flex items-center justify-center shrink-0 z-10 text-accent">
-                <Icon className="w-5 h-5" />
+        <div className="rounded-lg border border-line bg-card px-4 py-3 flex items-start gap-3">
+            <div className="mt-0.5 w-8 h-8 rounded-full bg-accent/10 border border-accent/20 flex items-center justify-center shrink-0 text-accent">
+                <Icon className="w-4 h-4" aria-hidden="true" />
             </div>
-            <Card className="flex-1 border-line shadow-sm bg-white">
-                <CardContent className="pt-4 pb-4 flex flex-col gap-2">
-                    <div className="flex items-start justify-between gap-2 flex-wrap">
-                        <div className="flex items-center gap-2">
-                            <Badge variant={variant} className="text-xs">{label}</Badge>
-                            {event.author && (
-                                <Muted className="text-xs">by @{event.author.username}</Muted>
-                            )}
-                        </div>
-                        {isOwner && (
-                            <div className="flex items-center gap-1">
-                                <Button
-                                    variant="ghost"
-                                    size="sm"
-                                    className="h-7 w-7 p-0 text-ink-soft hover:text-ink"
-                                    onClick={() => onEdit(event)}
-                                    aria-label="Edit entry"
-                                >
-                                    <Pencil className="w-3.5 h-3.5" />
-                                </Button>
-                                <Button
-                                    variant="ghost"
-                                    size="sm"
-                                    className="h-7 w-7 p-0 text-ink-soft hover:text-red-500"
-                                    onClick={() => onDelete(event)}
-                                    aria-label="Delete entry"
-                                >
-                                    <Trash2 className="w-3.5 h-3.5" />
-                                </Button>
-                            </div>
+            <div className="flex flex-col gap-2 flex-1 min-w-0">
+                <div className="flex items-start justify-between gap-2 flex-wrap">
+                    <div className="flex items-center gap-2">
+                        <Badge variant={variant} className="text-xs">{label}</Badge>
+                        {event.author && (
+                            <Muted className="text-xs">by @{event.author.username}</Muted>
                         )}
                     </div>
-                    {event.content && (
-                        <p className="text-sm text-ink leading-relaxed whitespace-pre-wrap">{event.content}</p>
+                    {isOwner && (
+                        <div className="flex items-center gap-1 shrink-0">
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                className="h-7 w-7 p-0 text-ink-soft hover:text-ink"
+                                onClick={() => onEdit(event)}
+                                aria-label="Edit entry"
+                            >
+                                <Pencil className="w-3.5 h-3.5" aria-hidden="true" />
+                            </Button>
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                className="h-7 w-7 p-0 text-ink-soft hover:text-red-500"
+                                onClick={() => onDelete(event)}
+                                aria-label="Delete entry"
+                            >
+                                <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
+                            </Button>
+                        </div>
                     )}
-                    {event.media_url && (
-                        <a
-                            href={event.media_url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-xs text-accent underline truncate"
-                        >
-                            {mediaFileName(event.media_url)}
-                        </a>
-                    )}
-                    <Muted className="text-xs">{formatTimestamp(event.timestamp)}</Muted>
-                </CardContent>
-            </Card>
+                </div>
+                {event.content && (
+                    <p className="text-sm text-ink leading-relaxed whitespace-pre-wrap">{event.content}</p>
+                )}
+                {event.media_url && (
+                    <a
+                        href={event.media_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-xs text-accent-aa underline truncate"
+                    >
+                        {mediaFileName(event.media_url)}
+                    </a>
+                )}
+                <Muted className="text-xs">{formatTimestamp(event.timestamp)}</Muted>
+            </div>
         </div>
     )
 }
@@ -424,14 +415,14 @@ function CreateMCTEDialog({ matchId, open, onOpenChange }: CreateMCTEDialogProps
                             Also share this on my profile
                         </Label>
                     </div>
-                    <DialogFooter className="mt-2">
+                    <DialogFooter className="mt-2 border-t border-lineg">
                         <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
                             Cancel
                         </Button>
                         <Button
                             type="submit"
                             disabled={!form.content.trim() || createMutation.isPending}
-                            className="bg-accent hover:bg-accent/90 text-white"
+                            className="bg-accent hover:bg-accent-light text-white"
                         >
                             {createMutation.isPending ? (
                                 <Loader2 className="w-4 h-4 animate-spin" />
@@ -530,7 +521,7 @@ function EditMCTEDialog({ matchId, event, open, onOpenChange }: EditMCTEDialogPr
                         <Button
                             type="submit"
                             disabled={!form.content?.trim() || editMutation.isPending}
-                            className="bg-accent hover:bg-accent/90 text-white"
+                            className="bg-accent hover:bg-accent-light text-white"
                         >
                             {editMutation.isPending ? (
                                 <Loader2 className="w-4 h-4 animate-spin" />
@@ -620,7 +611,7 @@ function EmptyState() {
 function ErrorState() {
     return (
         <div className="py-24 flex flex-col items-center gap-3 text-center">
-            <AlertCircle className="w-8 h-8 text-red-400" />
+            <AlertCircle className="w-8 h-8 text-red-400" aria-hidden="true" />
             <p className="text-ink text-lg font-semibold">Could not load journey</p>
             <p className="text-ink-soft text-sm max-w-sm">
                 You may not have access to this journey, or something went wrong. Please try again.

--- a/web/src/routes/_authorized/connections.$matchId.tsx
+++ b/web/src/routes/_authorized/connections.$matchId.tsx
@@ -25,6 +25,7 @@ import {
 import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
 import { MediaUploadField } from '@/components/MediaUploadField'
+import { MediaAttachment } from '@/components/MediaAttachment'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Checkbox } from '@/components/ui/checkbox'
 import { toast } from 'sonner'
@@ -50,10 +51,6 @@ export const Route = createFileRoute('/_authorized/connections/$matchId')({
     component: JourneyPage,
 })
 
-function mediaFileName(url: string): string {
-    const raw = url.split('/').pop()?.split('?')[0] ?? 'media'
-    return /^[a-f0-9]{32}_/.test(raw) ? raw.slice(33) : raw
-}
 
 // ---------------------------------------------------------------------------
 // AGTE event metadata
@@ -307,16 +304,7 @@ function MCTEItem({
                 {event.content && (
                     <p className="text-sm text-ink leading-relaxed whitespace-pre-wrap">{event.content}</p>
                 )}
-                {event.media_url && (
-                    <a
-                        href={event.media_url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-xs text-accent-aa underline truncate"
-                    >
-                        {mediaFileName(event.media_url)}
-                    </a>
-                )}
+                {event.media_url && <MediaAttachment url={event.media_url} />}
                 <Muted className="text-xs">{formatTimestamp(event.timestamp)}</Muted>
             </div>
         </div>

--- a/web/src/routes/_authorized/connections.$matchId.tsx
+++ b/web/src/routes/_authorized/connections.$matchId.tsx
@@ -233,7 +233,7 @@ function AGTEItem({ event }: { event: JourneyEvent }) {
     const cancelReason = payload['cancel_reason'] as string | undefined
 
     return (
-        <div className="rounded-lg border border-line bg-mist/50 px-4 py-3 flex items-start gap-3">
+        <div className="rounded-lg border border-line bg-card px-4 py-3 flex items-start gap-3">
             <div className={cn('mt-0.5 w-8 h-8 rounded-full bg-surface border border-line flex items-center justify-center shrink-0', color)}>
                 <Icon className="w-4 h-4" aria-hidden="true" />
             </div>

--- a/web/src/routes/_authorized/connections.$matchId.tsx
+++ b/web/src/routes/_authorized/connections.$matchId.tsx
@@ -57,18 +57,18 @@ export const Route = createFileRoute('/_authorized/connections/$matchId')({
 // ---------------------------------------------------------------------------
 
 const AGTE_META: Record<string, { label: string; Icon: React.ElementType; color: string }> = {
-    request_accepted: { label: 'Mentorship began', Icon: Handshake, color: 'text-green-600' },
+    request_accepted: { label: 'Mentorship began', Icon: Handshake, color: 'text-green-700' },
     session_scheduled: { label: 'Session scheduled', Icon: CalendarCheck, color: 'text-blue-600' },
-    session_rescheduled: { label: 'Session rescheduled', Icon: CalendarClock, color: 'text-amber-600' },
-    session_canceled: { label: 'Session canceled', Icon: CalendarX, color: 'text-red-500' },
-    session_completed: { label: 'Session completed', Icon: CalendarCheck2, color: 'text-green-600' },
+    session_rescheduled: { label: 'Session rescheduled', Icon: CalendarClock, color: 'text-amber-700' },
+    session_canceled: { label: 'Session canceled', Icon: CalendarX, color: 'text-red-600' },
+    session_completed: { label: 'Session completed', Icon: CalendarCheck2, color: 'text-green-700' },
     mentorship_ended: { label: 'Mentorship ended', Icon: Flag, color: 'text-ink-soft' },
 }
 
-const MCTE_META: Record<string, { label: string; Icon: React.ElementType; variant: 'default' | 'secondary' | 'outline' }> = {
-    achievement: { label: 'Achievement', Icon: Trophy, variant: 'default' },
-    social: { label: 'Social', Icon: Users, variant: 'secondary' },
-    progress: { label: 'Progress', Icon: TrendingUp, variant: 'outline' },
+const MCTE_META: Record<string, { label: string; Icon: React.ElementType; className: string }> = {
+    achievement: { label: 'Achievement', Icon: Trophy, className: 'bg-amber-100 text-amber-700 border-amber-200' },
+    social: { label: 'Social', Icon: Users, className: 'bg-blue-100 text-blue-700 border-blue-200' },
+    progress: { label: 'Progress', Icon: TrendingUp, className: 'bg-green-100 text-green-700 border-green-200' },
 }
 
 // ---------------------------------------------------------------------------
@@ -262,8 +262,8 @@ function MCTEItem({
     onEdit: (e: JourneyEvent) => void
     onDelete: (e: JourneyEvent) => void
 }) {
-    const meta = MCTE_META[event.type] ?? { label: event.type, Icon: AlertCircle, variant: 'outline' as const }
-    const { Icon, label, variant } = meta
+    const meta = MCTE_META[event.type] ?? { label: event.type, Icon: AlertCircle, className: 'bg-surface text-ink-soft border-line' }
+    const { Icon, label, className } = meta
 
     return (
         <div className="rounded-lg border border-line bg-card px-4 py-3 flex items-start gap-3">
@@ -273,7 +273,7 @@ function MCTEItem({
             <div className="flex flex-col gap-2 flex-1 min-w-0">
                 <div className="flex items-start justify-between gap-2 flex-wrap">
                     <div className="flex items-center gap-2">
-                        <Badge variant={variant} className="text-xs">{label}</Badge>
+                        <Badge variant="outline" className={cn('text-xs border', className)}>{label}</Badge>
                         {event.author && (
                             <Muted className="text-xs">by @{event.author.username}</Muted>
                         )}
@@ -375,7 +375,7 @@ function CreateMCTEDialog({ matchId, open, onOpenChange }: CreateMCTEDialogProps
                         </Select>
                     </div>
                     <div className="flex flex-col gap-1.5">
-                        <Label htmlFor="content">Content <span className="text-red-500">*</span></Label>
+                        <Label htmlFor="content">Content <span className="text-red-600" aria-hidden="true">*</span></Label>
                         <Textarea
                             id="content"
                             value={form.content}
@@ -473,7 +473,7 @@ function EditMCTEDialog({ matchId, event, open, onOpenChange }: EditMCTEDialogPr
                 </DialogHeader>
                 <form onSubmit={handleSubmit} className="flex flex-col gap-4 mt-2">
                     <div className="flex flex-col gap-1.5">
-                        <Label htmlFor="edit_content">Content <span className="text-red-500">*</span></Label>
+                        <Label htmlFor="edit_content">Content <span className="text-red-600" aria-hidden="true">*</span></Label>
                         <Textarea
                             id="edit_content"
                             value={form.content ?? ''}

--- a/web/src/routes/_authorized/connections.index.tsx
+++ b/web/src/routes/_authorized/connections.index.tsx
@@ -45,8 +45,8 @@ export function ConnectionsPage() {
 
             {/* Content */}
             {isLoading ? (
-                <div className="flex justify-center py-16">
-                    <Loader2 className="h-6 w-6 animate-spin text-ink-soft" />
+                <div className="flex justify-center py-16" role="status" aria-label="Loading connections">
+                    <Loader2 className="h-6 w-6 animate-spin text-ink-soft" aria-hidden="true" />
                 </div>
             ) : connections.length === 0 ? (
                 <EmptyState isMentor={isMentor} />
@@ -86,7 +86,7 @@ interface ConnectionCardProps {
 
 function ConnectionCard({ matchId, username, displayName, pictureUrl, title }: ConnectionCardProps) {
     return (
-        <Card className="island-shell border-line shadow-sm hover:shadow-md transition-shadow bg-white">
+        <Card className="island-shell border-line shadow-sm hover:shadow-md transition-shadow bg-card">
             <CardContent className="pt-6 flex flex-col items-center text-center gap-4">
                 {pictureUrl ? (
                     <img
@@ -115,7 +115,7 @@ function ConnectionCard({ matchId, username, displayName, pictureUrl, title }: C
                             size="sm"
                             className="w-full border-line text-ink-soft hover:text-ink hover:border-accent/30 transition-colors gap-2"
                         >
-                            <UserCircle className="w-4 h-4" />
+                            <UserCircle className="w-4 h-4" aria-hidden="true" />
                             View Profile
                         </Button>
                     </Link>
@@ -125,11 +125,11 @@ function ConnectionCard({ matchId, username, displayName, pictureUrl, title }: C
                         className="w-full"
                     >
                         <Button
-                            variant="ghost"
+                            variant="outline"
                             size="sm"
-                            className="w-full text-ink-soft hover:text-accent hover:bg-accent/5 transition-colors gap-2"
+                            className="w-full border-line text-ink-soft hover:text-ink hover:border-accent/30 transition-colors gap-2"
                         >
-                            <BookOpen className="w-4 h-4" />
+                            <BookOpen className="w-4 h-4" aria-hidden="true" />
                             View Journey
                         </Button>
                     </Link>

--- a/web/src/routes/_authorized/connections.index.tsx
+++ b/web/src/routes/_authorized/connections.index.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button'
 import { useQuery } from '@tanstack/react-query'
 import { meQueryOptions } from '#/lib/queries/AuthQueries.ts'
 import { useMyMatches } from '#/lib/queries/MentorshipQueries.ts'
-import { getInitials } from '#/lib/utils.ts'
+import { getAbsoluteMediaUrl, getInitials } from '#/lib/utils.ts'
 import { Loader2, UserCircle, BookOpen } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'
 
@@ -90,7 +90,7 @@ function ConnectionCard({ matchId, username, displayName, pictureUrl, title }: C
             <CardContent className="pt-6 flex flex-col items-center text-center gap-4">
                 {pictureUrl ? (
                     <img
-                        src={pictureUrl}
+                        src={getAbsoluteMediaUrl(pictureUrl)}
                         alt={displayName}
                         className="h-20 w-20 rounded-2xl object-cover ring-1 ring-line"
                     />

--- a/web/src/routes/_authorized/dashboard.tsx
+++ b/web/src/routes/_authorized/dashboard.tsx
@@ -2,7 +2,7 @@
 import { meQueryOptions } from "#/lib/queries/AuthQueries.ts"
 import { useMeetingSessions, useMyRequests, useRespondToRequest, matchFeedbackQueryOptions } from "#/lib/queries/MentorshipQueries.ts"
 import { useNotifications, useMarkAllNotificationsRead, NOTIFICATION_INVALIDATION_MAP } from "#/lib/queries/NotificationQueries.ts"
-import { getInitials } from "#/lib/utils.ts"
+import { getAbsoluteMediaUrl, getInitials } from "#/lib/utils.ts"
 import { Body, Heading, Muted } from '@/components/Typography'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -347,7 +347,7 @@ function MenteeDashboardView() {
                       <div className="flex items-center gap-3">
                         {session.mentor.picture_url ? (
                             <img
-                                src={session.mentor.picture_url}
+                                src={getAbsoluteMediaUrl(session.mentor.picture_url)}
                                 alt={session.mentor.display_name}
                                 className="h-11 w-11 rounded-full object-cover border border-white/50 shadow-sm"
                             />
@@ -417,7 +417,7 @@ function MenteeDashboardView() {
                       <div className="flex items-center gap-3">
                         {session.mentor.picture_url ? (
                           <img
-                            src={session.mentor.picture_url}
+                            src={getAbsoluteMediaUrl(session.mentor.picture_url)}
                             alt={session.mentor.display_name}
                             className="h-10 w-10 rounded-full object-cover border border-white/50 shadow-sm"
                           />
@@ -490,7 +490,7 @@ function MenteeDashboardView() {
                         <div className="flex items-center gap-3">
                           {req.mentor.picture_url ? (
                               <img
-                                  src={req.mentor.picture_url}
+                                  src={getAbsoluteMediaUrl(req.mentor.picture_url)}
                                   alt={req.mentor.display_name}
                                   className="h-11 w-11 rounded-full object-cover border border-white/50 shadow-sm"
                               />
@@ -654,7 +654,7 @@ function MentorDashboardView() {
                         <div className="flex items-center gap-3">
                           {session.mentee.picture_url ? (
                               <img
-                                  src={session.mentee.picture_url}
+                                  src={getAbsoluteMediaUrl(session.mentee.picture_url)}
                                   alt={displayName}
                                   className="h-11 w-11 rounded-full object-cover border border-white/50 shadow-sm"
                               />

--- a/web/src/routes/_authorized/dashboard.tsx
+++ b/web/src/routes/_authorized/dashboard.tsx
@@ -314,7 +314,7 @@ function MenteeDashboardView() {
               <CalendarDays className="w-5 h-5 text-accent" />
               Upcoming Sessions
               {!sessionsLoading && upcomingSessions.length > 0 && (
-                <span className="inline-flex items-center justify-center h-5 min-w-5 px-1 rounded-full bg-accent/15 text-accent text-xs font-bold">
+                <span className="inline-flex items-center justify-center h-5 min-w-5 px-1 rounded-full bg-accent/15 text-accent-aa text-xs font-bold">
                   {upcomingSessions.length}
                 </span>
               )}
@@ -373,7 +373,7 @@ function MenteeDashboardView() {
                         <Link
                             to="/profiles/$username"
                             params={{ username: session.mentor.username }}
-                            className="text-xs text-accent hover:underline underline-offset-4"
+                            className="text-xs text-accent-aa hover:underline underline-offset-4"
                         >
                           View profile
                         </Link>
@@ -383,7 +383,7 @@ function MenteeDashboardView() {
                   </Card>
               ))}
               <Link to="/schedule" className="block mt-2">
-                <Button variant="ghost" className="w-full text-accent hover:bg-accent/10">
+                <Button variant="ghost" className="w-full text-accent-aa hover:bg-accent/10">
                   {upcomingSessions.length > 3
                       ? `View all ${upcomingSessions.length} sessions`
                       : 'View Full Schedule'
@@ -460,7 +460,7 @@ function MenteeDashboardView() {
             <Heading as="h3" className="text-xl flex items-center gap-2">
               Sent Requests
               {!requestsLoading && sentRequests.length > 0 && (
-                <span className="inline-flex items-center justify-center h-5 min-w-5 px-1 rounded-full bg-accent/15 text-accent text-xs font-bold">
+                <span className="inline-flex items-center justify-center h-5 min-w-5 px-1 rounded-full bg-accent/15 text-accent-aa text-xs font-bold">
                   {sentRequests.length}
                 </span>
               )}
@@ -511,7 +511,7 @@ function MenteeDashboardView() {
                           <Link
                               to="/profiles/$username"
                               params={{ username: req.mentor.username }}
-                              className="text-xs text-accent hover:underline underline-offset-4 shrink-0"
+                              className="text-xs text-accent-aa hover:underline underline-offset-4 shrink-0"
                           >
                             View profile
                           </Link>
@@ -616,7 +616,7 @@ function MentorDashboardView() {
               <CalendarDays className="w-5 h-5 text-accent" />
               Upcoming Sessions
               {!sessionsLoading && upcomingSessions.length > 0 && (
-                <span className="inline-flex items-center justify-center h-5 min-w-5 px-1 rounded-full bg-accent/15 text-accent text-xs font-bold">
+                <span className="inline-flex items-center justify-center h-5 min-w-5 px-1 rounded-full bg-accent/15 text-accent-aa text-xs font-bold">
                   {upcomingSessions.length}
                 </span>
               )}
@@ -678,7 +678,7 @@ function MentorDashboardView() {
                               <Link
                                   to="/profiles/$username"
                                   params={{ username: session.mentee.username }}
-                                  className="text-xs text-accent hover:underline underline-offset-4"
+                                  className="text-xs text-accent-aa hover:underline underline-offset-4"
                               >
                                 View profile
                               </Link>
@@ -691,7 +691,7 @@ function MentorDashboardView() {
               })}
 
               <Link to="/schedule" className="block mt-2">
-                <Button variant="ghost" className="w-full text-accent hover:bg-accent/10">
+                <Button variant="ghost" className="w-full text-accent-aa hover:bg-accent/10">
                   {upcomingSessions.length > 3
                       ? `View all ${upcomingSessions.length} sessions`
                       : 'View Full Schedule'
@@ -708,7 +708,7 @@ function MentorDashboardView() {
             <Heading as="h3" className="text-xl flex items-center gap-2">
               Incoming Requests
               {!requestsLoading && displayRequests.length > 0 && (
-                <span className="inline-flex items-center justify-center h-5 min-w-5 px-1 rounded-full bg-accent/15 text-accent text-xs font-bold">
+                <span className="inline-flex items-center justify-center h-5 min-w-5 px-1 rounded-full bg-accent/15 text-accent-aa text-xs font-bold">
                   {pendingRequests.length}
                 </span>
               )}
@@ -746,7 +746,7 @@ function MentorDashboardView() {
                           <Link
                               to="/profiles/$username"
                               params={{ username: req.mentee.username }}
-                              className="text-xs text-accent hover:underline underline-offset-4 shrink-0"
+                              className="text-xs text-accent-aa hover:underline underline-offset-4 shrink-0"
                           >
                             View profile
                           </Link>
@@ -807,7 +807,7 @@ function MentorDashboardView() {
                 )
               })}
               {pendingRequests.length > 3 && (
-                  <Button variant="ghost" className="w-full text-accent hover:bg-accent/10 mt-2">
+                  <Button variant="ghost" className="w-full text-accent-aa hover:bg-accent/10 mt-2">
                     View all {pendingRequests.length} requests <ArrowRight className="w-4 h-4 ml-2" />
                   </Button>
               )}

--- a/web/src/routes/_authorized/messages.tsx
+++ b/web/src/routes/_authorized/messages.tsx
@@ -13,7 +13,7 @@ import { cn, getAbsoluteMediaUrl, getInitials } from '#/lib/utils.ts'
 import { MediaAttachment } from '@/components/MediaAttachment'
 import { Button } from '@/components/ui/button'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, Link } from '@tanstack/react-router'
 import { Check, CheckCheck, Loader2, MessageSquare, Paperclip, Send, X } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState, type SyntheticEvent } from 'react'
 
@@ -127,21 +127,34 @@ function ConversationItem({
             ? conversation.mentee
             : conversation.mentor
 
+    const updatedAt = new Date(conversation.updated_at)
+    const now = new Date()
+    const isToday = updatedAt.toDateString() === now.toDateString()
+    const timeLabel = isToday
+        ? updatedAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+        : updatedAt.toLocaleDateString([], { month: 'short', day: 'numeric' })
+
     return (
         <button
             onClick={onSelect}
             className={cn(
-                'w-full flex items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-accent-muted/60',
-                isSelected && 'bg-accent-muted',
+                'w-full flex items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-accent-muted/60 border-l-2',
+                isSelected ? 'bg-accent-muted border-l-accent' : 'border-l-transparent',
             )}
         >
             <Avatar name={other.display_name} pictureUrl={other.picture_url} size="md" />
             <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-ink truncate">{other.display_name}</p>
+                <div className="flex items-center justify-between gap-1">
+                    <p className={cn('text-sm truncate', isSelected ? 'font-semibold text-ink' : 'font-medium text-ink')}>{other.display_name}</p>
+                    <time className="text-[10px] text-ink-soft shrink-0">{timeLabel}</time>
+                </div>
                 <p className="text-xs text-ink-soft truncate">@{other.username}</p>
             </div>
             {conversation.unread_count > 0 && (
-                <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-accent px-1 text-[10px] font-bold text-white shadow-sm">
+                <span
+                    className="flex h-5 min-w-5 items-center justify-center rounded-full bg-accent px-1 text-[10px] font-bold text-white shadow-sm"
+                    aria-label={`${conversation.unread_count} unread messages`}
+                >
                     {conversation.unread_count > 99 ? '99+' : conversation.unread_count}
                 </span>
             )}
@@ -168,6 +181,11 @@ function MessageThread({ conversationId }: { readonly conversationId: string | n
 
 function Thread({ conversationId }: { readonly conversationId: string }) {
     const { data: me } = useQuery(meQueryOptions)
+    const { data: conversations = [] } = useConversations()
+    const conversation = conversations.find(c => c.id === conversationId)
+    const other = conversation
+        ? (conversation.mentor.username === me?.username ? conversation.mentee : conversation.mentor)
+        : null
     const { data: messages = [], isLoading, loadMore, hasMore } = useMessages(conversationId)
     const { mutate: markRead } = useMarkRead(conversationId)
     const sendMessage = useSendMessage(conversationId)
@@ -243,8 +261,25 @@ function Thread({ conversationId }: { readonly conversationId: string }) {
 
     return (
         <div className="flex-1 flex flex-col min-w-0">
+            {/* Thread header */}
+            {other && (
+                <div className="shrink-0 flex items-center gap-3 px-5 py-3 border-b border-line">
+                    <Avatar name={other.display_name} pictureUrl={other.picture_url} size="md" />
+                    <div className="flex-1 min-w-0">
+                        <p className="text-sm font-semibold text-ink truncate">{other.display_name}</p>
+                        <p className="text-xs text-ink-soft truncate">@{other.username}</p>
+                    </div>
+                    <Link
+                        to="/profiles/$username"
+                        params={{ username: other.username }}
+                        className="text-xs text-accent-aa hover:underline shrink-0"
+                    >
+                        View profile
+                    </Link>
+                </div>
+            )}
             {/* Messages */}
-            <div 
+            <div
                 ref={scrollContainerRef}
                 onScroll={handleScroll}
                 className="flex-1 overflow-y-auto px-6 py-4 flex flex-col gap-3"
@@ -366,18 +401,18 @@ function MessageBubble({
     const getStatusIcon = () => {
         const status = message.status_for_me
         if (status === 'read') {
-            return <CheckCheck className="h-3 w-3 text-white/80" />
+            return <CheckCheck className="h-3 w-3 text-white" aria-hidden="true" />
         }
         if (status === 'delivered') {
-            return <CheckCheck className="h-3 w-3 text-white/80" />
+            return <CheckCheck className="h-3 w-3 text-white/70" aria-hidden="true" />
         }
-        if (status === 'sent' || status === 'sending') {
-            return <Check className="h-3 w-3 text-white/60" />
+        if (status === 'sent' || (status as unknown as string) === 'sending') {
+            return <Check className="h-3 w-3 text-white/50" aria-hidden="true" />
         }
         return null
     }
 
-    const isSending = message.status_for_me === 'sending'
+    const isSending = (message.status_for_me as unknown as string) === 'sending'
 
     return (
         <div className={cn('flex items-end gap-2 group', isMe && 'flex-row-reverse')}>
@@ -406,7 +441,7 @@ function MessageBubble({
                     />
                 )}
                 <div className={cn('flex items-center gap-1 text-[10px] mt-1', isMe ? 'justify-end' : 'justify-start')}>
-                    <time className="opacity-80">
+                    <time>
                         {new Date(message.created_at).toLocaleTimeString([], {
                             hour: '2-digit',
                             minute: '2-digit',

--- a/web/src/routes/_authorized/messages.tsx
+++ b/web/src/routes/_authorized/messages.tsx
@@ -9,7 +9,8 @@ import {
     type Message,
 } from '#/lib/queries/MessagingQueries.ts'
 import { useMarkAllNotificationsRead, useNotifications } from '#/lib/queries/NotificationQueries.ts'
-import { cn, getInitials } from '#/lib/utils.ts'
+import { cn, getAbsoluteMediaUrl, getInitials } from '#/lib/utils.ts'
+import { MediaAttachment } from '@/components/MediaAttachment'
 import { Button } from '@/components/ui/button'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
@@ -398,14 +399,11 @@ function MessageBubble({
             >
                 <p className="whitespace-pre-wrap wrap-break-word">{message.body}</p>
                 {message.attachment_url && (
-                    <a
-                        href={message.attachment_url}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="block mt-1 underline text-xs opacity-80"
-                    >
-                        Attachment
-                    </a>
+                    <MediaAttachment
+                        url={message.attachment_url}
+                        imgClassName="mt-1 max-h-48 w-full rounded-lg border-0 object-contain"
+                        linkClassName="mt-1 block underline text-xs opacity-80 text-inherit"
+                    />
                 )}
                 <div className={cn('flex items-center gap-1 text-[10px] mt-1', isMe ? 'justify-end' : 'justify-start')}>
                     <time className="opacity-80">
@@ -445,7 +443,7 @@ function Avatar({
     if (pictureUrl) {
         return (
             <img
-                src={pictureUrl}
+                src={getAbsoluteMediaUrl(pictureUrl)}
                 alt={name}
                 className={cn('rounded-full object-cover shrink-0', dim)}
             />

--- a/web/src/routes/_authorized/route.tsx
+++ b/web/src/routes/_authorized/route.tsx
@@ -21,9 +21,15 @@ export const Route = createFileRoute('/_authorized')({
 function AuthorizedLayout() {
     return (
         <div className="flex min-h-screen flex-col bg-bg dark:bg-background">
+            <a
+                href="#main-content"
+                className="sr-only focus:not-sr-only focus:fixed focus:top-3 focus:left-3 focus:z-[100] focus:rounded-lg focus:bg-accent focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-white focus:shadow-lg"
+            >
+                Skip to main content
+            </a>
             <AuthorizedHeader />
             <EmailVerificationBanner />
-            <main className="flex-1">
+            <main id="main-content" className="flex-1">
                 <Outlet />
             </main>
         </div>

--- a/web/src/routes/_authorized/schedule.tsx
+++ b/web/src/routes/_authorized/schedule.tsx
@@ -1,6 +1,6 @@
 import { meQueryOptions } from '#/lib/queries/AuthQueries.ts'
 import { useMeetingSessions } from '#/lib/queries/MentorshipQueries.ts'
-import { getInitials } from '#/lib/utils.ts'
+import { getAbsoluteMediaUrl, getInitials } from '#/lib/utils.ts'
 import { Body, Heading } from '@/components/Typography'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -102,7 +102,7 @@ function ScheduleTable({ sessions, peerLabel }: ScheduleTableProps) {
                     <div className="flex items-center gap-2">
                       {session.peerPicture ? (
                           <img
-                              src={session.peerPicture}
+                              src={getAbsoluteMediaUrl(session.peerPicture)}
                               alt={session.peerName}
                               className="h-7 w-7 rounded-full object-cover border border-white/50 shadow-sm"
                           />

--- a/web/src/routes/_authorized/schedule.tsx
+++ b/web/src/routes/_authorized/schedule.tsx
@@ -78,13 +78,13 @@ function ScheduleTable({ sessions, peerLabel }: ScheduleTableProps) {
 
   return (
       <div className="overflow-x-auto border-t border-line">
-        <Table>
+        <Table aria-label="Sessions schedule">
           <TableHeader className="bg-black/2">
             <TableRow className="border-line hover:bg-transparent">
-              <TableHead className="w-37.5 font-semibold text-ink pl-6 py-4">Date</TableHead>
-              <TableHead className="w-37.5 font-semibold text-ink py-4">Time</TableHead>
-              <TableHead className="font-semibold text-ink py-4">{peerLabel}</TableHead>
-              <TableHead className="w-30 font-semibold text-ink pr-6 py-4">Status</TableHead>
+              <TableHead scope="col" className="w-37.5 font-semibold text-ink pl-6 py-4">Date</TableHead>
+              <TableHead scope="col" className="w-37.5 font-semibold text-ink py-4">Time</TableHead>
+              <TableHead scope="col" className="font-semibold text-ink py-4">{peerLabel}</TableHead>
+              <TableHead scope="col" className="w-30 font-semibold text-ink pr-6 py-4">Status</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -115,7 +115,7 @@ function ScheduleTable({ sessions, peerLabel }: ScheduleTableProps) {
                         <Link
                             to="/profiles/$username"
                             params={{ username: session.peerUsername }}
-                            className="text-sm font-medium hover:text-accent hover:underline underline-offset-4 transition-colors"
+                            className="text-sm font-medium hover:text-accent-aa hover:underline underline-offset-4 transition-colors"
                         >
                           {session.peerName}
                         </Link>
@@ -228,8 +228,8 @@ export function SchedulePage() {
         </div>
 
         {isLoading ? (
-            <div className="flex justify-center py-16">
-              <Loader2 className="h-6 w-6 animate-spin text-ink-soft" />
+            <div role="status" aria-label="Loading schedule" className="flex justify-center py-16">
+              <Loader2 className="h-6 w-6 animate-spin text-ink-soft" aria-hidden="true" />
             </div>
         ) : (
             <Card className="island-shell overflow-hidden border-line flex flex-col">
@@ -241,11 +241,11 @@ export function SchedulePage() {
                     {currentMonth.toLocaleString('default', { month: 'long', year: 'numeric' })}
                   </Heading>
                   <div className="flex gap-2">
-                    <Button variant="outline" size="icon" onClick={prevMonth} className="h-8 w-8">
-                      <ChevronLeft className="w-4 h-4" />
+                    <Button variant="outline" size="icon" onClick={prevMonth} className="h-8 w-8" aria-label="Previous month">
+                      <ChevronLeft className="w-4 h-4" aria-hidden="true" />
                     </Button>
-                    <Button variant="outline" size="icon" onClick={nextMonth} className="h-8 w-8">
-                      <ChevronRight className="w-4 h-4" />
+                    <Button variant="outline" size="icon" onClick={nextMonth} className="h-8 w-8" aria-label="Next month">
+                      <ChevronRight className="w-4 h-4" aria-hidden="true" />
                     </Button>
                   </div>
                 </div>
@@ -262,13 +262,13 @@ export function SchedulePage() {
                     </div>
                   </div>
                   <div className="text-xs text-ink-soft flex items-center gap-1.5 bg-black/3 px-2 py-1 rounded-md">
-                    <Globe className="w-3.5 h-3.5" /> All times in your local timezone
+                    <Globe className="w-3.5 h-3.5" aria-hidden="true" /> All times in your local timezone
                   </div>
                 </div>
 
                 <div className="grid grid-cols-7 gap-px bg-line/50 rounded-lg overflow-hidden border border-line">
                   {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map(day => (
-                      <div key={day} className="bg-white py-2 text-center text-xs font-semibold text-ink-soft">
+                      <div key={day} className="bg-card py-2 text-center text-xs font-semibold text-ink-soft">
                         {day}
                       </div>
                   ))}
@@ -299,6 +299,8 @@ export function SchedulePage() {
                                 isCurrentMonth ? '' : 'opacity-40 bg-black/2'
                             } ${isSelected ? 'ring-2 ring-inset ring-accent bg-accent/5' : ''}`}
                             aria-pressed={isSelected}
+                            aria-label={`${date.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })}${dayEvents.length > 0 ? `, ${dayEvents.length} session${dayEvents.length > 1 ? 's' : ''}` : ''}`}
+                            aria-current={isToday ? 'date' : undefined}
                         >
                           <div className={`text-sm font-medium w-7 h-7 flex items-center justify-center rounded-full mb-1 ${dayLabelClass}`}>
                             {date.getDate()}
@@ -324,7 +326,7 @@ export function SchedulePage() {
               </div>
 
               {/* List header */}
-              <div className="px-6 py-4 flex items-center justify-between bg-white border-t border-line">
+              <div className="px-6 py-4 flex items-center justify-between bg-card border-t border-line">
                 <Heading as="h4" className="text-lg">
                   {selectedDate ? `Sessions for ${formattedSelectedDate}` : 'All Sessions'}
                 </Heading>
@@ -336,7 +338,7 @@ export function SchedulePage() {
               </div>
 
               {/* Table */}
-              <div className="bg-white">
+              <div className="bg-card">
                 <ScheduleTable
                     sessions={filteredSessions}
                     peerLabel={isMentor ? 'Student' : 'Mentor'}

--- a/web/src/routes/_onBoarding/gettingToKnowYou.tsx
+++ b/web/src/routes/_onBoarding/gettingToKnowYou.tsx
@@ -1,12 +1,14 @@
 import { SkillPicker } from "#/components/SkillPicker.tsx"
-import { Heading, Muted, Subheading } from "#/components/Typography.tsx"
+import { Display, Heading, Muted, Subheading } from "#/components/Typography.tsx"
 import { Button } from "#/components/ui/button.tsx"
 import { Input } from "#/components/ui/input.tsx"
+import { Label as FormLabel } from "#/components/ui/label.tsx"
 import { Textarea } from "#/components/ui/textarea.tsx"
 import { logout, meQueryOptions, useUpdateAppUsageMode } from "#/lib/queries/AuthQueries.ts"
 import { useOwnProfile, useUpdateProfile, useUpdateUsername } from "#/lib/queries/ProfileQueries.ts"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute, useRouter } from '@tanstack/react-router'
+import { ArrowLeft, ArrowRight } from 'lucide-react'
 import { useEffect, useState } from 'react'
 
 export const Route = createFileRoute('/_onBoarding/gettingToKnowYou')({
@@ -221,133 +223,178 @@ function RouteComponent() {
         setActiveIndex(i => i - 1)
     }
 
+    const inputId = `onboarding-input-${current.key}`
+
     return (
-        <div className="min-h-screen page-wrap flex flex-col items-center">
-            <div className="island-shell rounded-2xl px-10 py-10 rise-in w-full max-w-xl flex flex-col gap-6 mt-10">
+        <div className="min-h-screen flex flex-col">
 
-                {/* Progress bar */}
-                <div className="flex gap-2">
-                    {questions.map((_, i) => (
+            {/* Brand header */}
+            <header className="page-wrap py-6">
+                <Display as="span" className="text-lg tracking-tight">Neighborship</Display>
+            </header>
+
+            {/* Card */}
+            <div className="page-wrap flex flex-col items-center pt-8 pb-16">
+                <div className="island-shell rounded-2xl px-10 py-10 rise-in w-full max-w-xl flex flex-col gap-8">
+
+                    {/* Progress */}
+                    <div className="flex flex-col gap-2">
                         <div
-                            key={i}
-                            className={`h-1.5 flex-1 rounded-full transition-all duration-300 ${
-                                i <= activeIndex ? 'bg-primary' : 'bg-accent-muted'
-                            }`}
-                        />
-                    ))}
-                </div>
-
-                {/* Question */}
-                <div className="flex flex-col gap-1">
-                    <Heading as="h1" className="text-4xl font-extralight">
-                        {current.question}
-                    </Heading>
-                    <Subheading>{current.clarification}</Subheading>
-                    {current.mutedText && <Muted>{current.mutedText}</Muted>}
-                </div>
-
-                {/* Input area */}
-                <div className="flex flex-col gap-3">
-                    {current.type === 'text' && (
-                        <Input
-                            className="bg-background"
-                            placeholder="Type here..."
-                            value={answers[current.key] as string}
-                            onChange={e =>
-                                setAnswers(prev => ({ ...prev, [current.key]: e.target.value }))
-                            }
-                            onKeyDown={e => e.key === 'Enter' && handleNext()}
-                        />
-                    )}
-
-                    {current.type === 'textarea' && (
-                        <Textarea
-                            className="bg-background resize-none"
-                            placeholder="Write a short bio..."
-                            rows={4}
-                            value={answers.bio}
-                            onChange={e =>
-                                setAnswers(prev => ({ ...prev, bio: e.target.value }))
-                            }
-                        />
-                    )}
-
-                    {current.type === 'choice' && (
-                        <div className="flex gap-3">
-                            {(['mentee', 'mentor'] as const).map(option => (
-                                <button
-                                    key={option}
-                                    onClick={() =>
-                                        setAnswers(prev => ({ ...prev, primaryUsage: option }))
-                                    }
-                                    className={`flex-1 py-4 rounded-xl border-2 capitalize text-lg font-medium transition-all ${
-                                        answers.primaryUsage === option
-                                            ? 'border-primary bg-primary text-primary-foreground'
-                                            : 'border-border hover:border-primary/60'
+                            role="progressbar"
+                            aria-valuenow={activeIndex + 1}
+                            aria-valuemin={1}
+                            aria-valuemax={questions.length}
+                            aria-label={`Step ${activeIndex + 1} of ${questions.length}`}
+                            className="flex gap-1.5"
+                        >
+                            {questions.map((_, i) => (
+                                <div
+                                    key={i}
+                                    className={`h-2 flex-1 rounded-full transition-all duration-300 ${
+                                        i <= activeIndex ? 'bg-accent' : 'bg-accent-muted'
                                     }`}
-                                >
-                                    {option}
-                                </button>
+                                />
                             ))}
                         </div>
-                    )}
+                        <Muted className="text-xs tabular-nums">
+                            Step {activeIndex + 1} of {questions.length}
+                        </Muted>
+                    </div>
 
-                    {current.type === 'username' && (
-                        <div className="flex flex-col gap-2">
+                    {/* Question */}
+                    <div className="flex flex-col gap-1.5">
+                        <FormLabel htmlFor={inputId} className="sr-only">
+                            {current.question}
+                        </FormLabel>
+                        <Heading as="h1" className="text-3xl font-light leading-snug">
+                            {current.question}
+                        </Heading>
+                        <Subheading className="text-ink-soft font-normal">{current.clarification}</Subheading>
+                        {current.mutedText && <Muted>{current.mutedText}</Muted>}
+                    </div>
+
+                    {/* Input area */}
+                    <div className="flex flex-col gap-3">
+                        {current.type === 'text' && (
                             <Input
-                                className="bg-background"
-                                placeholder="username"
-                                value={answers.username}
+                                id={inputId}
+                                className="bg-background py-3 rounded-xl"
+                                placeholder="Type here…"
+                                value={answers[current.key] as string}
                                 onChange={e =>
-                                    setAnswers(prev => ({ ...prev, username: e.target.value }))
+                                    setAnswers(prev => ({ ...prev, [current.key]: e.target.value }))
                                 }
                                 onKeyDown={e => e.key === 'Enter' && handleNext()}
+                                autoFocus
                             />
-                            <div className="flex flex-col gap-0.5">
-                                <Muted className="text-xs">Your profile URL will be:</Muted>
-                                <Muted className="text-sm font-mono">
-                                    https://neighborship.app/profiles/{answers.username || '...'}
-                                </Muted>
+                        )}
+
+                        {current.type === 'textarea' && (
+                            <Textarea
+                                id={inputId}
+                                className="bg-background resize-none rounded-xl"
+                                placeholder="Write a short bio…"
+                                rows={4}
+                                value={answers.bio}
+                                onChange={e =>
+                                    setAnswers(prev => ({ ...prev, bio: e.target.value }))
+                                }
+                                autoFocus
+                            />
+                        )}
+
+                        {current.type === 'choice' && (
+                            <div id={inputId} role="group" aria-label={current.question} className="flex gap-3">
+                                {(['mentee', 'mentor'] as const).map(option => (
+                                    <button
+                                        key={option}
+                                        type="button"
+                                        aria-pressed={answers.primaryUsage === option}
+                                        onClick={() =>
+                                            setAnswers(prev => ({ ...prev, primaryUsage: option }))
+                                        }
+                                        className={`flex-1 py-6 rounded-xl border-2 capitalize text-lg font-semibold transition-all ${
+                                            answers.primaryUsage === option
+                                                ? 'border-accent bg-accent text-white shadow-md'
+                                                : 'border-line text-ink-soft hover:border-accent/50 hover:text-ink'
+                                        }`}
+                                    >
+                                        {option === 'mentee' ? 'I want to learn' : 'I want to teach'}
+                                        <span className="block text-sm font-normal mt-1 capitalize">
+                                            {option}
+                                        </span>
+                                    </button>
+                                ))}
                             </div>
-                        </div>
-                    )}
+                        )}
 
-                    {current.type === 'skills' && current.skillsKey && (
-                        <SkillPicker
-                            selected={answers[current.skillsKey]}
-                            available={profileData?.available_catalog_skills ?? []}
-                            onChange={skills => setAnswers(prev => ({ ...prev, [current.skillsKey!]: skills }))}
-                            mode={answers.primaryUsage === 'mentor' ? 'mentor' : 'mentee'}
-                        />
-                    )}
+                        {current.type === 'username' && (
+                            <div className="flex flex-col gap-2">
+                                <Input
+                                    id={inputId}
+                                    className="bg-background py-3 rounded-xl"
+                                    placeholder="username"
+                                    value={answers.username}
+                                    onChange={e =>
+                                        setAnswers(prev => ({ ...prev, username: e.target.value }))
+                                    }
+                                    onKeyDown={e => e.key === 'Enter' && handleNext()}
+                                    autoFocus
+                                    autoComplete="username"
+                                />
+                                <div className="flex flex-col gap-0.5 px-1">
+                                    <Muted className="text-xs">Your profile URL will be:</Muted>
+                                    <Muted className="text-sm font-mono text-accent-aa">
+                                        neighborship.app/profiles/{answers.username || '…'}
+                                    </Muted>
+                                </div>
+                            </div>
+                        )}
 
-                    {error && <p className="text-destructive text-sm">{error}</p>}
-                    {submitError && <p className="text-destructive text-sm">{submitError}</p>}
+                        {current.type === 'skills' && current.skillsKey && (
+                            <div id={inputId}>
+                                <SkillPicker
+                                    selected={answers[current.skillsKey]}
+                                    available={profileData?.available_catalog_skills ?? []}
+                                    onChange={skills => setAnswers(prev => ({ ...prev, [current.skillsKey!]: skills }))}
+                                    mode={answers.primaryUsage === 'mentor' ? 'mentor' : 'mentee'}
+                                />
+                            </div>
+                        )}
+
+                        {error && (
+                            <p role="alert" className="text-destructive text-sm px-1">{error}</p>
+                        )}
+                        {submitError && (
+                            <p role="alert" className="text-destructive text-sm px-1">{submitError}</p>
+                        )}
+                    </div>
+
+                    {/* Navigation */}
+                    <div className="flex items-center justify-between pt-2 border-t border-line">
+                        <Button
+                            variant="ghost"
+                            onClick={handleBack}
+                            disabled={isSubmitting}
+                            className="gap-2 text-ink-soft hover:text-ink"
+                        >
+                            <ArrowLeft className="h-4 w-4" />
+                            {activeIndex === 0 ? 'Sign out' : 'Back'}
+                        </Button>
+                        <Button
+                            className="gap-2 px-7"
+                            onClick={handleNext}
+                            disabled={isSubmitting}
+                        >
+                            {isSubmitting
+                                ? 'Saving…'
+                                : activeIndex < questions.length - 1
+                                    ? <>Continue <ArrowRight className="h-4 w-4" /></>
+                                    : 'Finish'}
+                        </Button>
+                    </div>
+
                 </div>
-
-                {/* Navigation */}
-                <div className="flex items-center justify-between pt-2">
-                    <Button
-                        variant="ghost"
-                        onClick={handleBack}
-                        disabled={isSubmitting}
-                        className="text-muted-foreground"
-                    >
-                        ← Back
-                    </Button>
-                    <Button
-                        className="px-8"
-                        onClick={handleNext}
-                        disabled={isSubmitting}
-                    >
-                        {isSubmitting
-                            ? 'Saving...'
-                            : activeIndex < questions.length - 1
-                                ? 'Continue →'
-                                : 'Finish'}
-                    </Button>
-                </div>
-
             </div>
         </div>
     )

--- a/web/src/routes/_public/communities.$communitySlug.tsx
+++ b/web/src/routes/_public/communities.$communitySlug.tsx
@@ -18,6 +18,7 @@ import {
 import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
 import { MediaUploadField } from '@/components/MediaUploadField'
+import { MediaAttachment } from '@/components/MediaAttachment'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import {
     communityDetailQueryOptions,
@@ -36,14 +37,10 @@ import {
 } from '@/lib/queries/CommunityQueries.ts'
 import { meQueryOptions } from '@/lib/queries/AuthQueries.ts'
 import { useMessaging } from '@/lib/queries/MessagingQueries.ts'
-import { cn } from '@/lib/utils'
+import { cn, getAbsoluteMediaUrl } from '@/lib/utils'
 import { toast } from 'sonner'
 import type { PublicMentorProfile } from '@/lib/queries/DiscoverQueries.ts'
 
-function mediaFileName(url: string): string {
-    const raw = url.split('/').pop()?.split('?')[0] ?? 'media'
-    return /^[a-f0-9]{32}_/.test(raw) ? raw.slice(33) : raw
-}
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -92,7 +89,7 @@ function UserAvatar({
     if (pictureUrl) {
         return (
             <img
-                src={pictureUrl}
+                src={getAbsoluteMediaUrl(pictureUrl)}
                 alt={displayName}
                 className={cn('rounded-full object-cover shrink-0 border border-line', dim)}
             />
@@ -223,11 +220,7 @@ function CommunityPostCard({
                 </Muted>
             )}
 
-            {post.media_url && (
-                <a href={post.media_url} target="_blank" rel="noopener noreferrer" className="text-xs text-accent-aa underline truncate">
-                    {mediaFileName(post.media_url)}
-                </a>
-            )}
+            {post.media_url && <MediaAttachment url={post.media_url} />}
         </div>
     )
 }

--- a/web/src/routes/_public/communities.$communitySlug.tsx
+++ b/web/src/routes/_public/communities.$communitySlug.tsx
@@ -3,7 +3,7 @@ import { createFileRoute, useNavigate, Link } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
 import {
     Users, ChevronLeft, Pencil, Plus, Trophy, TrendingUp,
-    Trash2, Loader2, Lock, User, MessageSquare,
+    Trash2, Loader2, User, MessageSquare,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -126,21 +126,21 @@ function MemberCard({
                 <Button
                     variant="ghost"
                     size="sm"
-                    className="h-7 w-7 p-0 text-ink-soft hover:text-accent"
+                    className="h-7 w-7 p-0 text-ink-soft hover:text-accent-aa"
                     onClick={() => onViewProfile(profile.username)}
-                    aria-label="View profile"
+                    aria-label={`View ${profile.full_name}'s profile`}
                 >
-                    <User className="h-3.5 w-3.5" />
+                    <User className="h-3.5 w-3.5" aria-hidden="true" />
                 </Button>
                 {onSendMessage && (
                     <Button
                         variant="ghost"
                         size="sm"
-                        className="h-7 w-7 p-0 text-ink-soft hover:text-accent"
+                        className="h-7 w-7 p-0 text-ink-soft hover:text-accent-aa"
                         onClick={() => onSendMessage(profile.username)}
-                        aria-label="Send message"
+                        aria-label={`Send message to ${profile.full_name}`}
                     >
-                        <MessageSquare className="h-3.5 w-3.5" />
+                        <MessageSquare className="h-3.5 w-3.5" aria-hidden="true" />
                     </Button>
                 )}
             </div>
@@ -166,7 +166,7 @@ function CommunityPostCard({
     const { Icon, label, className } = EVENT_TYPE_META[post.event_type]
 
     return (
-        <div className="rounded-lg border border-line bg-white dark:bg-white/5 px-5 py-4 flex flex-col gap-3 hover:border-accent/40 transition-colors">
+        <div className="rounded-lg border border-line bg-card px-5 py-4 flex flex-col gap-3 hover:border-accent/40 transition-colors">
 
             {/* Header: avatar + author info + actions */}
             <div className="flex items-start justify-between gap-3">
@@ -190,10 +190,10 @@ function CommunityPostCard({
                 {isOwn && (
                     <div className="flex items-center gap-1 shrink-0">
                         <Button variant="ghost" size="sm" className="h-7 w-7 p-0 text-ink-soft hover:text-ink" onClick={() => onEdit(post)} aria-label="Edit post">
-                            <Pencil className="w-3.5 h-3.5" />
+                            <Pencil className="w-3.5 h-3.5" aria-hidden="true" />
                         </Button>
                         <Button variant="ghost" size="sm" className="h-7 w-7 p-0 text-ink-soft hover:text-red-500" onClick={() => onDelete(post)} aria-label="Delete post">
-                            <Trash2 className="w-3.5 h-3.5" />
+                            <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
                         </Button>
                     </div>
                 )}
@@ -201,7 +201,7 @@ function CommunityPostCard({
 
             {/* Event type badge */}
             <span className={`self-start inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full border ${className}`}>
-                <Icon className="w-3 h-3" />
+                <Icon className="w-3 h-3" aria-hidden="true" />
                 {label}
             </span>
 
@@ -214,7 +214,7 @@ function CommunityPostCard({
                     with{' '}
                     {post.tagged_users.map((u, i) => (
                         <span key={u.user_id}>
-                            <Link to="/profiles/$username" params={{ username: u.username }} className="text-accent hover:underline">
+                            <Link to="/profiles/$username" params={{ username: u.username }} className="text-accent-aa hover:underline">
                                 @{u.username}
                             </Link>
                             {i < post.tagged_users.length - 1 && ', '}
@@ -224,7 +224,7 @@ function CommunityPostCard({
             )}
 
             {post.media_url && (
-                <a href={post.media_url} target="_blank" rel="noopener noreferrer" className="text-xs text-accent underline truncate">
+                <a href={post.media_url} target="_blank" rel="noopener noreferrer" className="text-xs text-accent-aa underline truncate">
                     {mediaFileName(post.media_url)}
                 </a>
             )}
@@ -357,7 +357,7 @@ function CreatePostDialog({
                         <Checkbox checked={form.show_on_profile} onCheckedChange={(v) => setForm((f) => ({ ...f, show_on_profile: Boolean(v) }))} />
                         Share to my profile
                     </label>
-                    <DialogFooter className="mt-2">
+                    <DialogFooter className="mt-2 border-line border-t">
                         <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
                         <Button type="submit" disabled={!form.content.trim() || createMutation.isPending} className="bg-accent hover:bg-accent/90 text-white">
                             {createMutation.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : 'Publish'}
@@ -585,7 +585,7 @@ export function CommunityDetailPage() {
         hasNextPage,
         isFetchingNextPage,
         fetchNextPage,
-    } = useInfiniteCommunityPosts(community?.is_member ? community.id : '')
+    } = useInfiniteCommunityPosts(community?.id ?? '')
 
     const joinMutation = useJoinCommunityMutation()
     const leaveMutation = useLeaveCommunityMutation()
@@ -630,7 +630,7 @@ export function CommunityDetailPage() {
         return (
             <div className="page-wrap py-24 text-center">
                 <p className="text-ink-soft text-lg">Community not found.</p>
-                <Link to="/communities" className="text-accent hover:underline text-sm mt-2 block">← Back to Communities</Link>
+                <Link to="/communities" className="text-accent-aa hover:underline text-sm mt-2 block">← Back to Communities</Link>
             </div>
         )
     }
@@ -644,7 +644,7 @@ export function CommunityDetailPage() {
             {/* ── Back link ───────────────────────────────────────────────── */}
             <div className="px-4 sm:px-6">
                 <Link to="/communities" className="inline-flex items-center gap-1.5 text-sm text-ink-soft hover:text-ink transition-colors">
-                    <ChevronLeft className="h-4 w-4" />
+                    <ChevronLeft className="h-4 w-4" aria-hidden="true" />
                     Communities
                 </Link>
             </div>
@@ -700,13 +700,13 @@ export function CommunityDetailPage() {
                                     {community.created_by_username && (
                                         <Muted className="text-sm">
                                             Created by{' '}
-                                            <Link to="/profiles/$username" params={{ username: community.created_by_username }} className="text-accent hover:underline">
+                                            <Link to="/profiles/$username" params={{ username: community.created_by_username }} className="text-accent-aa hover:underline">
                                                 @{community.created_by_username}
                                             </Link>
                                         </Muted>
                                     )}
                                     <p className="flex items-center gap-1.5 text-ink-soft text-sm">
-                                        <Users className="h-3.5 w-3.5" />
+                                        <Users className="h-3.5 w-3.5" aria-hidden="true" />
                                         {community.member_count.toLocaleString()} member{community.member_count !== 1 ? 's' : ''}
                                     </p>
                                 </div>
@@ -723,7 +723,7 @@ export function CommunityDetailPage() {
                                     <div>
                                         {isCreator && (
                                             <button onClick={() => setShowEditModal(true)} className="inline-flex items-center gap-1.5 text-sm text-ink-soft hover:text-ink hover:bg-accent-muted/60 transition-colors px-2 py-1.5 rounded-md">
-                                                <Pencil className="h-3.5 w-3.5" />
+                                                <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
                                                 Edit Description
                                             </button>
                                         )}
@@ -744,61 +744,59 @@ export function CommunityDetailPage() {
 
                     {/* Feed */}
                     <div className="flex flex-col gap-4">
-                        {!isMember ? (
-                            <div className="island-shell rounded-xl p-12 text-center flex flex-col items-center gap-3 shadow-sm opacity-60">
-                                <Lock className="h-8 w-8 text-ink-soft" />
-                                <p className="text-ink font-semibold">Members only</p>
-                                <Muted className="text-sm">Join this community to access the feed.</Muted>
-                            </div>
-                        ) : (
-                            <>
+                        <>
+                            {isMember && (
                                 <div className="flex justify-end">
-                                    <Button onClick={() => setCreateOpen(true)} className="rounded-full bg-accent hover:bg-accent/90 text-white gap-2" size="sm">
-                                        <Plus className="w-4 h-4" />
+                                    <Button onClick={() => setCreateOpen(true)} className="rounded-full bg-accent hover:bg-accent-light text-white gap-2" size="sm">
+                                        <Plus className="w-4 h-4" aria-hidden="true" />
                                         New Post
                                     </Button>
                                 </div>
+                            )}
 
-                                {postsLoading ? (
-                                    <div className="flex justify-center py-12">
-                                        <Loader2 className="h-5 w-5 animate-spin text-ink-soft" />
+                            {postsLoading ? (
+                                <div className="flex justify-center py-12" role="status" aria-label="Loading posts">
+                                    <Loader2 className="h-5 w-5 animate-spin text-ink-soft" aria-hidden="true" />
+                                </div>
+                            ) : posts.length === 0 ? (
+                                <div className="island-shell rounded-xl p-12 text-center flex flex-col items-center gap-3 shadow-sm">
+                                    <p className="text-ink font-semibold">No posts yet.</p>
+                                    <Muted className="text-sm max-w-sm">
+                                        {isMember
+                                            ? 'Be the first to share something with this community.'
+                                            : 'Join this community to be the first to post.'}
+                                    </Muted>
+                                </div>
+                            ) : (
+                                <div className="island-shell rounded-xl overflow-hidden">
+                                    <div className="px-6 py-4 border-b border-line flex items-center justify-between">
+                                        <span className="text-sm font-semibold text-ink">Posts</span>
+                                        <span className="text-xs text-ink-soft">{totalPosts} total</span>
                                     </div>
-                                ) : posts.length === 0 ? (
-                                    <div className="island-shell rounded-xl p-12 text-center flex flex-col items-center gap-3 shadow-sm">
-                                        <p className="text-ink font-semibold">No posts yet.</p>
-                                        <Muted className="text-sm max-w-sm">Be the first to share something with this community.</Muted>
+                                    <div className="flex flex-col gap-3 p-4">
+                                        {posts.map((post) => (
+                                            <CommunityPostCard
+                                                key={post.id}
+                                                post={post}
+                                                isOwn={me?.username === post.author.username}
+                                                onEdit={setEditPost}
+                                                onDelete={setDeletePost}
+                                            />
+                                        ))}
                                     </div>
-                                ) : (
-                                    <div className="island-shell rounded-xl overflow-hidden">
-                                        <div className="px-6 py-4 border-b border-line flex items-center justify-between">
-                                            <span className="text-sm font-semibold text-ink">Posts</span>
-                                            <span className="text-xs text-ink-soft">{totalPosts} total</span>
-                                        </div>
-                                        <div className="flex flex-col gap-3 p-4">
-                                            {posts.map((post) => (
-                                                <CommunityPostCard
-                                                    key={post.id}
-                                                    post={post}
-                                                    isOwn={me?.username === post.author.username}
-                                                    onEdit={setEditPost}
-                                                    onDelete={setDeletePost}
-                                                />
-                                            ))}
-                                        </div>
-                                        <div className="px-4 pb-4 flex flex-col items-center gap-2">
-                                            <Muted className="text-xs">{posts.length} of {totalPosts} posts</Muted>
-                                            {hasNextPage && (
-                                                <Button variant="outline" size="sm" disabled={isFetchingNextPage} onClick={() => fetchNextPage()}>
-                                                    {isFetchingNextPage
-                                                        ? <><Loader2 className="w-3.5 h-3.5 animate-spin mr-1" /> Loading…</>
-                                                        : 'Load more'}
-                                                </Button>
-                                            )}
-                                        </div>
+                                    <div className="px-4 pb-4 flex flex-col items-center gap-2">
+                                        <Muted className="text-xs">{posts.length} of {totalPosts} posts</Muted>
+                                        {hasNextPage && (
+                                            <Button variant="outline" size="sm" disabled={isFetchingNextPage} onClick={() => fetchNextPage()}>
+                                                {isFetchingNextPage
+                                                    ? <><Loader2 className="w-3.5 h-3.5 animate-spin mr-1" aria-hidden="true" /> Loading…</>
+                                                    : 'Load more'}
+                                            </Button>
+                                        )}
                                     </div>
-                                )}
-                            </>
-                        )}
+                                </div>
+                            )}
+                        </>
                     </div>
 
                 </div>{/* end RIGHT column */}

--- a/web/src/routes/_public/communities.index.tsx
+++ b/web/src/routes/_public/communities.index.tsx
@@ -70,7 +70,7 @@ function CommunityRow({
             <div className="flex items-end justify-between">
                 <div className="flex flex-col gap-1">
                     <h2 className="text-xl font-bold text-ink flex items-center gap-2">
-                        {icon}
+                        <span aria-hidden="true">{icon}</span>
                         {title}
                     </h2>
                     <Muted className="text-sm">{subtitle}</Muted>
@@ -274,7 +274,7 @@ export function CommunitiesPage() {
                                 className="shrink-0"
                                 aria-label="Clear search"
                             >
-                                <X className="h-4 w-4" />
+                                <X className="h-4 w-4" aria-hidden="true" />
                             </Button>
                         )}
                         {me && (
@@ -283,7 +283,7 @@ export function CommunitiesPage() {
                                 size="sm"
                                 onClick={() => setShowCreateModal(true)}
                             >
-                                <Plus className="h-4 w-4" />
+                                <Plus className="h-4 w-4" aria-hidden="true" />
                                 <span className="hidden sm:inline">Create</span>
                             </Button>
                         )}
@@ -350,7 +350,7 @@ export function CommunitiesPage() {
                                 Be the first to{' '}
                                 <button
                                     onClick={() => setShowCreateModal(true)}
-                                    className="text-accent underline-offset-2 hover:underline"
+                                    className="text-accent-aa underline-offset-2 hover:underline"
                                 >
                                     create one
                                 </button>

--- a/web/src/routes/_public/discover.tsx
+++ b/web/src/routes/_public/discover.tsx
@@ -156,7 +156,7 @@ export function DiscoverPage() {
                         <MentorRow
                             title="Popular Mentors"
                             subtitle="Highest rated mentors trusted by the most mentees in the network."
-                            icon={<TrendingUp className="h-5 w-5 text-accent" />}
+                            icon={<TrendingUp className="h-5 w-5 text-accent" aria-hidden="true" />}
                             profiles={popularMentors}
                             onViewProfile={handleViewProfile}
                             onSendMessage={sendMessageTo}
@@ -168,7 +168,7 @@ export function DiscoverPage() {
                         <MentorRow
                             title="Recently Joined"
                             subtitle="Fresh perspectives, mentors who just joined and are ready to take on mentees."
-                            icon={<Sparkles className="h-5 w-5 text-amber-500" />}
+                            icon={<Sparkles className="h-5 w-5 text-amber-500" aria-hidden="true" />}
                             profiles={recentMentors}
                             onViewProfile={handleViewProfile}
                             onSendMessage={sendMessageTo}
@@ -221,7 +221,7 @@ export function DiscoverPage() {
                         <Button
                             onClick={() => fetchNextPage()}
                             disabled={isFetching}
-                            className="bg-accent hover:bg-accent-light text-white px-12 py-6 rounded-full text-sm font-bold uppercase tracking-widest shadow-md hover:-translate-y-0.5 transition-all duration-300"
+                            className="bg-accent hover:bg-accent-light text-white px-10 shadow-sm hover:-translate-y-0.5 transition-all duration-200"
                         >
                             {isFetching ? 'Loading...' : 'Load More'}
                         </Button>

--- a/web/src/routes/_unauthorized/login.tsx
+++ b/web/src/routes/_unauthorized/login.tsx
@@ -3,16 +3,13 @@ import { Button } from "@/components/ui/button"
 import {
     Card,
     CardContent,
-    CardDescription,
     CardFooter,
-    CardHeader,
-    CardTitle,
 } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { useGoogleLogin } from '@react-oauth/google'
 import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
-import { CalendarDays, Search, TrendingUp } from 'lucide-react'
+import { CalendarDays, Eye, EyeOff, Search, TrendingUp } from 'lucide-react'
 
 import { requestForToken } from "#/lib/firebase-client"
 import { googleLoginFn, handleAuthSuccess, loginFn } from "#/lib/queries/AuthQueries.ts"
@@ -33,6 +30,7 @@ export function LoginPage() {
     const router = useRouter()
     const [email, setEmail] = useState('')
     const [password, setPassword] = useState('')
+    const [showPassword, setShowPassword] = useState(false)
 
     const login = useMutation({
         mutationFn: loginFn,
@@ -82,14 +80,14 @@ export function LoginPage() {
     return (
         <div className="grid min-h-screen lg:grid-cols-[5fr_4fr]">
 
-            <aside className="lg:flex flex-col px-14 py-12 bg-petal border-r border-line">
+            <aside aria-hidden="true" className="hidden lg:flex flex-col px-14 py-12 bg-petal border-r border-line">
                 <Display className="mb-10">Neighborship</Display>
                 <div className="island-shell rounded-2xl px-8 py-10 space-y-6 min-h-3/4 rise-in">
                     <Body className="island-kicker">Peer tutoring platform</Body>
                     <Display as="h2" className="leading-[1.2] max-w-xs">
                         Study better,<br />together.
                     </Display>
-                    <Body className="text-(--color-brand-ink-soft) max-w-90">
+                    <Body className="text-ink-soft max-w-90">
                         Find mentors from your own campus, book sessions around your
                         schedule, and actually understand the material.
                     </Body>
@@ -109,22 +107,16 @@ export function LoginPage() {
                 </div>
             </aside>
 
-            <main className="flex flex-col justify-start items-center px-6 py-16 sm:px-12">
+            <main id="main-content" className="flex flex-col justify-start items-center px-6 py-16 sm:px-12">
                 <div className="w-full max-w-lg rise-in">
 
-                    <div className="mb-6 px-1">
-                        <Heading as="h2" className="mb-10">Welcome back</Heading>
+                    <div className="mb-8 px-1">
+                        <Heading as="h1">Welcome back</Heading>
+                        <Muted className="mt-2 text-ink-soft">Enter your email below to sign in to your account.</Muted>
                     </div>
 
                     <Card className="w-full island-shell border-line">
-                        <CardHeader>
-                            <CardTitle>Login to your account</CardTitle>
-                            <CardDescription>
-                                Enter your email below to login to your account
-                            </CardDescription>
-                        </CardHeader>
-
-                        <CardContent>
+                        <CardContent className="pt-6">
                             <form
                                 id="login-form"
                                 className="flex flex-col gap-5"
@@ -139,58 +131,77 @@ export function LoginPage() {
                                         onChange={(e) => setEmail(e.target.value)}
                                         placeholder="you@university.edu"
                                         required
+                                        autoComplete="email"
+                                        className="py-3 rounded-xl"
                                     />
                                 </div>
 
                                 <div className="grid gap-1.5">
-                                    <div className="flex items-center justify-between">
-                                        <Label htmlFor="password">Password</Label>
+                                    <Label htmlFor="password">Password</Label>
+                                    <div className="relative">
+                                        <Input
+                                            id="password"
+                                            type={showPassword ? 'text' : 'password'}
+                                            value={password}
+                                            onChange={(e) => setPassword(e.target.value)}
+                                            placeholder="••••••••"
+                                            required
+                                            autoComplete="current-password"
+                                            className="py-3 rounded-xl pr-10"
+                                        />
+                                        <Button
+                                            type="button"
+                                            variant="ghost"
+                                            size="icon"
+                                            className="absolute right-1 top-1/2 -translate-y-1/2 h-8 w-8 text-ink-soft hover:text-ink"
+                                            onClick={() => setShowPassword((v) => !v)}
+                                            aria-label={showPassword ? 'Hide password' : 'Show password'}
+                                        >
+                                            {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                                        </Button>
+                                    </div>
+                                    <div className="flex justify-end">
                                         <Link
                                             to="/forgot-password"
-                                            className="text-xs text-accent-light underline-offset-4 hover:underline hover:text-accent transition-colors"
+                                            className="text-xs text-accent-aa underline-offset-4 hover:underline hover:text-accent transition-colors"
                                         >
                                             Forgot your password?
                                         </Link>
                                     </div>
-                                    <Input
-                                        id="password"
-                                        type="password"
-                                        value={password}
-                                        onChange={(e) => setPassword(e.target.value)}
-                                        placeholder="••••••••"
-                                        required
-                                    />
                                 </div>
                             </form>
                         </CardContent>
 
                         <CardFooter className="flex-col gap-3">
-                            {/* THE REAL FORM SUBMIT BUTTON */}
                             <Button type="submit" form="login-form" className="w-full" disabled={login.isPending}>
                                 {login.isPending ? 'Signing in...' : 'Sign in'}
                             </Button>
 
                             {login.isError && (
-                                <p className="text-xs text-destructive">{login.error.message}</p>
+                                <div role="alert" className="w-full flex items-start gap-3 p-3 rounded-lg bg-destructive/10 border border-destructive/20">
+                                    <p className="text-sm text-destructive">{login.error.message}</p>
+                                </div>
                             )}
 
                             {googleLogin.isError && (
-                                <p className="text-xs text-destructive">{googleLogin.error.message}</p>
+                                <div role="alert" className="w-full flex items-start gap-3 p-3 rounded-lg bg-destructive/10 border border-destructive/20">
+                                    <p className="text-sm text-destructive">{googleLogin.error.message}</p>
+                                </div>
                             )}
 
                             <div className="flex items-center gap-3 w-full mt-2">
-                                <div className="flex-1 h-px bg-(--color-brand-line)" />
+                                <div className="flex-1 h-px bg-line" />
                                 <Muted as="span" className="text-xs uppercase tracking-widest">or</Muted>
-                                <div className="flex-1 h-px bg-(--color-brand-line)" />
+                                <div className="flex-1 h-px bg-line" />
                             </div>
 
                             <Button
                                 variant="outline"
-                                className="w-full gap-2 border-line"
+                                className="w-full gap-2 border-line rounded-xl"
                                 onClick={() => triggerGoogleLogin()}
                                 disabled={googleLogin.isPending}
                             >
-                                <svg width="15" height="15" viewBox="0 0 24 24" aria-hidden>
+                                <svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true">
                                     <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4" />
                                     <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
                                     <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z" fill="#FBBC05" />
@@ -203,7 +214,7 @@ export function LoginPage() {
                                 No account yet?{' '}
                                 <Link
                                     to="/register"
-                                    className="font-medium text-accent-light underline-offset-4 hover:underline hover:text-accent transition-colors"
+                                    className="font-medium text-accent-aa underline-offset-4 hover:underline hover:text-accent transition-colors"
                                 >
                                     Sign up free
                                 </Link>

--- a/web/src/routes/_unauthorized/register.tsx
+++ b/web/src/routes/_unauthorized/register.tsx
@@ -13,7 +13,7 @@ import { Label } from "@/components/ui/label"
 import { useGoogleLogin } from '@react-oauth/google'
 import { useMutation } from "@tanstack/react-query"
 import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
-import { Mail, User } from 'lucide-react'
+import { Mail } from 'lucide-react'
 import { useState } from 'react'
 import { z } from 'zod'
 
@@ -124,31 +124,32 @@ export function RegisterPage() {
     return (
         <div className="grid min-h-screen lg:grid-cols-[5fr_4fr]">
             {/* Left Column: Editorial Content */}
-            <aside className="lg:flex flex-col px-14 py-12 bg-petal border-r border-line relative overflow-hidden">
+            <aside aria-hidden="true" className="hidden lg:flex flex-col px-14 py-12 bg-petal border-r border-line relative overflow-hidden">
                 <Display className="mb-10 relative z-10">Neighborship</Display>
 
                 <div className="island-shell rounded-2xl px-8 py-10 space-y-6 min-h-3/4 relative z-10 rise-in">
-                    <Body className="island-kicker">Academic Editorial Excellence</Body>
-                    <Display as="h2" className="leading-[1.2] max-w-md">
-                        Join our community of academic excellence
+                    <Body className="island-kicker">Join the community</Body>
+                    <Display as="h2" className="leading-[1.2] max-w-xs">
+                        Your next mentor is already here.
                     </Display>
-                    <Body className="text-(--color-brand-ink-soft) max-w-md">
-                        Connect with top-tier tutors and fellow scholars. Refine your research,
-                        master your curriculum, and achieve editorial-grade perfection in your academic work.
+                    <Body className="text-ink-soft max-w-sm">
+                        No cold emails, no guesswork. Create your profile, find someone further
+                        down the road, and start the conversation that changes your trajectory.
                     </Body>
 
                     {/* Avatar Group */}
                     <div className="flex items-center gap-4 pt-4">
                         <div className="flex -space-x-3">
-                            <div className="w-12 h-12 rounded-full border-2 border-background bg-primary/20 flex items-center justify-center overflow-hidden">
-                                <User className="w-6 h-6 text-primary" />
-                            </div>
-                            <div className="w-12 h-12 rounded-full border-2 border-background bg-primary/20 flex items-center justify-center overflow-hidden">
-                                <User className="w-6 h-6 text-primary" />
-                            </div>
-                            <div className="w-12 h-12 rounded-full border-2 border-background bg-accent/20 flex items-center justify-center overflow-hidden">
-                                <User className="w-6 h-6 text-accent" />
-                            </div>
+                            {[
+                                { initials: 'AK', bg: 'bg-accent/20',   text: 'text-accent'   },
+                                { initials: 'MJ', bg: 'bg-primary/15',  text: 'text-primary'  },
+                                { initials: 'SR', bg: 'bg-accent/30',   text: 'text-accent'   },
+                                { initials: 'TL', bg: 'bg-primary/20',  text: 'text-primary'  },
+                            ].map(({ initials, bg, text }) => (
+                                <div key={initials} className={`w-10 h-10 rounded-full border-2 border-petal ${bg} flex items-center justify-center overflow-hidden shrink-0`}>
+                                    <span className={`text-xs font-bold ${text}`}>{initials}</span>
+                                </div>
+                            ))}
                         </div>
                         <span className="text-sm text-ink-soft font-medium">Join 2,000+ scholars</span>
                     </div>
@@ -164,8 +165,8 @@ export function RegisterPage() {
                 <div className="w-full max-w-md rise-in">
 
                     <div className="text-center md:text-left mb-10">
-                        <Heading as="h2" className="mb-2">Create your account</Heading>
-                        <Body className="text-muted-foreground">Enter your details to begin your academic journey.</Body>
+                        <Heading as="h1" className="mb-2">Create your account</Heading>
+                        <Muted className="mt-1 text-ink-soft">Free to join. Free to discover. Takes under a minute.</Muted>
                     </div>
 
                     <Card className="w-full island-shell border-line">
@@ -186,9 +187,10 @@ export function RegisterPage() {
                                             value={formData.email}
                                             onChange={(e) => handleChange('email', e.target.value)}
                                             aria-invalid={!!errors.email}
-                                            className="w-full px-4 py-3 rounded-xl"
+                                            autoComplete="email"
+                                            className="w-full px-4 py-3 pr-10 rounded-xl"
                                         />
-                                        <Mail className="absolute right-4 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+                                        <Mail aria-hidden="true" className="absolute right-4 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
                                     </div>
                                     {errors.email && (
                                         <p className="text-xs text-destructive ml-1">{errors.email}</p>
@@ -205,6 +207,7 @@ export function RegisterPage() {
                                             value={formData.password}
                                             onChange={(e) => handleChange('password', e.target.value)}
                                             aria-invalid={!!errors.password}
+                                            autoComplete="new-password"
                                             className="w-full px-4 py-3 rounded-xl"
                                         />
                                         {errors.password && (
@@ -221,6 +224,7 @@ export function RegisterPage() {
                                             value={formData.confirmPassword}
                                             onChange={(e) => handleChange('confirmPassword', e.target.value)}
                                             aria-invalid={!!errors.confirmPassword}
+                                            autoComplete="new-password"
                                             className="w-full px-4 py-3 rounded-xl"
                                         />
                                         {errors.confirmPassword && (
@@ -299,17 +303,15 @@ export function RegisterPage() {
                                 {googleLogin.isPending ? 'Logging in...' : 'Sign up with Google'}
                             </Button>
 
-                            <div className="mt-2 pt-2 border-t border-border/10 text-center w-full">
-                                <p className="text-primary/70">
-                                    Already have an account?{" "}
-                                    <Link
-                                        to="/login"
-                                        className="font-bold text-primary hover:underline underline-offset-4 transition-all"
-                                    >
-                                        Log in
-                                    </Link>
-                                </p>
-                            </div>
+                            <Muted className="text-xs text-center w-full">
+                                Already have an account?{' '}
+                                <Link
+                                    to="/login"
+                                    className="font-medium text-accent-aa underline-offset-4 hover:underline hover:text-accent transition-colors"
+                                >
+                                    Log in
+                                </Link>
+                            </Muted>
                         </CardFooter>
                     </Card>
                 </div>

--- a/web/src/routes/_unauthorized/route.tsx
+++ b/web/src/routes/_unauthorized/route.tsx
@@ -14,6 +14,12 @@ export const Route = createFileRoute('/_unauthorized')({
 function RouteComponent() {
   return (
       <div className="flex flex-col min-h-screen bg-bg dark:bg-background">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-3 focus:left-3 focus:z-[100] focus:rounded-lg focus:bg-accent focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-white focus:shadow-lg"
+        >
+          Skip to main content
+        </a>
         <UnauthorizedHeader />
         <Outlet />
         <UnauthorizedFooter />

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -57,6 +57,7 @@
   --accent:          #4a7c6f;
   --accent-light:    #5e9488;
   --accent-muted:    #e8f2f0;
+  --accent-aa:       #3d6b5f;
   --iris:            #8bb8b0;
 
   --bg-base:         #faf8f4;
@@ -66,7 +67,7 @@
   --surface-strong:  rgba(255, 254, 251, 0.96);
   --line:            rgba(28, 28, 24, 0.09);
   --inset-glint:     rgba(255, 255, 255, 0.88);
-  --kicker:          #4a7c6f;
+  --kicker:          #3d6b5f;
 
   --hero-a:          rgba(74, 124, 111, 0.09);
   --hero-b:          rgba(210, 195, 168, 0.18);
@@ -107,6 +108,7 @@
     --accent:         #6db0a2;
     --accent-light:   #88c4b8;
     --accent-muted:   #0f201e;
+    --accent-aa:      #6db0a2;
     --iris:           #a8cec8;
 
     --bg-base:        #14120e;
@@ -162,6 +164,7 @@
   --color-accent:         var(--accent);
   --color-accent-light:   var(--accent-light);
   --color-accent-muted:   var(--accent-muted);
+  --color-accent-aa:      var(--accent-aa);
   --color-iris:           var(--iris);
   --color-petal:          var(--petal);
   --color-mist:           var(--mist);

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -26,9 +26,13 @@ const config = defineConfig({
   server: {
       proxy: {
         '/api': {
-          target: 'http://127.0.0.1:8000',
+          target: 'http://backend:8000',
           changeOrigin: true,
-        }
+        },
+        '/media': {
+          target: 'http://backend:8000',
+          changeOrigin: true,
+        },
       },
     allowedHosts: ['www.neighborship.app','neighborship.app','mentorhood.app','www.mentorhood.app'],
     host: '0.0.0.0',


### PR DESCRIPTION
## Related Issue

  Closes #558 

  ## Description

  UI polish, WCAG AA accessibility pass, and media loading fixes across the web frontend. All pages listed below now pass axe DevTools with 0 critical/serious violations.

  ## Type of Change

  - [x] Bug fix
  - [x] New feature
  - [x] Refactoring (no functional changes)
  - [ ] Documentation
  - [ ] CI/CD or configuration

  ## Changes by Area

  ### Bug Fixes
  - **Media files not loading** — Added `getAbsoluteMediaUrl()` utility that converts Django's relative `/media/…` paths to absolute URLs using `VITE_API_URL`, matching how the mobile app
  handles the same issue. Applied to every `<img>` rendering a `picture_url` or `media_url` across all pages.
  - **Message thread profile photos missing** — Firestore documents do not store `sender_picture_url`. Fixed by injecting `picture_url` from the already-cached conversations REST data
  (username → picture map) into each message's sender at render time. No extra network request.

  ### New: Shared `MediaAttachment` Component
  Inline image preview for uploaded media across community posts, profile posts, MCTE timeline entries, and messages. Images render inline; PDFs and unsupported types fall back to a download
   link. Replaces scattered ad-hoc link patterns.

  ### Communities Page
  - Posts now visible to non-members (removed membership gate)
  - `text-accent` → `text-accent-aa` for WCAG AA contrast on links
  - `bg-white` → `bg-card` (dark mode safe)
  - `aria-hidden` on all decorative icons

  ### Connections — Index & Timeline
  - "View Journey" button restyled to match "View Profile" for visual consistency
  - Timeline wrapped in a card with event count header
  - MCTE type badges now use the same colored scheme as community posts (amber / blue / green)
  - **Contrast fixes** (all now ≥ 4.5:1): `text-green-600` → `text-green-700`, `text-red-500` → `text-red-600`, `text-amber-600` → `text-amber-700`
  - `bg-white` → `bg-card`; `aria-hidden` on decorative icons

  ### Messages Page — 0 axe issues
  - **Thread header**: shows the other person's avatar, display name, @username, and a "View profile" link at the top of every open conversation
  - **Conversation list**: each row now shows a relative timestamp (time if today, date otherwise); selected conversation gets a left accent-coloured border
  - **Read / delivered / sent icons**: visually differentiated — full-white double-check = read, 70% double-check = delivered, 50% single-check = sent/sending
  - **Contrast fix**: removed `opacity-80` from message timestamps; white-on-accent went from 3.7:1 (fail) to 4.77:1 (pass)
  - Unread count badge gets `aria-label` with the count

  ### Profile Page — 0 axe issues (was 2)
  - `bg-white/70` / `bg-white/80` → `bg-card` on all cards; `text-gray-500` → `text-ink-soft`
  - `StarRow`: container gets `aria-label="N out of 5 stars"`; each star icon gets `aria-hidden`
  - Average rating `<p>` gets `aria-label="Average rating: X.X out of 5"`
  - Review pagination buttons: `aria-label="Previous/Next page"` + `aria-hidden` on chevron icons
  - `AvailabilityCalendar` week navigation: `aria-label="Previous/Next week"`; modal close buttons: `aria-label="Close"`
  - Decorative card header icons (Star, Sparkles, CalendarDays) → `aria-hidden="true"`

  ### EditProfileModal
  - X close icon → `aria-hidden` (button already had `aria-label`)
  - Camera/spinner overlay → `aria-hidden` (parent button is the labeled element)
  - Validation error messages → `role="alert"` for immediate screen reader announcement
  - "Show initials only" switch wired to its label via `id` / `htmlFor`
  - Save button: `aria-busy` + `sr-only` "Saving…" text while pending

  ## Checklist

  - [x] I have tested my changes locally
  - [x] My code builds without errors
  - [ ] I have written or updated tests where applicable
  - [x] I have performed a self-review of my code

  ## Notes

  `getAbsoluteMediaUrl` is a no-op for already-absolute URLs (e.g. Google OAuth avatars), so OAuth profile pictures are unaffected.
