### PR TITLE
Feat/web small fixes

### DIFF
--- a/web/e2e/pages/DiscoverPage.ts
+++ b/web/e2e/pages/DiscoverPage.ts
@@ -77,7 +77,7 @@ export class DiscoverPage {
   }
 
   async search(value: string) {
-    await this.page.getByLabel('Search profiles, skills, or projects...').fill(value);
+    await this.page.getByLabel('Search profiles or skills...').fill(value);
     await this.page.waitForTimeout(400);
   }
 }

--- a/web/src/components/MediaAttachment.tsx
+++ b/web/src/components/MediaAttachment.tsx
@@ -14,20 +14,22 @@ interface MediaAttachmentProps {
     url: string
     imgClassName?: string
     linkClassName?: string
+    onLoad?: () => void
 }
 
-export function MediaAttachment({ url, imgClassName, linkClassName }: MediaAttachmentProps) {
+export function MediaAttachment({ url, imgClassName, linkClassName, onLoad }: MediaAttachmentProps) {
     const absUrl = getAbsoluteMediaUrl(url)
     const [imgFailed, setImgFailed] = useState(isPdfUrl(absUrl))
 
     if (!imgFailed) {
         return (
-            <a href={absUrl} target="_blank" rel="noopener noreferrer" className="block">
+            <a href={absUrl} target="_blank" rel="noopener noreferrer" className="block max-w-full overflow-hidden">
                 <img
                     src={absUrl}
                     alt={mediaFileName(url)}
                     className={cn('max-h-60 rounded-lg border border-line object-contain', imgClassName)}
                     onError={() => setImgFailed(true)}
+                    onLoad={onLoad}
                 />
             </a>
         )

--- a/web/src/components/community/CreateWorkshopDialog.tsx
+++ b/web/src/components/community/CreateWorkshopDialog.tsx
@@ -175,7 +175,7 @@ export function CreateWorkshopDialog({ tagId, open, onClose, editWorkshop }: Cre
                         </p>
                     )}
 
-                    <DialogFooter className="mt-2">
+                    <DialogFooter className="mt-2 border-line border-t">
                         <Button type="button" variant="outline" onClick={onClose} disabled={isPending}>Cancel</Button>
                         <Button type="submit" disabled={isPending} className="bg-accent hover:bg-accent/90 text-white">
                             {isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : isEdit ? 'Save Changes' : 'Create Workshop'}

--- a/web/src/components/community/WorkshopCard.tsx
+++ b/web/src/components/community/WorkshopCard.tsx
@@ -2,7 +2,7 @@ import { Link } from '@tanstack/react-router'
 import { Calendar, Clock, Users } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
-import { cn } from '@/lib/utils'
+import { cn, getAbsoluteMediaUrl } from '@/lib/utils'
 import type { CommunityWorkshop } from '@/lib/queries/WorkshopQueries.ts'
 
 const AVATAR_COLORS = [
@@ -104,7 +104,7 @@ export function WorkshopCard({ workshop, onViewDetails }: WorkshopCardProps) {
                 <div className="flex items-center gap-2 mt-auto pt-2 border-t border-line">
                     {workshop.author.picture_url ? (
                         <img
-                            src={workshop.author.picture_url}
+                            src={getAbsoluteMediaUrl(workshop.author.picture_url)}
                             alt={workshop.author.display_name}
                             className="h-7 w-7 rounded-full object-cover border border-white/50 shrink-0"
                         />

--- a/web/src/components/community/WorkshopDetailModal.tsx
+++ b/web/src/components/community/WorkshopDetailModal.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/components/ui/dialog'
 import { Muted } from '@/components/Typography'
 import { toast } from 'sonner'
-import { cn } from '@/lib/utils'
+import { cn, getAbsoluteMediaUrl } from '@/lib/utils'
 import {
     useCommunityWorkshopDetail,
     useJoinWorkshopMutation,
@@ -149,7 +149,7 @@ export function WorkshopDetailModal({ workshop, tagId, open, onClose, currentUse
                         {/* Host */}
                         <div className="flex items-center gap-3">
                             {resolved.author.picture_url ? (
-                                <img src={resolved.author.picture_url} alt={resolved.author.display_name} className="h-9 w-9 rounded-full object-cover border border-white/50 shrink-0" />
+                                <img src={getAbsoluteMediaUrl(resolved.author.picture_url)} alt={resolved.author.display_name} className="h-9 w-9 rounded-full object-cover border border-white/50 shrink-0" />
                             ) : (
                                 <div className={cn('h-9 w-9 rounded-full flex items-center justify-center text-xs font-bold shrink-0 border border-white/50', avatarColor(resolved.author.display_name))}>
                                     {miniInitials(resolved.author.display_name)}
@@ -182,7 +182,7 @@ export function WorkshopDetailModal({ workshop, tagId, open, onClose, currentUse
                                         {participants.map(p => (
                                             <div key={p.id} className="flex items-center gap-2.5 px-3 py-2">
                                                 {p.participant.picture_url ? (
-                                                    <img src={p.participant.picture_url} alt={p.participant.display_name} className="h-7 w-7 rounded-full object-cover border border-white/50 shrink-0" />
+                                                    <img src={getAbsoluteMediaUrl(p.participant.picture_url)} alt={p.participant.display_name} className="h-7 w-7 rounded-full object-cover border border-white/50 shrink-0" />
                                                 ) : (
                                                     <div className={cn('h-7 w-7 rounded-full flex items-center justify-center text-xs font-bold shrink-0', avatarColor(p.participant.display_name))}>
                                                         {miniInitials(p.participant.display_name)}
@@ -221,7 +221,7 @@ export function WorkshopDetailModal({ workshop, tagId, open, onClose, currentUse
                         )}
                     </div>
 
-                    <DialogFooter className="mt-4 flex flex-wrap gap-2">
+                    <DialogFooter className="mt-4 flex flex-wrap gap-2 border-t border-line">
                         {Boolean(isAuthor) && isActive && !confirmCancel && (
                             <>
                                 <Button variant="outline" size="sm" onClick={() => setEditOpen(true)}>Edit Workshop</Button>

--- a/web/src/components/dashboard/SessionManagementModal.tsx
+++ b/web/src/components/dashboard/SessionManagementModal.tsx
@@ -12,9 +12,8 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
 import { useQueryClient } from '@tanstack/react-query'
-import { ArrowLeft, Calendar, CalendarDays, ChevronLeft, ChevronRight, Clock, Link2, Loader2, XCircle } from 'lucide-react'
+import { ArrowLeft, Calendar, CalendarDays, ChevronLeft, ChevronRight, Clock, Loader2, XCircle } from 'lucide-react'
 import { useState } from 'react'
 import { toast } from 'sonner'
 
@@ -175,7 +174,7 @@ function RescheduleView({ sessionId, mentorUsername, onBack, onSuccess }: Resche
         })}
       </div>
 
-      <DialogFooter>
+      <DialogFooter className="border-t border-line">
         <Button variant="outline" onClick={onBack} className="border-line text-ink-soft" disabled={reschedule.isPending}>
           Back
         </Button>
@@ -196,23 +195,12 @@ function RescheduleView({ sessionId, mentorUsername, onBack, onSuccess }: Resche
 export function SessionManagementModal({ session }: Readonly<SessionManagementModalProps>) {
   const [isOpen, setIsOpen] = useState(false)
   const [view, setView] = useState<'manage' | 'reschedule'>('manage')
-  const [meetingLink, setMeetingLink] = useState('')
-  const [isSaved, setIsSaved] = useState(false)
   const queryClient = useQueryClient()
   const cancelSession = useCancelSession()
 
   const handleClose = () => {
     setIsOpen(false)
     setView('manage')
-    setIsSaved(false)
-  }
-
-  const handleSaveLink = (e: React.SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    if (!meetingLink.trim()) return
-    // FUTURE: Trigger TanStack Query mutation to update the session's meeting link on the backend
-    console.log('Saving meeting link for session', session.id, ':', meetingLink)
-    setIsSaved(true)
   }
 
   const handleCancelSession = () => {
@@ -286,41 +274,6 @@ export function SessionManagementModal({ session }: Readonly<SessionManagementMo
                   <Body className="text-sm">{sessionTime}</Body>
                 </div>
               </div>
-
-              {/* Meeting Link Input */}
-              <div className="flex flex-col gap-2">
-                <Body className="text-sm font-medium flex items-center gap-1.5">
-                  <Link2 className="w-4 h-4 text-accent" />
-                  Meeting Link
-                </Body>
-                <Muted className="text-xs text-ink-soft">
-                  Paste a Zoom or Google Meet link to share with your mentee.
-                </Muted>
-                <form onSubmit={handleSaveLink} className="flex gap-2 mt-1">
-                  <Input
-                    placeholder="https://zoom.us/j/... or meet.google.com/..."
-                    value={meetingLink}
-                    onChange={(e) => { setMeetingLink(e.target.value); setIsSaved(false) }}
-                    className="border-line"
-                  />
-                  <Button
-                    type="submit"
-                    variant="secondary"
-                    className="shrink-0 border border-line bg-white hover:bg-black/[0.02]"
-                    disabled={!meetingLink.trim()}
-                  >
-                    Save
-                  </Button>
-                </form>
-                {isSaved && (
-                  <Muted className="text-xs text-green-600 font-medium">
-                    Meeting link saved successfully.
-                  </Muted>
-                )}
-              </div>
-
-              {/* Divider */}
-              <div className="border-t border-line" />
 
               {/* Session Actions */}
               <div className="flex flex-col gap-2">

--- a/web/src/components/features/discover/DiscoverSearchBar.tsx
+++ b/web/src/components/features/discover/DiscoverSearchBar.tsx
@@ -12,7 +12,7 @@ interface DiscoverSearchBarProps {
 export function DiscoverSearchBar({
   value,
   onChange,
-  placeholder = 'Search profiles, skills, or projects...',
+  placeholder = 'Search profiles or skills...',
   className,
 
 }: Readonly<DiscoverSearchBarProps>) {

--- a/web/src/routes/_authorized/__tests__/discover.test.tsx
+++ b/web/src/routes/_authorized/__tests__/discover.test.tsx
@@ -143,7 +143,7 @@ describe('DiscoverPage', () => {
 
   it('renders the search bar', () => {
     renderDiscover()
-    expect(screen.getByPlaceholderText(/Search profiles, skills, or projects/i)).toBeInTheDocument()
+    expect(screen.getByPlaceholderText(/Search profiles or skills/i)).toBeInTheDocument()
   })
 
   it('renders the filter button', () => {
@@ -171,7 +171,7 @@ describe('DiscoverPage', () => {
 
   it('shows the empty state when no profiles match the search query', async () => {
     renderDiscover()
-    const input = screen.getByPlaceholderText(/Search profiles, skills, or projects/i)
+    const input = screen.getByPlaceholderText(/Search profiles or skills/i)
     fireEvent.change(input, { target: { value: 'xyznonexistent' } })
     await waitFor(() => {
       expect(screen.getByText(/No mentors found matching/i)).toBeInTheDocument()
@@ -180,7 +180,7 @@ describe('DiscoverPage', () => {
 
   it('filters profiles by skill name via search', async () => {
     renderDiscover()
-    const input = screen.getByPlaceholderText(/Search profiles, skills, or projects/i)
+    const input = screen.getByPlaceholderText(/Search profiles or skills/i)
     fireEvent.change(input, { target: { value: 'Kubernetes' } })
     await waitFor(() => {
       expect(screen.getByText('Mentor 1')).toBeInTheDocument()
@@ -190,7 +190,7 @@ describe('DiscoverPage', () => {
 
   it('restores profiles when search query is cleared', async () => {
     renderDiscover()
-    const input = screen.getByPlaceholderText(/Search profiles, skills, or projects/i)
+    const input = screen.getByPlaceholderText(/Search profiles or skills/i)
 
     fireEvent.change(input, { target: { value: 'Kubernetes' } })
     await waitFor(() => expect(screen.getByText('Mentor 1')).toBeInTheDocument())
@@ -295,7 +295,7 @@ describe('DiscoverPage', () => {
       expect(screen.getAllByRole('button', { name: /View Profile/i }).length).toBeGreaterThan(6)
     })
 
-    const input = screen.getByPlaceholderText(/Search profiles, skills, or projects/i)
+    const input = screen.getByPlaceholderText(/Search profiles or skills/i)
     fireEvent.change(input, { target: { value: 'python' } })
 
     await waitFor(() => {

--- a/web/src/routes/_authorized/connections.index.tsx
+++ b/web/src/routes/_authorized/connections.index.tsx
@@ -5,7 +5,7 @@ import { useQuery } from '@tanstack/react-query'
 import { meQueryOptions } from '#/lib/queries/AuthQueries.ts'
 import { useMyMatches, useDeactivateMatch } from '#/lib/queries/MentorshipQueries.ts'
 import { getAbsoluteMediaUrl, getInitials } from '#/lib/utils.ts'
-import { Loader2, UserCircle, BookOpen, AlertCircle } from 'lucide-react'
+import { Loader2, UserCircle, BookOpen, UserMinus } from 'lucide-react'
 import { Card, CardContent } from '@/components/ui/card'
 import {
     Dialog,
@@ -187,12 +187,12 @@ function ConnectionCard({ matchId, username, displayName, pictureUrl, title, onD
                         </Button>
                     </Link>
                     <Button
-                        variant="ghost"
+                        variant="outline"
                         size="sm"
                         onClick={onDeactivate}
-                        className="w-full text-red-500 hover:text-red-600 hover:bg-red-50 transition-colors gap-2 mt-1"
+                        className="w-full border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700 transition-colors gap-2"
                     >
-                        <AlertCircle className="w-4 h-4" />
+                        <UserMinus className="w-4 h-4" />
                         End Match
                     </Button>
                 </div>

--- a/web/src/routes/_authorized/connections.index.tsx
+++ b/web/src/routes/_authorized/connections.index.tsx
@@ -89,7 +89,7 @@ export function ConnectionsPage() {
                     <p className="text-sm text-ink-soft mt-1">
                         Are you sure you want to end this match? This will end the active mentorship connection.
                     </p>
-                    <DialogFooter className="mt-4">
+                    <DialogFooter className="mt-4 border-t border-line">
                         <Button type="button" variant="outline" onClick={() => setDeactivateTarget(null)}>
                             Keep Connection
                         </Button>
@@ -190,7 +190,7 @@ function ConnectionCard({ matchId, username, displayName, pictureUrl, title, onD
                         variant="outline"
                         size="sm"
                         onClick={onDeactivate}
-                        className="w-full border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700 transition-colors gap-2"
+                        className="w-full border-line text-ink-soft hover:border-red-200 hover:text-red-600 hover:bg-red-50 transition-colors gap-2"
                     >
                         <UserMinus className="w-4 h-4" />
                         End Match

--- a/web/src/routes/_authorized/messages.tsx
+++ b/web/src/routes/_authorized/messages.tsx
@@ -33,6 +33,11 @@ export function MessagesPage() {
     const navigate = Route.useNavigate()
     const [selectedId, setSelectedId] = useState<string | null>(conversationId || null)
 
+    useEffect(() => {
+        document.documentElement.style.overflow = 'hidden'
+        return () => { document.documentElement.style.overflow = '' }
+    }, [])
+
     const handleSelect = (id: string) => {
         setSelectedId(id)
         navigate({ search: { conversationId: id } })
@@ -57,7 +62,7 @@ export function MessagesPage() {
     }, [markAllRead])
 
     return (
-        <div className="p-4 md:p-6 h-[calc(100vh-3.5rem)]">
+        <div className="p-4 md:p-6 h-[calc(100vh-3.5rem)] min-h-0 overflow-hidden">
             <div className="flex h-full rounded-xl border border-line overflow-hidden shadow-sm bg-background max-w-5xl mx-auto">
                 <ConversationList selectedId={selectedId} onSelect={handleSelect} />
                 <MessageThread conversationId={selectedId} />
@@ -203,15 +208,32 @@ function Thread({ conversationId }: { readonly conversationId: string }) {
     }, [conversationId, markRead])
     
     const scrollContainerRef = useRef<HTMLDivElement>(null)
-    const bottomRef = useRef<HTMLDivElement>(null)
     const [isAtBottom, setIsAtBottom] = useState(true)
+    const isAtBottomRef = useRef(true)
+    const initialScrollDone = useRef(false)
 
-    // Handle auto-scroll to bottom
+    useEffect(() => {
+        isAtBottomRef.current = isAtBottom
+    }, [isAtBottom])
+
+    const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
+        const el = scrollContainerRef.current
+        if (el) el.scrollTo({ top: el.scrollHeight, behavior })
+    }, [])
+
+    // Auto-scroll on new messages; use instant on first load to avoid page scroll
     useEffect(() => {
         if (isAtBottom) {
-            bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+            const behavior = initialScrollDone.current ? 'smooth' : 'instant'
+            scrollToBottom(behavior)
+            initialScrollDone.current = true
         }
-    }, [messages, isAtBottom])
+    }, [messages, isAtBottom, scrollToBottom])
+
+    // Re-scroll after an image/attachment loads if user was at bottom
+    const handleMediaLoad = useCallback(() => {
+        if (isAtBottomRef.current) scrollToBottom('instant')
+    }, [scrollToBottom])
 
     const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
         const target = e.currentTarget
@@ -260,7 +282,7 @@ function Thread({ conversationId }: { readonly conversationId: string }) {
     )
 
     return (
-        <div className="flex-1 flex flex-col min-w-0">
+        <div className="flex-1 min-h-0 flex flex-col min-w-0">
             {/* Thread header */}
             {other && (
                 <div className="shrink-0 flex items-center gap-3 px-5 py-3 border-b border-line">
@@ -282,39 +304,41 @@ function Thread({ conversationId }: { readonly conversationId: string }) {
             <div
                 ref={scrollContainerRef}
                 onScroll={handleScroll}
-                className="flex-1 overflow-y-auto px-6 py-4 flex flex-col gap-3"
+                className="flex-1 min-h-0 overflow-y-auto overscroll-contain"
             >
-                {hasMore && (
-                    <div className="flex justify-center py-2">
-                        {isLoading ? (
-                            <Loader2 className="h-4 w-4 animate-spin text-ink-soft" />
-                        ) : (
-                            <p className="text-[10px] text-ink-soft italic">Scroll up to load more</p>
-                        )}
-                    </div>
-                )}
-                
-                {isLoading && messages.length === 0 ? (
-                    <div className="flex justify-center py-10">
-                        <Loader2 className="h-5 w-5 animate-spin text-ink-soft" />
-                    </div>
-                ) : messages.length === 0 ? (
-                    <p className="text-sm text-ink-soft text-center mt-10">
-                        No messages yet. Say hello!
-                    </p>
-                ) : (
-                    messages.map(msg => {
-                        const isMe = msg.sender.username === me?.username
-                        return (
-                            <MessageBubble
-                                key={msg.id}
-                                message={msg}
-                                isMe={isMe}
-                            />
-                        )
-                    })
-                )}
-                <div ref={bottomRef} />
+                <div className="flex flex-col gap-3 px-6 py-4">
+                    {hasMore && (
+                        <div className="flex justify-center py-2">
+                            {isLoading ? (
+                                <Loader2 className="h-4 w-4 animate-spin text-ink-soft" />
+                            ) : (
+                                <p className="text-[10px] text-ink-soft italic">Scroll up to load more</p>
+                            )}
+                        </div>
+                    )}
+
+                    {isLoading && messages.length === 0 ? (
+                        <div className="flex justify-center py-10">
+                            <Loader2 className="h-5 w-5 animate-spin text-ink-soft" />
+                        </div>
+                    ) : messages.length === 0 ? (
+                        <p className="text-sm text-ink-soft text-center mt-10">
+                            No messages yet. Say hello!
+                        </p>
+                    ) : (
+                        messages.map(msg => {
+                            const isMe = msg.sender.username === me?.username
+                            return (
+                                <MessageBubble
+                                    key={msg.id}
+                                    message={msg}
+                                    isMe={isMe}
+                                    onMediaLoad={handleMediaLoad}
+                                />
+                            )
+                        })
+                    )}
+                </div>
             </div>
 
             {/* Input */}
@@ -394,9 +418,11 @@ import { ReportMessageDialog } from '@/components/ReportMessageDialog'
 function MessageBubble({
     message,
     isMe,
+    onMediaLoad,
 }: {
     readonly message: Message
     readonly isMe: boolean
+    readonly onMediaLoad?: () => void
 }) {
     const getStatusIcon = () => {
         const status = message.status_for_me
@@ -436,8 +462,9 @@ function MessageBubble({
                 {message.attachment_url && (
                     <MediaAttachment
                         url={message.attachment_url}
-                        imgClassName="mt-1 max-h-48 w-full rounded-lg border-0 object-contain"
+                        imgClassName="mt-1 max-h-48 max-w-full rounded-lg border-0 object-contain"
                         linkClassName="mt-1 block underline text-xs opacity-80 text-inherit"
+                        onLoad={onMediaLoad}
                     />
                 )}
                 <div className={cn('flex items-center gap-1 text-[10px] mt-1', isMe ? 'justify-end' : 'justify-start')}>

--- a/web/src/routes/_public/communities.index.tsx
+++ b/web/src/routes/_public/communities.index.tsx
@@ -264,6 +264,7 @@ export function CommunitiesPage() {
                         <DiscoverSearchBar
                             value={query}
                             onChange={setQuery}
+                            placeholder="Search communities..."
                             className="flex-1 min-w-0"
                         />
                         {query && (

--- a/web/src/routes/_public/communities.index.tsx
+++ b/web/src/routes/_public/communities.index.tsx
@@ -170,7 +170,7 @@ function CreateCommunityModal({ open, onClose }: CreateCommunityModalProps) {
                             rows={3}
                         />
                     </div>
-                    <DialogFooter className="mt-2">
+                    <DialogFooter className="mt-2 border-line border-t">
                         <Button type="button" variant="ghost" onClick={handleClose} disabled={isPending}>
                             Cancel
                         </Button>


### PR DESCRIPTION
## Related Issue

  Closes #583 

  ## Description

  Small web UI fixes across several areas: removes the Google Meet section from the session management modal, fixes broken profile picture rendering in workshop components, improves the delete match button styling in the connections page, fixes a bug where image attachments in messages caused the page to scroll (showing blank whitespace below), and corrects the search bar placeholder text on the communities page.

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation
  - [ ] CI/CD or configuration

  ## Checklist

  - [x] I have tested my changes locally
  - [x] My code builds without errors
  - [ ] I have written or updated tests where applicable
  - [x] I have performed a self-review of my code

  ## Notes

  - The message scroll fix works by locking document-level overflow while the messages page is mounted and restructuring the scroll container's flex/overflow layout so media attachments an't push content outside the viewport.
  - The communities search placeholder uses the existing `placeholder` prop on `DiscoverSearchBar` 

