### PR TITLE
fix: improve community page sidebar visibility and UI fixes

### DIFF
--- a/web/src/components/MediaUploadField.tsx
+++ b/web/src/components/MediaUploadField.tsx
@@ -51,11 +51,11 @@ export function MediaUploadField({ onUrl, currentUrl }: MediaUploadFieldProps) {
                 }}
             />
             {preview ? (
-                <div className="flex items-center gap-2 rounded-lg border border-line bg-background px-3 py-2 text-sm">
+                <div className="flex items-center gap-2 w-full min-w-0 rounded-lg border border-line bg-background px-3 py-2 text-sm overflow-hidden">
                     {preview.objectUrl && (
                         <img src={preview.objectUrl} alt="" className="h-10 w-10 rounded object-cover shrink-0" />
                     )}
-                    <span className="flex-1 truncate text-ink-soft">{preview.name}</span>
+                    <span className="flex-1 min-w-0 truncate text-ink-soft">{preview.name}</span>
                     {upload.isPending && <Loader2 className="h-4 w-4 animate-spin shrink-0 text-accent" />}
                     <button type="button" onClick={handleClear} className="shrink-0 text-ink-soft hover:text-ink">
                         <X className="h-4 w-4" />

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -61,7 +61,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed top-1/2 left-1/2 z-50 flex flex-col w-full max-w-[calc(100%-2rem)] max-h-[90vh] -translate-x-1/2 -translate-y-1/2 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none overflow-hidden sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}

--- a/web/src/routes/_authorized/__tests__/messages.test.tsx
+++ b/web/src/routes/_authorized/__tests__/messages.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { MessagesPage } from '../messages'
 
 globalThis.HTMLElement.prototype.scrollIntoView = vi.fn()
+globalThis.HTMLElement.prototype.scrollTo = vi.fn()
 
 const { mockUseConversations, mockUseMessages, mockUseSendMessage, mockUseMarkRead } = vi.hoisted(() => ({
   mockUseConversations: vi.fn(),

--- a/web/src/routes/_public/communities.$communitySlug.tsx
+++ b/web/src/routes/_public/communities.$communitySlug.tsx
@@ -694,7 +694,7 @@ export function CommunityDetailPage() {
                 )}
 
                 {/* ── RIGHT: Community header + feed ──────────────────────── */}
-                <div className="flex-1 min-w-0 flex flex-col gap-5">
+                <div className="flex-1 min-w-0 flex flex-col gap-5 max-w-4xl mx-auto">
 
                     {/* Community header island */}
                     <div className="island-shell rounded-2xl shadow-md flex flex-col">

--- a/web/src/routes/_public/communities.$communitySlug.tsx
+++ b/web/src/routes/_public/communities.$communitySlug.tsx
@@ -654,7 +654,7 @@ export function CommunityDetailPage() {
         <div className="py-4 sm:py-6 rise-in flex flex-col gap-5">
 
             {/* ── Back link ───────────────────────────────────────────────── */}
-            <div className="px-4 sm:px-6">
+            <div className="page-wrap">
                 <Link to="/communities" className="inline-flex items-center gap-1.5 text-sm text-ink-soft hover:text-ink transition-colors">
                     <ChevronLeft className="h-4 w-4" aria-hidden="true" />
                     Communities
@@ -662,7 +662,7 @@ export function CommunityDetailPage() {
             </div>
 
             {/* ── Two-column layout: LEFT = members sidebar, RIGHT = header + feed ── */}
-            <div className="flex items-start gap-6 px-4 sm:px-6 w-full">
+            <div className="flex flex-col gap-5 px-4 sm:px-6 lg:grid lg:grid-cols-[256px_1fr_256px] lg:gap-6 lg:items-start w-full">
 
                 {/* ── LEFT: Members sidebar ────── */}
                 <aside className="hidden lg:flex flex-col w-64 shrink-0 sticky top-20 self-start">
@@ -709,7 +709,7 @@ export function CommunityDetailPage() {
                 </aside>
 
                 {/* ── RIGHT: Community header + feed ──────────────────────── */}
-                <div className="flex-1 min-w-0 flex flex-col gap-5 max-w-6xl mx-auto">
+                <div className="min-w-0 flex flex-col gap-5">
 
                     {/* Community header island */}
                     <div className="island-shell rounded-2xl shadow-md flex flex-col">
@@ -876,6 +876,8 @@ export function CommunityDetailPage() {
                     </div>
 
                 </div>{/* end RIGHT column */}
+
+                <div className="hidden lg:block" />{/* balancing column */}
 
             </div>{/* end two-column */}
 

--- a/web/src/routes/_public/communities.$communitySlug.tsx
+++ b/web/src/routes/_public/communities.$communitySlug.tsx
@@ -664,38 +664,49 @@ export function CommunityDetailPage() {
             {/* ── Two-column layout: LEFT = members sidebar, RIGHT = header + feed ── */}
             <div className="flex items-start gap-6 px-4 sm:px-6 w-full">
 
-                {/* ── LEFT: Members sidebar (authenticated users only) ────── */}
-                {me && (
-                    <aside className="hidden lg:flex flex-col w-64 shrink-0 sticky top-20 self-start">
-                        <div className="island-shell rounded-xl flex flex-col max-h-[calc(100vh-6rem)] overflow-hidden">
-                            <div className="px-4 py-3 border-b border-line flex items-center justify-between">
-                                <span className="text-sm font-semibold text-ink">Members</span>
-                                <span className="text-xs text-ink-soft">{totalMembers.toLocaleString()}</span>
-                            </div>
-                            <div className="overflow-y-auto divide-y divide-line">
-                                {members.length === 0 ? (
-                                    <p className="text-xs text-ink-soft px-4 py-6 text-center">No members yet.</p>
-                                ) : (
-                                    <>
-                                        {members.map((profile) => (
-                                            <MemberCard
-                                                key={profile.id}
-                                                profile={profile}
-                                                onViewProfile={(username) => navigate({ to: '/profiles/$username', params: { username } })}
-                                                onSendMessage={matchedUsernames.has(profile.username) ? sendMessageTo : undefined}
-                                            />
-                                        ))}
-                                        {totalMembers > 50 && (
-                                            <p className="text-xs text-ink-soft px-4 py-3 text-center">
-                                                and {(totalMembers - 50).toLocaleString()} more
-                                            </p>
-                                        )}
-                                    </>
-                                )}
-                            </div>
+                {/* ── LEFT: Members sidebar ────── */}
+                <aside className="hidden lg:flex flex-col w-64 shrink-0 sticky top-20 self-start">
+                    <div className="island-shell rounded-xl flex flex-col max-h-[calc(100vh-6rem)] overflow-hidden">
+                        <div className="px-4 py-3 border-b border-line flex items-center justify-between">
+                            <span className="text-sm font-semibold text-ink">Members</span>
+                            {me && <span className="text-xs text-ink-soft">{totalMembers.toLocaleString()}</span>}
                         </div>
-                    </aside>
-                )}
+                        <div className="overflow-y-auto divide-y divide-line">
+                            {!me ? (
+                                <div className="flex flex-col items-center gap-2 px-4 py-8 text-center">
+                                    <Lock className="h-5 w-5 text-ink-soft/50" aria-hidden="true" />
+                                    <p className="text-xs text-ink-soft leading-snug">
+                                        Log in to see who's in this community.
+                                    </p>
+                                    <Link
+                                        to="/login"
+                                        className="mt-1 inline-flex items-center justify-center text-xs font-medium px-3 py-1.5 rounded-md bg-accent hover:bg-accent/90 text-white transition-colors"
+                                    >
+                                        Log in
+                                    </Link>
+                                </div>
+                            ) : members.length === 0 ? (
+                                <p className="text-xs text-ink-soft px-4 py-6 text-center">No members in this community yet.</p>
+                            ) : (
+                                <>
+                                    {members.map((profile) => (
+                                        <MemberCard
+                                            key={profile.id}
+                                            profile={profile}
+                                            onViewProfile={(username) => navigate({ to: '/profiles/$username', params: { username } })}
+                                            onSendMessage={matchedUsernames.has(profile.username) ? sendMessageTo : undefined}
+                                        />
+                                    ))}
+                                    {totalMembers > 50 && (
+                                        <p className="text-xs text-ink-soft px-4 py-3 text-center">
+                                            and {(totalMembers - 50).toLocaleString()} more
+                                        </p>
+                                    )}
+                                </>
+                            )}
+                        </div>
+                    </div>
+                </aside>
 
                 {/* ── RIGHT: Community header + feed ──────────────────────── */}
                 <div className="flex-1 min-w-0 flex flex-col gap-5 max-w-6xl mx-auto">

--- a/web/src/routes/_public/communities.$communitySlug.tsx
+++ b/web/src/routes/_public/communities.$communitySlug.tsx
@@ -328,35 +328,37 @@ function CreatePostDialog({
         <Dialog open={open} onOpenChange={onOpenChange}>
             <DialogContent className="sm:max-w-md">
                 <DialogHeader><DialogTitle>New Post</DialogTitle></DialogHeader>
-                <form onSubmit={handleSubmit} className="flex flex-col gap-4 mt-2">
-                    <div className="flex flex-col gap-1.5">
-                        <Label htmlFor="cop_create_type">Type</Label>
-                        <Select value={form.event_type} onValueChange={(v) => setForm((f) => ({ ...f, event_type: v as CommunityPostCreatePayload['event_type'] }))}>
-                            <SelectTrigger id="cop_create_type"><SelectValue /></SelectTrigger>
-                            <SelectContent>
-                                <SelectItem value="achievement">Achievement</SelectItem>
-                                <SelectItem value="social">Social</SelectItem>
-                                <SelectItem value="progress">Progress</SelectItem>
-                            </SelectContent>
-                        </Select>
+                <form onSubmit={handleSubmit} className="contents">
+                    <div className="flex flex-col gap-4 overflow-y-auto flex-1 min-h-0 mt-2 pb-1">
+                        <div className="flex flex-col gap-1.5">
+                            <Label htmlFor="cop_create_type">Type</Label>
+                            <Select value={form.event_type} onValueChange={(v) => setForm((f) => ({ ...f, event_type: v as CommunityPostCreatePayload['event_type'] }))}>
+                                <SelectTrigger id="cop_create_type"><SelectValue /></SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="achievement">Achievement</SelectItem>
+                                    <SelectItem value="social">Social</SelectItem>
+                                    <SelectItem value="progress">Progress</SelectItem>
+                                </SelectContent>
+                            </Select>
+                        </div>
+                        <div className="flex flex-col gap-1.5">
+                            <Label htmlFor="cop_create_content">Content <span className="text-red-500">*</span></Label>
+                            <Textarea id="cop_create_content" value={form.content} onChange={(e) => setForm((f) => ({ ...f, content: e.target.value }))} placeholder="Share something with this community…" maxLength={2000} rows={4} required />
+                            <p className="text-xs text-ink-soft text-right">{form.content.length}/2000</p>
+                        </div>
+                        <div className="flex flex-col gap-1.5">
+                            <Label>Tag people <span className="text-ink-soft text-xs">(max 5)</span></Label>
+                            <TaggableUsersList communityId={communityId} selected={form.tagged_users ?? []} onChange={(usernames) => setForm((f) => ({ ...f, tagged_users: usernames }))} />
+                        </div>
+                        <div className="flex flex-col gap-1.5">
+                            <Label>Media (optional)</Label>
+                            <MediaUploadField onUrl={url => setForm(f => ({ ...f, media_url: url ?? undefined }))} />
+                        </div>
+                        <label className="flex items-center gap-2.5 cursor-pointer text-sm">
+                            <Checkbox checked={form.show_on_profile} onCheckedChange={(v) => setForm((f) => ({ ...f, show_on_profile: Boolean(v) }))} />
+                            Share to my profile
+                        </label>
                     </div>
-                    <div className="flex flex-col gap-1.5">
-                        <Label htmlFor="cop_create_content">Content <span className="text-red-500">*</span></Label>
-                        <Textarea id="cop_create_content" value={form.content} onChange={(e) => setForm((f) => ({ ...f, content: e.target.value }))} placeholder="Share something with this community…" maxLength={2000} rows={4} required />
-                        <p className="text-xs text-ink-soft text-right">{form.content.length}/2000</p>
-                    </div>
-                    <div className="flex flex-col gap-1.5">
-                        <Label>Tag people <span className="text-ink-soft text-xs">(max 5)</span></Label>
-                        <TaggableUsersList communityId={communityId} selected={form.tagged_users ?? []} onChange={(usernames) => setForm((f) => ({ ...f, tagged_users: usernames }))} />
-                    </div>
-                    <div className="flex flex-col gap-1.5">
-                        <Label>Media (optional)</Label>
-                        <MediaUploadField onUrl={url => setForm(f => ({ ...f, media_url: url ?? undefined }))} />
-                    </div>
-                    <label className="flex items-center gap-2.5 cursor-pointer text-sm">
-                        <Checkbox checked={form.show_on_profile} onCheckedChange={(v) => setForm((f) => ({ ...f, show_on_profile: Boolean(v) }))} />
-                        Share to my profile
-                    </label>
                     <DialogFooter className="mt-2 border-line border-t">
                         <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
                         <Button type="submit" disabled={!form.content.trim() || createMutation.isPending} className="bg-accent hover:bg-accent/90 text-white">
@@ -412,35 +414,37 @@ function EditPostDialog({
         <Dialog open={open} onOpenChange={onOpenChange}>
             <DialogContent className="sm:max-w-md">
                 <DialogHeader><DialogTitle>Edit Post</DialogTitle></DialogHeader>
-                <form onSubmit={handleSubmit} className="flex flex-col gap-4 mt-2">
-                    <div className="flex flex-col gap-1.5">
-                        <Label htmlFor="cop_edit_type">Type</Label>
-                        <Select value={form.event_type} onValueChange={(v) => setForm((f) => ({ ...f, event_type: v as CommunityPostUpdatePayload['event_type'] }))}>
-                            <SelectTrigger id="cop_edit_type"><SelectValue /></SelectTrigger>
-                            <SelectContent>
-                                <SelectItem value="achievement">Achievement</SelectItem>
-                                <SelectItem value="social">Social</SelectItem>
-                                <SelectItem value="progress">Progress</SelectItem>
-                            </SelectContent>
-                        </Select>
+                <form onSubmit={handleSubmit} className="contents">
+                    <div className="flex flex-col gap-4 overflow-y-auto flex-1 min-h-0 mt-2 pb-1">
+                        <div className="flex flex-col gap-1.5">
+                            <Label htmlFor="cop_edit_type">Type</Label>
+                            <Select value={form.event_type} onValueChange={(v) => setForm((f) => ({ ...f, event_type: v as CommunityPostUpdatePayload['event_type'] }))}>
+                                <SelectTrigger id="cop_edit_type"><SelectValue /></SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="achievement">Achievement</SelectItem>
+                                    <SelectItem value="social">Social</SelectItem>
+                                    <SelectItem value="progress">Progress</SelectItem>
+                                </SelectContent>
+                            </Select>
+                        </div>
+                        <div className="flex flex-col gap-1.5">
+                            <Label htmlFor="cop_edit_content">Content <span className="text-red-500">*</span></Label>
+                            <Textarea id="cop_edit_content" value={form.content ?? ''} onChange={(e) => setForm((f) => ({ ...f, content: e.target.value }))} placeholder="Share something with this community…" maxLength={2000} rows={4} required />
+                            <p className="text-xs text-ink-soft text-right">{(form.content ?? '').length}/2000</p>
+                        </div>
+                        <div className="flex flex-col gap-1.5">
+                            <Label>Tag people <span className="text-ink-soft text-xs">(max 5)</span></Label>
+                            <TaggableUsersList communityId={communityId} selected={form.tagged_users ?? []} onChange={(usernames) => setForm((f) => ({ ...f, tagged_users: usernames }))} />
+                        </div>
+                        <div className="flex flex-col gap-1.5">
+                            <Label>Media (optional)</Label>
+                            <MediaUploadField currentUrl={post.media_url} onUrl={url => setForm(f => ({ ...f, media_url: url ?? undefined }))} />
+                        </div>
+                        <label className="flex items-center gap-2.5 cursor-pointer text-sm">
+                            <Checkbox checked={form.show_on_profile} onCheckedChange={(v) => setForm((f) => ({ ...f, show_on_profile: Boolean(v) }))} />
+                            Share to my profile
+                        </label>
                     </div>
-                    <div className="flex flex-col gap-1.5">
-                        <Label htmlFor="cop_edit_content">Content <span className="text-red-500">*</span></Label>
-                        <Textarea id="cop_edit_content" value={form.content ?? ''} onChange={(e) => setForm((f) => ({ ...f, content: e.target.value }))} placeholder="Share something with this community…" maxLength={2000} rows={4} required />
-                        <p className="text-xs text-ink-soft text-right">{(form.content ?? '').length}/2000</p>
-                    </div>
-                    <div className="flex flex-col gap-1.5">
-                        <Label>Tag people <span className="text-ink-soft text-xs">(max 5)</span></Label>
-                        <TaggableUsersList communityId={communityId} selected={form.tagged_users ?? []} onChange={(usernames) => setForm((f) => ({ ...f, tagged_users: usernames }))} />
-                    </div>
-                    <div className="flex flex-col gap-1.5">
-                        <Label>Media (optional)</Label>
-                        <MediaUploadField currentUrl={post.media_url} onUrl={url => setForm(f => ({ ...f, media_url: url ?? undefined }))} />
-                    </div>
-                    <label className="flex items-center gap-2.5 cursor-pointer text-sm">
-                        <Checkbox checked={form.show_on_profile} onCheckedChange={(v) => setForm((f) => ({ ...f, show_on_profile: Boolean(v) }))} />
-                        Share to my profile
-                    </label>
                     <DialogFooter className="mt-2">
                         <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
                         <Button type="submit" disabled={!form.content?.trim() || editMutation.isPending} className="bg-accent hover:bg-accent/90 text-white">

--- a/web/src/routes/_public/communities.$communitySlug.tsx
+++ b/web/src/routes/_public/communities.$communitySlug.tsx
@@ -694,7 +694,7 @@ export function CommunityDetailPage() {
                 )}
 
                 {/* ── RIGHT: Community header + feed ──────────────────────── */}
-                <div className="flex-1 min-w-0 flex flex-col gap-5 max-w-4xl mx-auto">
+                <div className="flex-1 min-w-0 flex flex-col gap-5 max-w-6xl mx-auto">
 
                     {/* Community header island */}
                     <div className="island-shell rounded-2xl shadow-md flex flex-col">


### PR DESCRIPTION
  ## Related Issue

  Closes #582 

  ## Description

  Improves the community detail page UI with several fixes and enhancements:

  - **Guest member sidebar**: The members sidebar is now visible to unauthenticated users, showing a lock icon with a "Log
  in" button that redirects to the login screen, instead of being hidden entirely.
  - **Empty members state**: When a community has no members, authenticated users now see a clearer "No members in this community yet." message.
  - **Community info panel size**: Adjusted the size and layout of the community info panel for better presentation.
  - **Edit post UI bug**: Fixed a visual bug in the edit post dialog.

  ## Type of Change

  - [x] Bug fix
  - [x] New feature

  ## Checklist

  - [x] I have tested my changes locally
  - [x] My code builds without errors
  - [ ] I have written or updated tests where applicable
  - [x] I have performed a self-review of my code

  ## Notes

  The members sidebar query remains gated behind authentication (`enabled: !!me`), so no extra API calls are made for guest users — only the UI state changes.