### PR TITLE
test: add unit tests to increase the mobile test coverage

### DIFF
--- a/mobile/__tests__/components/community/WorkshopCard.test.tsx
+++ b/mobile/__tests__/components/community/WorkshopCard.test.tsx
@@ -1,0 +1,149 @@
+import { fireEvent, render } from "@testing-library/react-native";
+import React from "react";
+
+import { WorkshopCard } from "@/components/community/WorkshopCard";
+import { type CommunityWorkshopListItem } from "@/lib/queries/workshops";
+
+jest.mock("@expo/vector-icons", () => ({ Ionicons: "View" }));
+
+const mockIsWorkshopActive = jest.fn();
+jest.mock("@/lib/queries/workshops", () => ({
+  ...jest.requireActual("@/lib/queries/workshops"),
+  isWorkshopActive: (...args: unknown[]) => mockIsWorkshopActive(...args),
+}));
+
+function makeWorkshop(
+  overrides: Partial<CommunityWorkshopListItem> = {},
+): CommunityWorkshopListItem {
+  return {
+    id: "ws-1",
+    community_id: "c-1",
+    community_name: "JS Guild",
+    author: {
+      id: "u-1",
+      username: "alice",
+      display_name: "Alice",
+      picture_url: "",
+      title: "",
+    },
+    title: "Intro to GraphQL",
+    description: "A talk about GraphQL.",
+    scheduled_at: "2026-05-20T12:00:00Z",
+    end_at: "2026-05-20T13:00:00Z",
+    max_participants: 20,
+    participant_count: 8,
+    is_full: false,
+    status: "SCHEDULED",
+    current_user_enrolled: false,
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("WorkshopCard", () => {
+  beforeEach(() => {
+    mockIsWorkshopActive.mockReturnValue(true);
+  });
+
+  it("renders workshop title, community name, and description", () => {
+    const { getByText } = render(<WorkshopCard workshop={makeWorkshop()} />);
+
+    expect(getByText("Intro to GraphQL")).toBeTruthy();
+    expect(getByText("JS Guild")).toBeTruthy();
+    expect(getByText("A talk about GraphQL.")).toBeTruthy();
+  });
+
+  it("shows Open badge for an active non-full workshop", () => {
+    const { getByText } = render(
+      <WorkshopCard workshop={makeWorkshop({ is_full: false })} />,
+    );
+
+    expect(getByText("Open")).toBeTruthy();
+  });
+
+  it("shows Full badge for an active but fully booked workshop", () => {
+    const { getByText } = render(
+      <WorkshopCard workshop={makeWorkshop({ is_full: true })} />,
+    );
+
+    expect(getByText("Full")).toBeTruthy();
+  });
+
+  it("shows Cancelled badge for a cancelled workshop", () => {
+    const { getByText } = render(
+      <WorkshopCard workshop={makeWorkshop({ status: "CANCELLED" })} />,
+    );
+
+    expect(getByText("Cancelled")).toBeTruthy();
+  });
+
+  it("shows Ended badge when the workshop is no longer active", () => {
+    mockIsWorkshopActive.mockReturnValue(false);
+    const { getByText } = render(<WorkshopCard workshop={makeWorkshop()} />);
+
+    expect(getByText("Ended")).toBeTruthy();
+  });
+
+  it("shows fallback text when description is empty", () => {
+    const { getByText } = render(
+      <WorkshopCard workshop={makeWorkshop({ description: "" })} />,
+    );
+
+    expect(getByText("No workshop description yet.")).toBeTruthy();
+  });
+
+  it("displays participant count in current/max format", () => {
+    const { getByText } = render(
+      <WorkshopCard
+        workshop={makeWorkshop({ participant_count: 8, max_participants: 20 })}
+      />,
+    );
+
+    expect(getByText("8/20 participants")).toBeTruthy();
+  });
+
+  it("shows the host display name", () => {
+    const { getByText } = render(<WorkshopCard workshop={makeWorkshop()} />);
+
+    expect(getByText("Host: Alice")).toBeTruthy();
+  });
+
+  it("falls back to Unknown when author is null", () => {
+    const { getByText } = render(
+      <WorkshopCard workshop={makeWorkshop({ author: null })} />,
+    );
+
+    expect(getByText("Host: Unknown")).toBeTruthy();
+  });
+
+  it("calls onPress with the workshop when the card is tapped", () => {
+    const onPress = jest.fn();
+    const workshop = makeWorkshop();
+    const { getByTestId } = render(
+      <WorkshopCard workshop={workshop} onPress={onPress} />,
+    );
+
+    fireEvent.press(getByTestId("community-workshop-card-ws-1"));
+
+    expect(onPress).toHaveBeenCalledWith(workshop);
+  });
+
+  it("calls onCommunityPress when the community link is tapped without propagating to onPress", () => {
+    const onPress = jest.fn();
+    const onCommunityPress = jest.fn();
+    const workshop = makeWorkshop();
+    const { getByTestId } = render(
+      <WorkshopCard
+        workshop={workshop}
+        onPress={onPress}
+        onCommunityPress={onCommunityPress}
+      />,
+    );
+
+    fireEvent.press(getByTestId("community-workshop-community-link-ws-1"));
+
+    expect(onCommunityPress).toHaveBeenCalledWith(workshop);
+    expect(onPress).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/__tests__/components/discover/DiscoverSearchBar.test.tsx
+++ b/mobile/__tests__/components/discover/DiscoverSearchBar.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render } from "@testing-library/react-native";
+import React from "react";
+
+import { DiscoverSearchBar } from "@/components/discover/DiscoverSearchBar";
+
+jest.mock("@expo/vector-icons", () => ({ Ionicons: "View" }));
+jest.mock("@/hooks/use-color-scheme", () => ({
+  useColorScheme: () => "light",
+}));
+
+describe("DiscoverSearchBar", () => {
+  it("renders the default placeholder when none is provided", () => {
+    const { getByPlaceholderText } = render(
+      <DiscoverSearchBar
+        value=""
+        onChangeText={jest.fn()}
+        testID="search-input"
+      />,
+    );
+
+    expect(
+      getByPlaceholderText("Search mentors, skills, topics..."),
+    ).toBeTruthy();
+  });
+
+  it("renders a custom placeholder when the prop is set", () => {
+    const { getByPlaceholderText } = render(
+      <DiscoverSearchBar
+        value=""
+        onChangeText={jest.fn()}
+        placeholder="Find a mentor..."
+        testID="search-input"
+      />,
+    );
+
+    expect(getByPlaceholderText("Find a mentor...")).toBeTruthy();
+  });
+
+  it("forwards typed text to onChangeText", () => {
+    const onChangeText = jest.fn();
+    const { getByTestId } = render(
+      <DiscoverSearchBar
+        value=""
+        onChangeText={onChangeText}
+        testID="search-input"
+      />,
+    );
+
+    fireEvent.changeText(getByTestId("search-input"), "React Native");
+
+    expect(onChangeText).toHaveBeenCalledWith("React Native");
+  });
+
+  it("reflects the controlled value prop in the input", () => {
+    const { getByDisplayValue } = render(
+      <DiscoverSearchBar
+        value="GraphQL"
+        onChangeText={jest.fn()}
+        testID="search-input"
+      />,
+    );
+
+    expect(getByDisplayValue("GraphQL")).toBeTruthy();
+  });
+});

--- a/mobile/__tests__/hooks/use-refresh-control.test.ts
+++ b/mobile/__tests__/hooks/use-refresh-control.test.ts
@@ -1,0 +1,51 @@
+import { act, renderHook } from "@testing-library/react-native";
+
+import { useRefreshControl } from "@/hooks/use-refresh-control";
+
+describe("useRefreshControl", () => {
+  it("returns refreshing as false before any refresh is triggered", () => {
+    const { result } = renderHook(() =>
+      useRefreshControl(jest.fn().mockResolvedValue(undefined)),
+    );
+
+    expect(result.current.refreshing).toBe(false);
+  });
+
+  it("sets refreshing to true while the async refresh function is pending", async () => {
+    let resolveRefresh!: () => void;
+    const refreshFn = jest.fn(
+      () => new Promise<void>((resolve) => { resolveRefresh = resolve; }),
+    );
+    const { result } = renderHook(() => useRefreshControl(refreshFn));
+
+    act(() => {
+      result.current.onRefresh();
+    });
+
+    expect(result.current.refreshing).toBe(true);
+
+    await act(async () => { resolveRefresh(); });
+  });
+
+  it("resets refreshing to false once the refresh function resolves", async () => {
+    const refreshFn = jest.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useRefreshControl(refreshFn));
+
+    await act(async () => {
+      await result.current.onRefresh();
+    });
+
+    expect(result.current.refreshing).toBe(false);
+  });
+
+  it("resets refreshing to false even when the refresh function rejects", async () => {
+    const refreshFn = jest.fn().mockRejectedValue(new Error("network error"));
+    const { result } = renderHook(() => useRefreshControl(refreshFn));
+
+    await act(async () => {
+      await result.current.onRefresh().catch(() => {});
+    });
+
+    expect(result.current.refreshing).toBe(false);
+  });
+});

--- a/mobile/__tests__/hooks/usePushNotifications.test.ts
+++ b/mobile/__tests__/hooks/usePushNotifications.test.ts
@@ -1,0 +1,112 @@
+import { renderHook, waitFor } from "@testing-library/react-native";
+
+// expo-notifications and expo-device are mocked globally in jest.setup.js
+
+const mockRegisterToken = jest.fn();
+const mockInvalidateQueries = jest.fn();
+const mockIsFirebaseAvailable = jest.fn();
+
+jest.mock("@/lib/queries/notifications", () => ({
+  useRegisterFCMTokenMutation: () => ({ mutate: mockRegisterToken }),
+  notificationsQueryKey: (username: string) => ["notifications", username],
+}));
+
+jest.mock("@/lib/auth/store", () => ({
+  useAuthStore: (
+    selector: (state: { user: { username: string } }) => unknown,
+  ) => selector({ user: { username: "alice" } }),
+}));
+
+jest.mock("@/lib/firebase-client", () => ({
+  isFirebaseAvailable: () => mockIsFirebaseAvailable(),
+}));
+
+jest.mock("@tanstack/react-query", () => ({
+  ...jest.requireActual("@tanstack/react-query"),
+  useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
+}));
+
+// Import after mocks so the hook picks them up
+import { usePushNotifications } from "@/hooks/usePushNotifications";
+
+describe("usePushNotifications", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Notifications: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsFirebaseAvailable.mockReturnValue(true);
+    Notifications = require("expo-notifications");
+  });
+
+  it("skips all setup when the user is not authenticated", async () => {
+    renderHook(() => usePushNotifications(false));
+
+    // Allow any pending microtasks to drain
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    expect(Notifications.addNotificationReceivedListener).not.toHaveBeenCalled();
+    expect(mockRegisterToken).not.toHaveBeenCalled();
+  });
+
+  it("uses polling fallback and skips Firebase token registration when Firebase is not configured", async () => {
+    mockIsFirebaseAvailable.mockReturnValue(false);
+
+    renderHook(() => usePushNotifications(true));
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    expect(Notifications.addNotificationReceivedListener).not.toHaveBeenCalled();
+    expect(mockRegisterToken).not.toHaveBeenCalled();
+  });
+
+  it("registers the device FCM token after loading notification modules when authenticated", async () => {
+    renderHook(() => usePushNotifications(true));
+
+    await waitFor(() => {
+      expect(mockRegisterToken).toHaveBeenCalledWith({
+        token: "mock-token",
+        device_type: expect.stringMatching(/^(ios|android)$/),
+      });
+    });
+  });
+
+  it("invalidates the notifications query for the current user when a notification arrives", async () => {
+    renderHook(() => usePushNotifications(true));
+
+    await waitFor(() => {
+      expect(Notifications.addNotificationReceivedListener).toHaveBeenCalled();
+    });
+
+    const [receivedCallback] =
+      Notifications.addNotificationReceivedListener.mock.calls[0];
+    receivedCallback();
+
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["notifications", "alice"],
+    });
+  });
+
+  it("removes both notification listeners when the hook unmounts", async () => {
+    const mockRemoveReceived = jest.fn();
+    const mockRemoveResponse = jest.fn();
+
+    Notifications.addNotificationReceivedListener.mockReturnValue({
+      remove: mockRemoveReceived,
+    });
+    Notifications.addNotificationResponseReceivedListener.mockReturnValue({
+      remove: mockRemoveResponse,
+    });
+
+    const { unmount } = renderHook(() => usePushNotifications(true));
+
+    await waitFor(() => {
+      expect(Notifications.addNotificationReceivedListener).toHaveBeenCalled();
+    });
+
+    unmount();
+
+    expect(mockRemoveReceived).toHaveBeenCalled();
+    expect(mockRemoveResponse).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Related Issue

  Closes #598 

  ## Description

  Adds missing unit tests for four untested mobile files identified in the test coverage audit:

  - `components/community/WorkshopCard` — 11 behavior-driven tests covering all four status badges (Open / Full / Cancelled
   / Ended), empty description fallback, participant count, host display, null author, `onPress`, and community link tap
  isolation.
  - `components/discover/DiscoverSearchBar` — 4 tests covering default/custom placeholder, controlled value, and
  `onChangeText` forwarding.
  - `hooks/usePushNotifications` — 5 tests covering the unauthenticated no-op path, Firebase-unavailable polling fallback,
  FCM token registration, query invalidation on notification arrival, and listener cleanup on unmount.
  - `hooks/useRefreshControl` — 4 tests covering initial state, pending state, resolve, and reject (with `finally` cleanup
  
  All tests follow the behavior-driven naming convention already established in the codebase and reuse the global mock
  infrastructure in `jest.setup.js`.
  
  ## Type of Change

  - [ ] Bug fix
  - [ ] New feature
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation
  - [x] CI/CD or configuration

  ## Checklist
  
  - [x] I have tested my changes locally
  - [x] My code builds without errors
  - [x] I have written or updated tests where applicable
  - [x] I have performed a self-review of my code

  ## Notes
  
  All 24 new tests pass. No source files were modified — only new `__tests__/` files were added.