### PR TITLE
fix(mobile): resolve crash when refreshing community feed

### DIFF
--- a/mobile/lib/queries/communityPosts.ts
+++ b/mobile/lib/queries/communityPosts.ts
@@ -151,6 +151,9 @@ export function useMyCommunityPostsFeedQuery(
     isFetching: queries.some((query) => query.isFetching),
     isError: queries.some((query) => query.isError),
     error: queries.find((query) => query.error)?.error,
+    refetch: async () => {
+      await Promise.all(queries.map((query) => query.refetch()));
+    },
   };
 }
 


### PR DESCRIPTION
## Related Issue

Closes #587 

## Description

This PR fixes a crash on the mobile Community screen by adding a missing `refetch` function to the `useMyCommunityPostsFeedQuery` hook. 

Since `useMyCommunityPostsFeedQuery` uses `useQueries` to fetch posts from multiple communities, it returned a custom object that lacked the standard TanStack Query `refetch` method. I have implemented a wrapper `refetch` function that triggers a refetch for all underlying queries, ensuring the feed stays up to date during a pull-to-refresh action.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or configuration

## Checklist

- [x] I have tested my changes locally
- [x] My code builds without errors
- [x] I have updated tests where applicable
- [x] I have performed a self-review of my code

## Notes

Verified using the existing `mobile/__tests__/app/community.test.tsx` suite, which now covers the functional availability of the refetch method.
