### PR TITLE
bug: fixed application crash upon taking a community join notification

### DIFF
--- a/backend/profiles/signals.py
+++ b/backend/profiles/signals.py
@@ -139,7 +139,7 @@ def notify_tag_creator_on_join(
         user_id=creator_user_id,
         type=NotificationType.TAG_NEW_MEMBER,
         title=f"New member in {tag.name}",
-        message=f"A new user just joined your tag '{tag.name}'.",
+        message=f"A new user just joined your community '{tag.name}'.",
         actor_id=instance.profile_id,
         resource_type="community_tag",
         resource_id=tag.id,

--- a/web/src/components/notifications/NotificationItem.tsx
+++ b/web/src/components/notifications/NotificationItem.tsx
@@ -8,6 +8,7 @@ import {
     UserPlus,
     UserX,
     XCircle,
+    Bell,
 } from 'lucide-react'
 import { cn } from '#/lib/utils.ts'
 import type { Notification, NotificationType } from '#/lib/queries/NotificationQueries.ts'
@@ -69,10 +70,36 @@ const VARIANT_MAP: Record<NotificationType, VariantConfig> = {
         iconClass: 'text-blue-500',
         borderClass: 'border-l-blue-400',
     },
+    tag_new_member: {
+        icon: UserPlus,
+        iconClass: 'text-accent',
+        borderClass: 'border-l-accent',
+    },
+    tag_description_updated: {
+        icon: Clock,
+        iconClass: 'text-yellow-600',
+        borderClass: 'border-l-yellow-400',
+    },
+    tag_deleted: {
+        icon: UserX,
+        iconClass: 'text-red-500',
+        borderClass: 'border-l-red-400',
+    },
+    tag_matches_interest: {
+        icon: Star,
+        iconClass: 'text-yellow-500',
+        borderClass: 'border-l-yellow-400',
+    },
+}
+
+const DEFAULT_VARIANT: VariantConfig = {
+    icon: Bell,
+    iconClass: 'text-ink-soft',
+    borderClass: 'border-l-line',
 }
 
 export function NotificationItem({ notification }: { notification: Notification }) {
-    const variant = VARIANT_MAP[notification.type]
+    const variant = VARIANT_MAP[notification.type] || DEFAULT_VARIANT
     const Icon = variant.icon
     const conversationId =
         notification.type === 'new_message' ? (notification.resource_id ?? undefined) : undefined

--- a/web/src/lib/queries/NotificationQueries.ts
+++ b/web/src/lib/queries/NotificationQueries.ts
@@ -19,6 +19,10 @@ export type NotificationType =
     | 'new_message'
     | 'new_feedback_available'
     | 'report_resolved'
+    | 'tag_new_member'
+    | 'tag_description_updated'
+    | 'tag_deleted'
+    | 'tag_matches_interest'
 
 export interface Notification {
     id: string
@@ -101,4 +105,8 @@ export const NOTIFICATION_INVALIDATION_MAP: Record<NotificationType, string[][]>
     new_message:                 [['messaging', 'conversations']],
     new_feedback_available:      [['profiles', 'me']],
     report_resolved:             [['reports']],
+    tag_new_member:              [['communities']],
+    tag_description_updated:     [['communities']],
+    tag_deleted:                 [['communities']],
+    tag_matches_interest:        [['communities']],
 }


### PR DESCRIPTION
## Related Issue

Closes #584 

## Description

This PR fixes a critical frontend crash that occurs when the application receives notification types related to community tags (`tag_new_member`, `tag_description_updated`, `tag_deleted`, and `tag_matches_interest`). 

The fix includes:
- Adding the missing notification types to the frontend type definitions.
- Configuring icons and styles for these types in the `NotificationItem` component.
- Implementing a **fail-safe fallback mechanism** (using a default `Bell` icon) to prevent crashes if new notification types are added to the backend in the future without corresponding frontend updates.
- Updating cache invalidation logic to properly refresh community data upon receiving these notifications.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or configuration

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code

## Notes

The fix was verified with a unit test confirming that both known, new, and unknown notification types render gracefully without crashing. Receiving community notifications now correctly invalidates the `['communities']` query key.