### PR TITLE
fix: change schedule dedup by matchid to sessionid

### DIFF
--- a/mobile/__tests__/lib/mentorship-queries.test.ts
+++ b/mobile/__tests__/lib/mentorship-queries.test.ts
@@ -1,6 +1,6 @@
 import {
-  mapJourneyFeedToTimelineEvents,
   mapAvailabilityToSchedule,
+  mapJourneyFeedToTimelineEvents,
   mapMeetingSessionsToDashboard,
   mapRequestsToDashboard,
   mapUpcomingSessionsToDashboard,
@@ -315,7 +315,7 @@ describe("mentorship query mappers", () => {
     });
   });
 
-  it("deduplicates active meeting sessions by match after reschedule", () => {
+  it("keeps multiple active meeting sessions for the same match", () => {
     const sessions: BackendMeetingSession[] = [
       {
         session_id: "session-old",
@@ -379,10 +379,91 @@ describe("mentorship query mappers", () => {
 
     const mapped = mapMeetingSessionsToDashboard(sessions);
 
+    expect(mapped).toHaveLength(2);
+    expect(mapped[0]).toMatchObject({
+      id: "slot-old",
+      sessionId: "session-old",
+      requestId: "match-1",
+      user: "Ada Lovelace",
+      status: "Upcoming",
+    });
+    expect(mapped[1]).toMatchObject({
+      id: "slot-new",
+      sessionId: "session-new",
+      requestId: "match-1",
+      user: "Ada Lovelace",
+      status: "Upcoming",
+    });
+  });
+
+  it("deduplicates meeting sessions by session id", () => {
+    const sessions: BackendMeetingSession[] = [
+      {
+        session_id: "session-dup",
+        match_id: "match-1",
+        mentor: {
+          id: "mentor-1",
+          username: "mentor_ada",
+          display_name: "Ada Lovelace",
+          picture_url: "",
+          title: "Mentor",
+        },
+        mentee: {
+          id: "mentee-1",
+          username: "me_user",
+          display_name: "Me User",
+          picture_url: "",
+          title: "Mentee",
+        },
+        source_slot_id: "slot-old",
+        scheduled_start_at: "2026-04-20T09:00:00Z",
+        scheduled_end_at: "2026-04-20T10:00:00Z",
+        status: "SCHEDULED",
+        display_status: "SCHEDULED",
+        my_role: "MENTEE",
+        allowed_actions: ["cancel"],
+        canceled_by_role: null,
+        cancel_reason: "",
+        created_at: "2026-04-10T08:00:00Z",
+        updated_at: "2026-04-10T09:00:00Z",
+      },
+      {
+        session_id: "session-dup",
+        match_id: "match-1",
+        mentor: {
+          id: "mentor-1",
+          username: "mentor_ada",
+          display_name: "Ada Lovelace",
+          picture_url: "",
+          title: "Mentor",
+        },
+        mentee: {
+          id: "mentee-1",
+          username: "me_user",
+          display_name: "Me User",
+          picture_url: "",
+          title: "Mentee",
+        },
+        source_slot_id: "slot-new",
+        scheduled_start_at: "2026-04-21T11:00:00Z",
+        scheduled_end_at: "2026-04-21T12:00:00Z",
+        status: "SCHEDULED",
+        display_status: "SCHEDULED",
+        my_role: "MENTEE",
+        allowed_actions: ["cancel", "reschedule"],
+        canceled_by_role: null,
+        cancel_reason: "",
+        created_at: "2026-04-10T08:00:00Z",
+        updated_at: "2026-04-10T10:00:00Z",
+      },
+    ];
+
+    const mapped = mapMeetingSessionsToDashboard(sessions);
+
     expect(mapped).toHaveLength(1);
     expect(mapped[0]).toMatchObject({
       id: "slot-new",
-      sessionId: "session-new",
+      sessionId: "session-dup",
       requestId: "match-1",
       user: "Ada Lovelace",
       status: "Upcoming",

--- a/mobile/lib/queries/mentorship.ts
+++ b/mobile/lib/queries/mentorship.ts
@@ -468,7 +468,10 @@ export function useUpdateTimelineEventMutation(currentUsername?: string) {
       timestamp,
       show_on_profile,
     }: UpdateTimelineEventPayload) =>
-      apiPatch<TimelineEvent, Omit<UpdateTimelineEventPayload, "matchId" | "eventId">>(
+      apiPatch<
+        TimelineEvent,
+        Omit<UpdateTimelineEventPayload, "matchId" | "eventId">
+      >(
         `/api/mentorship/matches/${encodeURIComponent(matchId)}/journey/events/${encodeURIComponent(eventId)}/`,
         {
           ...(event_type ? { event_type } : {}),
@@ -852,7 +855,10 @@ export function useRespondToMentorshipRequestMutation() {
  *
  * @param username Profile username path parameter.
  */
-export function useAvailabilitySlotsQuery(username: string, enabled: boolean = true) {
+export function useAvailabilitySlotsQuery(
+  username: string,
+  enabled: boolean = true,
+) {
   return useQuery({
     queryKey: ["profiles", username, "availability-slots"],
     queryFn: () =>
@@ -1056,22 +1062,15 @@ export function mapMeetingSessionsToDashboard(
   sessions: BackendMeetingSession[],
 ): DashboardSessionItem[] {
   const now = new Date();
-  const latestActiveSessionByMatch = new Map<string, BackendMeetingSession>();
-  const nonActiveSessions: BackendMeetingSession[] = [];
+  const latestSessionById = new Map<string, BackendMeetingSession>();
 
   sessions.forEach((session) => {
-    const isActive =
-      session.display_status === "SCHEDULED" ||
-      session.display_status === "RESCHEDULED";
+    const key =
+      session.session_id || `${session.match_id}:${session.scheduled_start_at}`;
+    const current = latestSessionById.get(key);
 
-    if (!isActive) {
-      nonActiveSessions.push(session);
-      return;
-    }
-
-    const current = latestActiveSessionByMatch.get(session.match_id);
     if (!current) {
-      latestActiveSessionByMatch.set(session.match_id, session);
+      latestSessionById.set(key, session);
       return;
     }
 
@@ -1079,7 +1078,7 @@ export function mapMeetingSessionsToDashboard(
     const nextUpdatedAt = new Date(session.updated_at).getTime();
 
     if (nextUpdatedAt > currentUpdatedAt) {
-      latestActiveSessionByMatch.set(session.match_id, session);
+      latestSessionById.set(key, session);
       return;
     }
 
@@ -1088,14 +1087,11 @@ export function mapMeetingSessionsToDashboard(
       new Date(session.scheduled_start_at).getTime() >
         new Date(current.scheduled_start_at).getTime()
     ) {
-      latestActiveSessionByMatch.set(session.match_id, session);
+      latestSessionById.set(key, session);
     }
   });
 
-  const normalizedSessions = [
-    ...latestActiveSessionByMatch.values(),
-    ...nonActiveSessions,
-  ];
+  const normalizedSessions = Array.from(latestSessionById.values());
 
   return normalizedSessions
     .map((session) => {


### PR DESCRIPTION
**Title:** Fix schedule to show multiple sessions per match

## Related Issue

Closes #586 

## Description

Fixes schedule/session mapping to avoid collapsing multiple bookings from the same match and updates tests to cover the scenario.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or configuration

## Checklist

- [x] I have tested my changes locally 
- [x] My code builds without errors
- [x] I have written or updated tests where applicable
- [x] I have performed a self-review of my code

## Notes

Adjusted mapper to dedupe by `session_id` instead of `match_id`.